### PR TITLE
Only price tokens where pools have atleast one base

### DIFF
--- a/jobs/pool/src/price.ts
+++ b/jobs/pool/src/price.ts
@@ -113,7 +113,7 @@ async function getPools(client: PrismaClient, chainId: ChainId) {
   const endTime = performance.now()
 
   console.log(`Fetched ${results.length} pools (${((endTime - startTime) / 1000).toFixed(1)}s). `)
-  return results
+  return results.filter(pool => pool.token1.isCommon || pool.token0.isCommon)
 }
 
 async function getPoolsByPagination(


### PR DESCRIPTION
Tested price api locally on two networks, ethereum and arbitrum
Tested incentives/volume/pools too

I suggest we merge this to master, tag/checkout a release branch and point GCP build to it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on filtering pools based on common tokens in the `price.ts` file.

### Detailed summary:
- Added a filter to return only pools with common tokens.
- Removed the console log statement.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->