### PR TITLE
chore: return null pool code map if variables missing

### DIFF
--- a/packages/wagmi/future/hooks/pools/actions/getAllPoolsCodeMap.ts
+++ b/packages/wagmi/future/hooks/pools/actions/getAllPoolsCodeMap.ts
@@ -1,15 +1,20 @@
 import { UsePoolsParams } from '../types'
-import { DataFetcher, LiquidityProviders } from '@sushiswap/router'
+import { DataFetcher, LiquidityProviders, PoolCode } from '@sushiswap/router'
 import { isRouteProcessor3ChainId } from '@sushiswap/route-processor'
 
-export const getAllPoolsCodeMap = async (variables: Omit<UsePoolsParams, 'enabled'>) => {
-  const dataFetcher = DataFetcher.onChain(variables.chainId)
+const nullPoolCodeMap = new Map<string, PoolCode>()
+
+export const getAllPoolsCodeMap = async ({ currencyA, currencyB, chainId }: Omit<UsePoolsParams, 'enabled'>) => {
+  if (!currencyA || !currencyB || !chainId) {
+    return nullPoolCodeMap
+  }
+  const dataFetcher = DataFetcher.onChain(chainId)
   const liquidityProviders = [LiquidityProviders.SushiSwap, LiquidityProviders.Trident]
-  if (isRouteProcessor3ChainId(variables.chainId)) {
+  if (isRouteProcessor3ChainId(chainId)) {
     liquidityProviders.push(LiquidityProviders.SushiSwapV3)
   }
   dataFetcher.startDataFetching(liquidityProviders)
-  await dataFetcher.fetchPoolsForToken(variables.currencyA!, variables.currencyB!)
+  await dataFetcher.fetchPoolsForToken(currencyA, currencyB)
   dataFetcher.stopDataFetching()
-  return dataFetcher.getCurrentPoolCodeMap(variables.currencyA!, variables.currencyB!)
+  return dataFetcher.getCurrentPoolCodeMap(currencyA, currencyB)
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for the `PoolCode` type and improves the `getAllPoolsCodeMap` function by adding null checks and fixing a bug.

### Detailed summary
- Import the `PoolCode` type from `@sushiswap/router`
- Add null checks for `currencyA`, `currencyB`, and `chainId`
- Fix a bug where `variables` was used instead of `currencyA` and `currencyB`
- Use `getCurrentPoolCodeMap` to return a map of pool codes for the given tokens

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->