### PR TITLE
feature: sushiswapv3 graphclient config

### DIFF
--- a/packages/graph-client/.graphclientrc.yml
+++ b/packages/graph-client/.graphclientrc.yml
@@ -151,6 +151,14 @@ sources:
           ignore:
             - _SubgraphErrorPolicy_
 
+  - name: SushiSwapV3
+    handler:
+      graphql:
+        endpoint: https://{context.subgraphHost:api.thegraph.com/subgraphs/name}/{context.subgraphName:uniswap/uniswap-v3}
+        retry: 3
+    transforms:
+
+
 # Had to disable global transforms since we have a jsonSchema handler in here now...
 transforms:
   - autoPagination:

--- a/packages/graph-client/queries/sushiswap-v3.graphql
+++ b/packages/graph-client/queries/sushiswap-v3.graphql
@@ -1,21 +1,13 @@
 
-query PoolDayDatas(
+query SushiSwapV3PoolDayData(
+    $id: ID!
     $block: Block_height,
-    $first: Int = 100,
-    $orderBy: PoolDayData_orderBy,
-    $orderDirection: OrderDirection,
-    $skip: Int = 0,
-    $subgraphError: _SubgraphErrorPolicy_! = deny,
-    $where: PoolDayData_filter
+    $subgraphError: _SubgraphErrorPolicy_! = deny
 ) {
-  poolDayDatas(
+  poolDayData(
+    id: $id,
     block: $block, 
-    first: $first, 
-    orderBy: $orderBy, 
-    orderDirection: $orderDirection, 
-    skip: $skip, 
-    subgraphError: $subgraphError, 
-    where: $where
+    subgraphError: $subgraphError
 ) {
     id
     date
@@ -42,23 +34,15 @@ query PoolDayDatas(
   }
 }
 
-query PoolHourDatas(
+query SushiSwapV3PoolHourData(
+    $id: ID!
     $block: Block_height,
-    $first: Int = 100,
-    $orderBy: PoolHourData_orderBy,
-    $orderDirection: OrderDirection,
-    $skip: Int = 0,
-    $subgraphError: _SubgraphErrorPolicy_! = deny,
-    $where: PoolHourData_filter
+    $subgraphError: _SubgraphErrorPolicy_! = deny
 ) {
-  poolHourDatas(
+  poolHourData(
+    id: $id,
     block: $block, 
-    first: $first, 
-    orderBy: $orderBy, 
-    orderDirection: $orderDirection, 
-    skip: $skip, 
-    subgraphError: $subgraphError, 
-    where: $where
+    subgraphError: $subgraphError
   ) {
     id
     periodStartUnix

--- a/packages/graph-client/queries/sushiswap-v3.graphql
+++ b/packages/graph-client/queries/sushiswap-v3.graphql
@@ -1,0 +1,86 @@
+
+query PoolDayDatas(
+    $block: Block_height,
+    $first: Int = 100,
+    $orderBy: PoolDayData_orderBy,
+    $orderDirection: OrderDirection,
+    $skip: Int = 0,
+    $subgraphError: _SubgraphErrorPolicy_! = deny,
+    $where: PoolDayData_filter
+) {
+  poolDayDatas(
+    block: $block, 
+    first: $first, 
+    orderBy: $orderBy, 
+    orderDirection: $orderDirection, 
+    skip: $skip, 
+    subgraphError: $subgraphError, 
+    where: $where
+) {
+    id
+    date
+    pool {
+        id
+    }
+    liquidity
+    sqrtPrice
+    token0Price
+    token1Price
+    tick
+    feeGrowthGlobal0X128
+    feeGrowthGlobal1X128
+    tvlUSD
+    volumeToken0
+    volumeToken1
+    volumeUSD
+    feesUSD
+    txCount
+    open
+    high
+    low
+    close
+  }
+}
+
+query PoolHourDatas(
+    $block: Block_height,
+    $first: Int = 100,
+    $orderBy: PoolHourData_orderBy,
+    $orderDirection: OrderDirection,
+    $skip: Int = 0,
+    $subgraphError: _SubgraphErrorPolicy_! = deny,
+    $where: PoolHourData_filter
+) {
+  poolHourDatas(
+    block: $block, 
+    first: $first, 
+    orderBy: $orderBy, 
+    orderDirection: $orderDirection, 
+    skip: $skip, 
+    subgraphError: $subgraphError, 
+    where: $where
+  ) {
+    id
+    periodStartUnix
+    pool {
+        id
+    }
+    liquidity
+    sqrtPrice
+    token0Price
+    token1Price
+    tick
+    feeGrowthGlobal0X128
+    feeGrowthGlobal1X128
+    tvlUSD
+    volumeToken0
+    volumeToken1
+    volumeUSD
+    feesUSD
+    txCount
+    open
+    high
+    low
+    close
+  }
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds two GraphQL queries for SushiSwapV3 to the graph-client package.

### Detailed summary
- Adds two GraphQL queries for SushiSwapV3 to the graph-client package
- Queries are named `SushiSwapV3PoolDayData` and `SushiSwapV3PoolHourData`
- Queries return data related to SushiSwapV3 pool activity, including liquidity, prices, volume, fees, and more
- Queries accept parameters for pool ID, block height, and error policy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->