### PR TITLE
fix(packages/format): account for 0 value in formatUSD

### DIFF
--- a/packages/format/src/price.ts
+++ b/packages/format/src/price.ts
@@ -2,6 +2,7 @@ import numeral from 'numeral'
 
 export const formatUSD = (value: string | number, inputString = '$0.00a'): string => {
   if (typeof value === 'string') value = Number(value)
+  if (value === 0) return '$0.00'
   if (value < 0.000001) return '<$0.01'
   if (value < 0.0001) return numeral(value).format('$0.000000a')
   if (value < 0.001) return numeral(value).format('$0.0000a')


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the `formatUSD` function in the `price.ts` file by adding more precise formatting for small values and returning a specific string for 0 values.

### Detailed summary
- Added a check to return `$0.00` for 0 values
- Added a check to return `<$0.01` for values less than `0.000001`
- Added formatting for values less than `0.0001` and `0.001` using `numeral` library

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->