### PR TITLE
Update common-bases.ts

### DIFF
--- a/config/router/src/common-bases.ts
+++ b/config/router/src/common-bases.ts
@@ -21,6 +21,7 @@ export const COMMON_BASES = {
     Native.onChain(ChainId.ETHEREUM),
     WNATIVE[ChainId.ETHEREUM],
     SUSHI[ChainId.ETHEREUM],
+    XSUSHI[ChainId.ETHEREUM],
     WBTC[ChainId.ETHEREUM],
     USDC[ChainId.ETHEREUM],
     USDT[ChainId.ETHEREUM],
@@ -56,6 +57,8 @@ export const COMMON_BASES = {
     USDC[ChainId.POLYGON],
     USDT[ChainId.POLYGON],
     DAI[ChainId.POLYGON],
+    SUSHI[ChainId.POLYGON],
+    XSUSHI[ChainId.POLYGON],
   ],
   [ChainId.POLYGON_TESTNET]: [],
   [ChainId.AVALANCHE]: [
@@ -97,6 +100,8 @@ export const COMMON_BASES = {
     USDT[ChainId.FANTOM],
     DAI[ChainId.FANTOM],
     MIM[ChainId.FANTOM],
+    SUSHI[ChainId.FANTOM],
+    XSUSHI[ChainId.FANTOM],
   ],
   [ChainId.FANTOM_TESTNET]: [],
   [ChainId.ARBITRUM]: [
@@ -186,6 +191,9 @@ export const COMMON_BASES = {
     USDC[ChainId.OPTIMISM],
     USDT[ChainId.OPTIMISM],
     DAI[ChainId.OPTIMISM],
+    WETH9[ChainId.OPTIMISM],
+    SUSHI[ChainId.OPTIMISM],
+    XSUSHI[ChainId.OPTIMISM],
   ],
   [ChainId.KAVA]: [
     Native.onChain(ChainId.KAVA),


### PR DESCRIPTION
Updated common bases to include routing for XSushi and Sushi on Fantom, Polygon, and Optimism. 

Updated routing on Optimism to include WETH9.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `XSUSHI` to the `COMMON_BASES` array for various chains.

### Detailed summary
- Adds `XSUSHI` to the `COMMON_BASES` array for Ethereum, Polygon, Fantom, and Optimism chains. 
- Adds `WETH9` to the `COMMON_BASES` array for Optimism chain.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->