### PR TITLE
Fix: Save vesting tokens to get rebase, use chainid from props instead of wagmi network hook

### DIFF
--- a/apps/furo/components/Dashboard.tsx
+++ b/apps/furo/components/Dashboard.tsx
@@ -54,8 +54,22 @@ export const Dashboard: FC<{ chainId: number; address: string; showOutgoing: boo
       tokens.push(toToken(stream.token, chainId))
     })
 
+    vestings?.incomingVestings?.forEach((vesting) => {
+      tokens.push(toToken(vesting.token, chainId))
+    })
+
+    vestings?.outgoingVestings?.forEach((vesting) => {
+      tokens.push(toToken(vesting.token, chainId))
+    })
+
     return [ids, tokens]
-  }, [chainId, streams?.incomingStreams, streams?.outgoingStreams])
+  }, [
+    chainId,
+    streams?.incomingStreams,
+    streams?.outgoingStreams,
+    vestings?.incomingVestings,
+    vestings?.outgoingVestings,
+  ])
 
   const { data: rebases, isValidating: isValidatingRebases } = useSWR<Rebase[]>(
     () =>


### PR DESCRIPTION
A user could not see his vesting, rebase for vest tokens were missing

Also changed so we are using props instead of chainId from useNetwork, otherwise we we wont map the objects correctly when users are not connected to a wallet?

Before:
https://sushi.com/furo/user/0xc9ecab4ae699ac237a5abc5a7f2c08afc09aa253?chainId=1

After:
https://furo-apxq2r9pd-teamsushi.vercel.app/furo/user/0xc9ecab4ae699ac237a5abc5a7f2c08afc09aa253?chainId=1