### PR TITLE
chore(packages/format): handle small values in formatUSD

### DIFF
--- a/packages/format/src/price.ts
+++ b/packages/format/src/price.ts
@@ -2,7 +2,7 @@ import numeral from 'numeral'
 
 export const formatUSD = (value: string | number, inputString = '$0.00a'): string => {
   if (typeof value === 'string') value = Number(value)
-  if (value < 0.000001) return '$0.00'
+  if (value < 0.000001) return '<$0.01'
   if (value < 0.0001) return numeral(value).format('$0.000000a')
   if (value < 0.001) return numeral(value).format('$0.0000a')
   if (value < 0.01) return numeral(value).format('$0.000a')


### PR DESCRIPTION
Some tokens such as BTT have a small USD value and currently display as "$0.00".
<img width="588" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/4df4d63b-c616-48c4-91a0-fff0cd3b193a">

After:
<img width="614" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/da755f20-3f25-4aea-8cf7-56901d4482ae">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `formatUSD` function in `packages/format/src/price.ts` to change the return value when the input value is less than `0.000001` from `'$0.00'` to `'<$0.01'`.

### Detailed summary
- Changed return value of `formatUSD` function from `'$0.00'` to `'<$0.01'` when input value is less than `0.000001`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->