### PR TITLE
Fix bug related to right award calculation for withdrawn amount

### DIFF
--- a/contracts/MasterChefV2.sol
+++ b/contracts/MasterChefV2.sol
@@ -235,7 +235,19 @@ contract MasterChefV2 is BoringOwnable, BoringBatchable {
         UserInfo storage user = userInfo[pid][msg.sender];
 
         // Effects
-        user.rewardDebt = user.rewardDebt.sub(int256(amount.mul(pool.accSushiPerShare) / ACC_SUSHI_PRECISION));
+        uint256 userAmount = user.amount;
+        int256 accumulatedSushi = int256(userAmount.mul(pool.accSushiPerShare) / ACC_SUSHI_PRECISION);
+        uint256 _pendingSushi = accumulatedSushi.sub(user.rewardDebt).toUInt256();
+
+        // calculate the reward against amount being withdrawn
+        uint256 debtToDecrease;
+        if (userAmount != 0) {
+            debtToDecrease = _pendingSushi
+            .mul(amount) / user.amount;
+        }
+
+        // decrease the reward debt only by the reward amount against amount being withdrawn
+        user.rewardDebt = user.rewardDebt.sub(int256(debtToDecrease));
         user.amount = user.amount.sub(amount);
 
         // Interactions


### PR DESCRIPTION
The `rewardDebt` is reduced to preserve the reward against the withdrawn LP amount for later `harvest` yet the `rewardDebt` amount is reduced with the amount taking reward into consideration from the start i.e. `pool.accSushiPerShare` and it does not take into account the `rewardDebt` for the LP amount being withdrawn. 

The PR fixes this issue by calculating the Sushi reward amount against the LP amount being withdrawn and reduces the `rewardDebt` by only that amount instead of calculating the reward from the start.