### PR TITLE
Update License, add Security Policy

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2020 SushiSwap
+Copyright (c) 2020, 2021 SushiSwap
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SushiSwap
 
-https://sushi.com/.
+https://sushi.com/
 
 ## Deployed Contracts
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SushiSwap
 
-https://sushiswap.fi.
+https://sushi.com/.
 
 ## Deployed Contracts
 
@@ -14,6 +14,10 @@ https://dev.sushi.com/sushiswap/contracts
 
 [History](docs/HISTORY.md)
 
+## Security
+
+[Security Policy](SECURITY.md)
+
 ## License
 
-MIT
+[MIT](LICENSE.txt)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+At SushiSwap, we consider the security of our systems a top priority. But even with such priority and maximum effort, there is still the possibility that vulnerabilities can exist. 
+
+In case you discover a vulnerability, we would like to know about it immediately so we can take steps to address it as quickly as possible.  
+
+If you discover a vulnerability, please do the following: 
+
+    E-mail your findings to security@sushi.com. 
+
+    Do not take advantage of the vulnerability or similar problems you have discovered, including, but not limited to, testing the vulnerability on the Ethereum mainnet or testnet. 
+
+    Do not reveal the vulnerability to others until it has been resolved, including, but not limited to, filing a public ticket mentioning the vulnerability. 
+    
+    Do provide sufficient information to reproduce the vulnerability, so we will be able to resolve it as quickly as possible. Complex vulnerabilities may require further explanation so we might ask you for additional information. 
+
+We will promise the following: 
+
+    We will respond to your report within 3 business days with our evaluation of the report and an expected resolution date. 
+
+    If you have followed the instructions above, we will not take any legal action against you in regard to the report. 
+
+    We will handle your report with strict confidentiality, and not pass on your personal details to third parties without your permission. 
+
+    If you so wish we will keep you informed of the progress towards resolving the problem. 
+
+    In public disclosures concerning the problem reported, we will give your name as the discoverer of the problem (unless you desire otherwise). 
+
+    As a token of our gratitude for your assistance, we offer a reward for every report of a security problem that was not yet known to us. The amount of the reward will be determined based on the severity of the discovered vulnerability, the quality of the report and any additional assistance you provide.  


### PR DESCRIPTION
This PR has basic house-keeping updates:

* Bump `LICENSE` to 2021. See discussion of updating notice [here](https://softwareengineering.stackexchange.com/a/210491).
* Add `SECURITY` section to `README` and related policy based on [Aave template](https://github.com/aave/aave-protocol/blob/master/README.md).