### PR TITLE
fix(apps/earn): fix "Total Assets" amount on pool page

### DIFF
--- a/apps/earn/components/PoolSection/PoolComposition.tsx
+++ b/apps/earn/components/PoolSection/PoolComposition.tsx
@@ -29,7 +29,7 @@ export const PoolComposition: FC<PoolCompositionProps> = ({ pool }) => {
             <span className="font-semibold dark:text-slate-50 text-gray-900">
               {' '}
               {formatUSD(
-                liquidityNative ?? 0 * Number(prices?.[Native.onChain(pool.chainId).wrapped.address]?.toFixed(10))
+                (liquidityNative ?? 0) * Number(prices?.[Native.onChain(pool.chainId).wrapped.address]?.toFixed(10))
               )}
             </span>
           </Typography>


### PR DESCRIPTION
Before:
<img width="575" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/4f711061-4f93-4ed2-86f9-919ff850c242">


After:
<img width="589" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/aba1a6a0-c264-4391-8a7f-ad77f776454e">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a calculation error in the `PoolComposition` component of the `earn` app. 

### Detailed summary
- Fixed calculation error in `PoolComposition.tsx`
- Wrapped `liquidityNative` in parentheses to ensure proper multiplication order

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->