### PR TITLE
chore: lower aggregation threshold

### DIFF
--- a/packages/wagmi/future/hooks/trade/hooks/useClientTrade.ts
+++ b/packages/wagmi/future/hooks/trade/hooks/useClientTrade.ts
@@ -73,7 +73,7 @@ export const useClientTrade = (variables: UseTradeParams) => {
         BigNumber.from(amount.quotient.toString()),
         toToken,
         feeData.gasPrice.toNumber(),
-        2.5 // 2.5% impact before dex aggregation
+        1 // 1% impact before dex aggregation
       )
 
       const logPools = Array.from(poolsCodeMap.values())


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR reduces the impact before dex aggregation from 2.5% to 1%. 

### Detailed summary
- `useClientTrade.ts`: 
  - Change the impact before dex aggregation from 2.5% to 1%.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->