### PR TITLE
fix: EGN-251 Uni2 LP Token sorting

### DIFF
--- a/packages/router/src/liquidity-providers/UniswapV2Base.ts
+++ b/packages/router/src/liquidity-providers/UniswapV2Base.ts
@@ -449,7 +449,9 @@ export abstract class UniswapV2BaseProvider extends LiquidityProvider {
   }
 
   getStaticPools(t1: Token, t2: Token): StaticPool[] {
-    const currencyCombination = getCurrencyCombinations(this.chainId, t1, t2)
+    const currencyCombination = getCurrencyCombinations(this.chainId, t1, t2).map(([c0, c1]) =>
+      c0.sortsBefore(c1) ? [c0, c1] : [c1, c0]
+    )
     return currencyCombination.map((combination) => ({
       address: this._getPoolAddress(combination[0], combination[1]),
       token0: combination[0],


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the sorting of currency combinations in the `UniswapV2Base` class of the router package. 

### Detailed summary
- Added sorting of currency combinations to ensure consistency
- Uses `sortsBefore()` method to determine order of currencies
- Improves accuracy of pool address retrieval

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->