### PR TITLE
feat(solidity): isContract

### DIFF
--- a/contracts/SushiMaker.sol
+++ b/contracts/SushiMaker.sol
@@ -92,12 +92,12 @@ contract SushiMaker is Ownable {
     }
 
     function isContract(address account) internal view returns (bool) {
-    /// @dev isContract According to EIP-1052, 0x0 is the value returned for not-yet created accounts
-    // and 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is returned
-    // for accounts without code, i.e. `keccak256('')`
+    /// @dev isContract EIP-1052
+    //  return 0x0; this is the value returned for not-yet created accounts
+    //  return 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470; is returned or accounts without code, i.e. `keccak256('')`
         bytes32 codehash;
         bytes32 accountHash = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
-    // solhint-disable-next-line no-inline-assembly
+        // solhint-disable-next-line no-inline-assembly
         assembly { codehash := extcodehash(account) }
         return (codehash != accountHash && codehash != 0x0);
     }

--- a/contracts/SushiMaker.sol
+++ b/contracts/SushiMaker.sol
@@ -91,6 +91,18 @@ contract SushiMaker is Ownable {
         _;
     }
 
+    function isContract(address account) internal view returns (bool) {
+    /// @dev isContract According to EIP-1052, 0x0 is the value returned for not-yet created accounts
+    // and 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is returned
+    // for accounts without code, i.e. `keccak256('')`
+        bytes32 codehash;
+        bytes32 accountHash = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
+    // solhint-disable-next-line no-inline-assembly
+        assembly { codehash := extcodehash(account) }
+        return (codehash != accountHash && codehash != 0x0);
+    }
+
+
     // F1 - F10: OK
     // F3: _convert is separate to save gas by only checking the 'onlyEOA' modifier once in case of convertMultiple
     // F6: There is an exploit to add lots of SUSHI to the bar, run convert, then remove the SUSHI again.


### PR DESCRIPTION
### low level function for EOA/Contract inquiry

Don't have to merge this, thought this may be helpful as we are using something similar as a pattern, here is an example for usage:



```solidity
function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
    require(isContract(target), "!SIGERR call to non-contract");
    (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
    if (success) {
        return returndata;
    } else {
        if (returndata.length > 0) {
            assembly {
                let returndata_size := mload(returndata)
                revert(add(32, returndata), returndata_size)
            }
        } else {
            revert(errorMessage);
        }
    }
}
```