### PR TITLE
fix(packages/ui): styles in NetworkSelectorDialog

### DIFF
--- a/packages/ui/future/components/networkselector/NetworkSelectorDialog.tsx
+++ b/packages/ui/future/components/networkselector/NetworkSelectorDialog.tsx
@@ -1,5 +1,4 @@
 import { Popover } from '@headlessui/react'
-import { CheckIcon } from '@heroicons/react/24/outline'
 import chains from '@sushiswap/chain'
 import classNames from 'classnames'
 import React, { FC, useState } from 'react'
@@ -34,27 +33,22 @@ export const NetworkSelectorDialog = <T extends number>({
                         onClick={() => onSelect(el, close)}
                         key={el}
                         className={classNames(
-                          'w-full group hover:bg-white hover:dark:bg-slate-800 px-2.5 flex rounded-lg justify-between gap-2 items-center cursor-pointer transform-all h-[40px]'
+                          'w-full group hover:bg-black/[0.04] hover:dark:bg-white/[0.06] px-2.5 flex rounded-lg justify-between gap-2 items-center cursor-pointer transform-all h-[40px]'
                         )}
                       >
                         <div className="flex items-center gap-2">
-                          <NetworkIcon
-                            type="naked"
-                            chainId={el}
-                            width={24}
-                            height={24}
-                            className="text-gray-600 group-hover:text-gray-900 dark:text-slate-50"
-                          />
+                          <NetworkIcon chainId={el} width={24} height={24} />
                           <p
                             className={classNames(
-                              selected === el ? 'font-semibold text-gray-900' : 'font-medium text-gray-500',
-                              'text-sm group-hover:text-gray-900 dark:text-slate-300 group-hover:dark:text-slate-50'
+                              selected === el
+                                ? 'text-gray-900 dark:text-white font-medium'
+                                : 'text-gray-600 dark:text-slate-400'
                             )}
                           >
                             {chains[el].name}
                           </p>
                         </div>
-                        {selected === el && <CheckIcon width={20} height={20} strokeWidth={2} className="text-blue" />}
+                        {selected === el && <div className="w-2 h-2 mr-1 rounded-full bg-green" />}
                       </button>
                     ))}
                 </div>


### PR DESCRIPTION
Addresses EGN-281 and homogenizes NetworkSelectorDialog styles with [`NetworkSelectorMenu`](https://github.com/sushiswap/sushiswap/blob/master/packages/ui/future/components/networkselector/NetworkSelectorMenu.tsx).

Before:
<img width="456" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/30e22ec5-4727-4e56-81ca-e908030a10f3">


After:
<img width="467" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/d286b72a-db5e-412e-9d72-e8c88c9419a3">



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the styling of the NetworkSelectorDialog component in the UI package. 

### Detailed summary
- Replaces the `NetworkIcon` component with a simpler implementation
- Updates the hover and selected styles of the component
- Replaces the `CheckIcon` with a simple green dot for selected networks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->