### PR TITLE
Revert "fix: EGN-251 Uni2 LP Token sorting"

### DIFF
--- a/packages/currency/src/constants/token-addresses.ts
+++ b/packages/currency/src/constants/token-addresses.ts
@@ -129,7 +129,6 @@ export const ANKR_ADDRESS = {
 
 export const AAVE_ADDRESS = {
   [ChainId.ETHEREUM]: '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9',
-  [ChainId.POLYGON]: '0xD6DF932A45C0f255f85145f286eA0b292B21C90B',
 } as const
 
 export const COMP_ADDRESS = {

--- a/packages/router/src/liquidity-providers/UniswapV2Base.ts
+++ b/packages/router/src/liquidity-providers/UniswapV2Base.ts
@@ -428,10 +428,9 @@ export abstract class UniswapV2BaseProvider extends LiquidityProvider {
   }
 
   _getPoolAddress(t1: Token, t2: Token): string {
-    const [addr1, addr2] = t1.sortsBefore(t2) ? [t1.address, t2.address] : [t2.address, t1.address]
     return getCreate2Address(
       this.factory[this.chainId as keyof typeof this.factory],
-      keccak256(['bytes'], [pack(['address', 'address'], [addr1, addr2])]),
+      keccak256(['bytes'], [pack(['address', 'address'], [t1.address, t2.address])]),
       this.initCodeHash[this.chainId as keyof typeof this.initCodeHash]
     )
   }

--- a/protocols/route-processor/test/Router3.test.ts
+++ b/protocols/route-processor/test/Router3.test.ts
@@ -4,8 +4,6 @@ import { erc20Abi, weth9Abi } from '@sushiswap/abi'
 import { bentoBoxV1Address, BentoBoxV1ChainId } from '@sushiswap/bentobox'
 import { ChainId, chainName } from '@sushiswap/chain'
 import {
-  AAVE,
-  AAVE_ADDRESS,
   DAI,
   DAI_ADDRESS,
   FRAX,
@@ -47,7 +45,7 @@ import { hardhat } from 'viem/chains'
 import { getAllPoolCodes } from './utils/getAllPoolCodes'
 
 // Updating  pools' state allows to test DF updating ability, but makes tests very-very slow (
-const UPDATE_POOL_STATES = true //false
+const UPDATE_POOL_STATES = false
 const POLLING_INTERVAL = process.env.ALCHEMY_ID ? 1_000 : 10_000
 const delay = async (ms: number) => new Promise((res) => setTimeout(res, ms))
 
@@ -456,17 +454,6 @@ describe('End-to-end RouteProcessor3 test', async function () {
     intermidiateResult[0] = getBigNumber(1000000 * 1e18)
     intermidiateResult = await updMakeSwap(env, Native.onChain(chainId), SUSHI_LOCAL, intermidiateResult, usedPools)
     intermidiateResult = await updMakeSwap(env, SUSHI_LOCAL, Native.onChain(chainId), intermidiateResult, usedPools)
-  })
-
-  // EGN-251 issue
-  it.only('Native => Aave => Dai', async function () {
-    await env.snapshot.restore()
-    const usedPools = new Set<string>()
-    intermidiateResult[0] = getBigNumber(100 * 1e18)
-    const aave = AAVE[chainId as keyof typeof AAVE_ADDRESS]
-    const dai = DAI[chainId as keyof typeof DAI_ADDRESS]
-    intermidiateResult = await updMakeSwap(env, Native.onChain(chainId), aave, intermidiateResult, usedPools)
-    intermidiateResult = await updMakeSwap(env, aave, dai, intermidiateResult, usedPools)
   })
 
   it('Native => WrappedNative => Native', async function () {


### PR DESCRIPTION
Reverts sushiswap/sushiswap#768

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `token-addresses.ts` file, modifies the `UniswapV2Base.ts` file, and updates the `Router3.test.ts` file. It removes the `AAVE_ADDRESS` constant for the `POLYGON` chain, updates the `getPoolAddress` function in `UniswapV2Base.ts` to use `t1.address` and `t2.address` instead of `addr1` and `addr2`, and sets `UPDATE_POOL_STATES` to `false` in `Router3.test.ts`.

### Detailed summary
- Removes `AAVE_ADDRESS` constant for `POLYGON` chain in `token-addresses.ts`
- Modifies `getPoolAddress` function in `UniswapV2Base.ts` to use `t1.address` and `t2.address` instead of `addr1` and `addr2`
- Sets `UPDATE_POOL_STATES` to `false` in `Router3.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->