### PR TITLE
Feature/client side dex aggregation

### DIFF
--- a/apps/_root/ui/swap/ConfirmationDialog.tsx
+++ b/apps/_root/ui/swap/ConfirmationDialog.tsx
@@ -141,6 +141,7 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ children }) =>
                 (leg) =>
                   leg.poolName.startsWith('Wrap') ||
                   leg.poolName.startsWith('SushiSwap') ||
+                  leg.poolName.startsWith('SushiSwapV3') ||
                   leg.poolName.startsWith('Trident') ||
                   leg.poolName.startsWith('BentoBridge')
               )
@@ -151,12 +152,21 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ children }) =>
                 receipt,
               })
             } else if (
-              !trade?.route?.legs?.every(
+              trade?.route?.legs?.some(
                 (leg) =>
-                  leg.poolName.startsWith('Wrap') ||
-                  leg.poolName.startsWith('SushiSwap') ||
-                  leg.poolName.startsWith('Trident') ||
-                  leg.poolName.startsWith('BentoBridge')
+                  !leg.poolName.startsWith('Wrap') &&
+                  (leg.poolName.startsWith('SushiSwap') ||
+                    leg.poolName.startsWith('SushiSwapV3') ||
+                    leg.poolName.startsWith('Trident') ||
+                    leg.poolName.startsWith('BentoBridge'))
+              ) &&
+              trade?.route?.legs?.some(
+                (leg) =>
+                  !leg.poolName.startsWith('Wrap') &&
+                  (!leg.poolName.startsWith('SushiSwap') ||
+                    !leg.poolName.startsWith('SushiSwapV3') ||
+                    !leg.poolName.startsWith('Trident') ||
+                    !leg.poolName.startsWith('BentoBridge'))
               )
             ) {
               log.info('Swap success (mix)', {
@@ -169,6 +179,7 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ children }) =>
                 (leg) =>
                   !leg.poolName.startsWith('Wrap') &&
                   !leg.poolName.startsWith('SushiSwap') &&
+                  !leg.poolName.startsWith('SushiSwapV3') &&
                   !leg.poolName.startsWith('Trident') &&
                   !leg.poolName.startsWith('BentoBridge')
               )
@@ -193,6 +204,7 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ children }) =>
                 (leg) =>
                   leg.poolName.startsWith('Wrap') ||
                   leg.poolName.startsWith('SushiSwap') ||
+                  leg.poolName.startsWith('SushiSwapV3') ||
                   leg.poolName.startsWith('Trident') ||
                   leg.poolName.startsWith('BentoBridge')
               )
@@ -203,12 +215,21 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ children }) =>
                 receipt,
               })
             } else if (
-              !trade?.route?.legs?.every(
+              trade?.route?.legs?.some(
                 (leg) =>
-                  leg.poolName.startsWith('Wrap') ||
-                  leg.poolName.startsWith('SushiSwap') ||
-                  leg.poolName.startsWith('Trident') ||
-                  leg.poolName.startsWith('BentoBridge')
+                  !leg.poolName.startsWith('Wrap') &&
+                  (leg.poolName.startsWith('SushiSwap') ||
+                    leg.poolName.startsWith('SushiSwapV3') ||
+                    leg.poolName.startsWith('Trident') ||
+                    leg.poolName.startsWith('BentoBridge'))
+              ) &&
+              trade?.route?.legs?.some(
+                (leg) =>
+                  !leg.poolName.startsWith('Wrap') &&
+                  (!leg.poolName.startsWith('SushiSwap') ||
+                    !leg.poolName.startsWith('SushiSwapV3') ||
+                    !leg.poolName.startsWith('Trident') ||
+                    !leg.poolName.startsWith('BentoBridge'))
               )
             ) {
               log.info('Swap failed (mix)', {
@@ -221,6 +242,7 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ children }) =>
                 (leg) =>
                   !leg.poolName.startsWith('Wrap') &&
                   !leg.poolName.startsWith('SushiSwap') &&
+                  !leg.poolName.startsWith('SushiSwapV3') &&
                   !leg.poolName.startsWith('Trident') &&
                   !leg.poolName.startsWith('BentoBridge')
               )

--- a/packages/wagmi/future/hooks/pools/actions/getAllPoolsCodeMap.ts
+++ b/packages/wagmi/future/hooks/pools/actions/getAllPoolsCodeMap.ts
@@ -9,7 +9,13 @@ export const getAllPoolsCodeMap = async ({ currencyA, currencyB, chainId }: Omit
     return nullPoolCodeMap
   }
   const dataFetcher = DataFetcher.onChain(chainId)
-  const liquidityProviders = [LiquidityProviders.SushiSwap, LiquidityProviders.Trident]
+  const liquidityProviders = [
+    LiquidityProviders.SushiSwap,
+    LiquidityProviders.Trident,
+    LiquidityProviders.UniswapV2,
+    LiquidityProviders.QuickSwap,
+    LiquidityProviders.ApeSwap,
+  ]
   if (isRouteProcessor3ChainId(chainId)) {
     liquidityProviders.push(LiquidityProviders.SushiSwapV3)
   }

--- a/packages/wagmi/future/hooks/trade/hooks/useClientTrade.ts
+++ b/packages/wagmi/future/hooks/trade/hooks/useClientTrade.ts
@@ -66,13 +66,14 @@ export const useClientTrade = (variables: UseTradeParams) => {
           overrides: undefined,
         }
 
-      const route = Router.findSushiRoute(
+      const route = Router.findSpecialRoute(
         poolsCodeMap,
         chainId,
         fromToken,
         BigNumber.from(amount.quotient.toString()),
         toToken,
-        feeData.gasPrice.toNumber()
+        feeData.gasPrice.toNumber(),
+        5 // 5% impact before dex aggregation
       )
 
       const logPools = Array.from(poolsCodeMap.values())


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for new liquidity providers and a 5% impact before dex aggregation. It also updates the `useClientTrade` and `getAllPoolsCodeMap` files and modifies the `ConfirmationDialog` component to include `SushiSwapV3` in the list of supported pools.

### Detailed summary
- Added support for `UniswapV2`, `QuickSwap`, and `ApeSwap` liquidity providers in `getAllPoolsCodeMap`
- Updated `useClientTrade` to include a 5% impact before dex aggregation
- Modified `ConfirmationDialog` component to include `SushiSwapV3` in the list of supported pools in various places

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->