### PR TITLE
chore(packages/react-query): use token-prices v1 api in usePrices

### DIFF
--- a/packages/react-query/src/hooks/prices/usePrices.ts
+++ b/packages/react-query/src/hooks/prices/usePrices.ts
@@ -22,8 +22,8 @@ const hydrate = (data: Record<string, number>) => {
 
 export const usePrices = ({ chainId }: UsePrices) => {
   return useQuery({
-    queryKey: [`https://token-price.sushi.com/v0/${chainId}`],
-    queryFn: async () => fetch(`https://token-price.sushi.com/v0/${chainId}`).then((response) => response.json()),
+    queryKey: [`https://token-price.sushi.com/v1/${chainId}`],
+    queryFn: async () => fetch(`https://token-price.sushi.com/v1/${chainId}`).then((response) => response.json()),
     staleTime: 900000, // 15 mins
     cacheTime: 3600000, // 1hr
     refetchOnWindowFocus: false,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `usePrices` hook in the `react-query` package to fetch token prices from a new API endpoint.

### Detailed summary
- Updates the API endpoint URL in the `queryKey` and `queryFn` options of the `useQuery` function.
- The new URL uses version 1 of the API instead of version 0.
- The `staleTime` and `cacheTime` options remain unchanged.
- The `refetchOnWindowFocus` option is set to `false`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->