### PR TITLE
Update additional-bases.ts

### DIFF
--- a/config/router/src/additional-bases.ts
+++ b/config/router/src/additional-bases.ts
@@ -73,6 +73,7 @@ export const ADDITIONAL_BASES: {
       COMP[ChainId.ETHEREUM],
       GALA[ChainId.ETHEREUM],
       XSUSHI[ChainId.ETHEREUM],
+      LINK[ChainId.ETHEREUM],
     ],
   },
   [ChainId.POLYGON]: {
@@ -88,6 +89,8 @@ export const ADDITIONAL_BASES: {
       SNX[ChainId.POLYGON],
       CRV[ChainId.POLYGON],
       YFI[ChainId.POLYGON],
+      XSUSHI[ChainId.POLYGON],
+      SUSHI[ChainId.POLYGON],
       // ENJ[ChainId.POLYGON], // could not find on polygon
     ],
   },
@@ -104,6 +107,8 @@ export const ADDITIONAL_BASES: {
       SNX[ChainId.FANTOM],
       CRV[ChainId.FANTOM],
       YFI[ChainId.FANTOM],
+      SUSHI[ChainId.POLYGON],
+      XSUSHI[ChainId.POLYGON],
     ],
   },
   [ChainId.BSC]: {


### PR DESCRIPTION
Updated bases to include Link-Two, Sushi-Three, XSushi-Three, Sushi-Four, and XSushi-Four as routable pairs.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds SUSHI and LINK as additional bases on certain chains, and updates XSUSHI on others.

### Detailed summary
- Adds LINK as an additional base on Ethereum
- Adds SUSHI and XSUSHI as additional bases on Polygon
- Updates XSUSHI and adds SUSHI as additional bases on Fantom

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->