### PR TITLE
fix re-entrant risk

### DIFF
--- a/contracts/MasterChef.sol
+++ b/contracts/MasterChef.sol
@@ -239,10 +239,11 @@ contract MasterChef is Ownable {
     function emergencyWithdraw(uint256 _pid) public {
         PoolInfo storage pool = poolInfo[_pid];
         UserInfo storage user = userInfo[_pid][msg.sender];
-        pool.lpToken.safeTransfer(address(msg.sender), user.amount);
-        emit EmergencyWithdraw(msg.sender, _pid, user.amount);
+        uint256 amount = user.amount;
         user.amount = 0;
         user.rewardDebt = 0;
+        pool.lpToken.safeTransfer(address(msg.sender), amount);
+        emit EmergencyWithdraw(msg.sender, _pid, amount);
     }
 
     // Safe sushi transfer function, just in case if rounding error causes pool to not have enough SUSHIs.


### PR DESCRIPTION
The function (emergencyWithdraw) could be re-entered to stole assets if the LP token is ERC777 standard based. 