### PR TITLE
chore: reduce bias threshold to 2.5%

### DIFF
--- a/packages/wagmi/future/hooks/trade/hooks/useClientTrade.ts
+++ b/packages/wagmi/future/hooks/trade/hooks/useClientTrade.ts
@@ -73,7 +73,7 @@ export const useClientTrade = (variables: UseTradeParams) => {
         BigNumber.from(amount.quotient.toString()),
         toToken,
         feeData.gasPrice.toNumber(),
-        5 // 5% impact before dex aggregation
+        2.5 // 2.5% impact before dex aggregation
       )
 
       const logPools = Array.from(poolsCodeMap.values())


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on reducing the impact before dex aggregation in the `useClientTrade.ts` file. 

### Detailed summary
- Reduced impact before dex aggregation from 5% to 2.5%
- No other notable changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->