### PR TITLE
fix tag in Mocks deploy script

### DIFF
--- a/deploy/Mocks.js
+++ b/deploy/Mocks.js
@@ -19,4 +19,4 @@ module.exports.skip = ({ getChainId }) =>
     }
   })
 
-module.exports.tags = ["test"]
+module.exports.tags = ["Mocks"]


### PR DESCRIPTION
Wrong tag in `Mocks.js` results in `WETH9Mock` dependency not being deployed.