### PR TITLE
chore: enable spookswap v2, trader joe v2 & pancakeswap v2

### DIFF
--- a/apps/_root/test/pages/swap.test.ts
+++ b/apps/_root/test/pages/swap.test.ts
@@ -85,7 +85,7 @@ test('Swap Native to USDC, then USDC to NATIVE', async ({ page }) => {
     page,
     inputCurrency: native,
     outputCurrency: usdc,
-    amount: '1',
+    amount: '100',
   })
 
   // Ensure balances at least change...
@@ -119,7 +119,7 @@ test('Swap Native to SUSHI, then SUSHI to NATIVE', async ({ page }) => {
     page,
     inputCurrency: native,
     outputCurrency: sushi,
-    amount: '1',
+    amount: '100',
   })
 
   // Ensure balances at least change...

--- a/packages/wagmi/future/hooks/pools/actions/getAllPoolsCodeMap.ts
+++ b/packages/wagmi/future/hooks/pools/actions/getAllPoolsCodeMap.ts
@@ -15,6 +15,9 @@ export const getAllPoolsCodeMap = async ({ currencyA, currencyB, chainId }: Omit
     LiquidityProviders.UniswapV2,
     LiquidityProviders.QuickSwap,
     LiquidityProviders.ApeSwap,
+    LiquidityProviders.SpookySwap,
+    LiquidityProviders.TraderJoe,
+    LiquidityProviders.PancakeSwap,
   ]
   if (isRouteProcessor3ChainId(chainId)) {
     liquidityProviders.push(LiquidityProviders.SushiSwapV3)


### PR DESCRIPTION
enable spookswap v2, trader joe v2 & pancakeswap v2 for clientside dex aggregation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for new liquidity providers and updates swap amounts in the test pages.

### Detailed summary
- Added support for `SpookySwap`, `TraderJoe`, and `PancakeSwap` liquidity providers in `getAllPoolsCodeMap.ts`.
- Added support for `SushiSwapV3` liquidity provider in `getAllPoolsCodeMap.ts` for `isRouteProcessor3ChainId` condition.
- Updated `amount` values from `1` to `100` in `swap.test.ts` for `native` to `usdc` and `native` to `sushi` swaps.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->