### PR TITLE
fix(packages/dexie): catch indexeddb error in getToken

### DIFF
--- a/packages/dexie/src/tokens/getToken.ts
+++ b/packages/dexie/src/tokens/getToken.ts
@@ -5,7 +5,7 @@ import {SavedToken} from "./types";
 
 export const getToken = async ({ chainId, address }: { chainId: ChainId | undefined, address: string | undefined}): Promise<SavedToken | undefined> => {
    try  {
-      return db.tokens.where('id').equals(`${chainId}:${address?.toLowerCase()}`).first();
+      return db.tokens.where('id').equals(`${chainId}:${address?.toLowerCase()}`).first().catch(() => undefined);
    } catch (e) {
       return undefined
    }


### PR DESCRIPTION
Dexie errors in `getToken` are being thrown inside the promise, so they aren't actually being caught by the `try...catch`.

This is causing the swap app to crash on firefox private mode when enabling cross-chain or selecting a different network from the header. [Example link](https://www.sushi.com/swap?toChainId=42161&toCurrency=0x912CE59144191C1204E64559FE8253a0e49E6548). Firefox doesn't support IndexedDB in private mode, resulting in Dexie throwing a `databaseClosedError`. Chrome incognito works regardless.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds error handling to a `getToken` function in `getToken.ts`. 

### Detailed summary:
- Added a `.catch()` statement to handle errors in the `first()` method call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->