### PR TITLE
Github has deprecated git protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/chai": "^4.2.22",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.10.1",
-    "@uniswap/v2-core": "git://github.com/uniswap/uniswap-v2-core.git#27f6354bae6685612c182c3bc7577e61bc8717e3",
+    "@uniswap/v2-core": "https://github.com/Uniswap/v2-core.git#27f6354bae6685612c182c3bc7577e61bc8717e3",
     "chai": "^4.3.4",
     "cross-env": "^7.0.0",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
Sushiswap repo no longer builds since March 15h. `package.json` refers to `uniswap-v2-core` using protocol Github has deprecated.

Updated to HTTP checkout, as git:// is no longer supported.

More info: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Actual error:

```
Error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/uniswap/uniswap-v2-core.git
Directory: /home/runner/work/eth-hentai/eth-hentai/sushiswap
Output:
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```