### PR TITLE
feature: add unverified pools

### DIFF
--- a/apps/analytics/components/PoolTable/PoolTable.tsx
+++ b/apps/analytics/components/PoolTable/PoolTable.tsx
@@ -31,7 +31,7 @@ const COLUMNS = [
   APR_COLUMN,
 ] as any
 
-export const PoolTable: FC = () => {
+export const PoolTable: FC<{ isWhitelisted: boolean }> = ({ isWhitelisted }) => {
   const { chainIds, tokenSymbols } = usePoolFilters()
   const { isSm } = useBreakpoint('sm')
   const { isMd } = useBreakpoint('md')
@@ -50,9 +50,9 @@ export const PoolTable: FC = () => {
       tokenSymbols,
       orderBy: sorting[0]?.id,
       orderDir: sorting[0] ? (sorting[0].desc ? 'desc' : 'asc') : 'desc',
-      isWhitelisted: true,
+      isWhitelisted,
     }),
-    [chainIds, sorting, tokenSymbols]
+    [chainIds, sorting, tokenSymbols, isWhitelisted]
   )
 
   const { data: pools, isValidating, size, setSize } = usePoolsInfinite({ args, swrConfig: useSWRConfig() })

--- a/apps/analytics/components/PoolsFiltersProvider.tsx
+++ b/apps/analytics/components/PoolsFiltersProvider.tsx
@@ -13,6 +13,8 @@ enum Filters {
 
 export enum SelectedTable {
   Markets = 'Markets',
+  VerifiedPools = 'Verified Pools',
+  UnverifiedPools = 'Unverified Pools',
   Tokens = 'Tokens',
 }
 

--- a/apps/analytics/components/TableSection/TableSection.tsx
+++ b/apps/analytics/components/TableSection/TableSection.tsx
@@ -13,7 +13,7 @@ export const TableSection: FC = () => {
   const onChange = useCallback(
     (val: number) => {
       setFilters({
-        selectedTable: val === 0 ? SelectedTable.Markets : SelectedTable.Tokens,
+        selectedTable: val === 0 ? SelectedTable.VerifiedPools : SelectedTable.UnverifiedPools,
       })
     },
     [setFilters]
@@ -26,11 +26,17 @@ export const TableSection: FC = () => {
           <Tab as={Fragment}>
             {({ selected }) => (
               <Button size="sm" variant={selected ? 'outlined' : 'empty'} color="default">
-                Pools
+                Verified Pools
               </Button>
             )}
           </Tab>
-
+          <Tab as={Fragment}>
+            {({ selected }) => (
+              <Button size="sm" variant={selected ? 'outlined' : 'empty'} color="default">
+                Unverified Pools
+              </Button>
+            )}
+          </Tab>
           {/* <Tab as={Fragment}>
             {({ selected }) => (
               <Button size="sm" variant={selected ? 'outlined' : 'empty'} color="default">
@@ -42,7 +48,10 @@ export const TableSection: FC = () => {
         <TableFilters />
         <Tab.Panels>
           <Tab.Panel unmount={false}>
-            <PoolTable />
+            <PoolTable isWhitelisted={true} />
+          </Tab.Panel>
+          <Tab.Panel unmount={false}>
+            <PoolTable isWhitelisted={false} />
           </Tab.Panel>
           {/* <Tab.Panel unmount={false}>
             <TokenTable />

--- a/apps/analytics/lib/constants.ts
+++ b/apps/analytics/lib/constants.ts
@@ -7,3 +7,10 @@ export const defaultPoolsArgs: GetPoolsArgs = {
   orderDir: 'desc',
   isWhitelisted: true,
 }
+
+export const defaultUnverifiedPoolsArgs: GetPoolsArgs = {
+  chainIds: SUPPORTED_CHAIN_IDS,
+  orderBy: 'liquidityUSD',
+  orderDir: 'desc',
+  isWhitelisted: false,
+}

--- a/apps/analytics/pages/index.tsx
+++ b/apps/analytics/pages/index.tsx
@@ -7,7 +7,7 @@ import { getPools, getPoolCount, getPoolCountUrl, getPoolsUrl } from '@sushiswap
 
 import { ChartSection, Layout, PoolsFiltersProvider, TableSection } from '../components'
 import { getBundles, getCharts, getTokenCount, getTokens } from '../lib/api'
-import { defaultPoolsArgs } from 'lib/constants'
+import { defaultPoolsArgs, defaultUnverifiedPoolsArgs } from 'lib/constants'
 
 export const getStaticProps: GetStaticProps = async () => {
   const [pools, tokens, charts, poolCount, tokenCount, bundles] = await Promise.all([
@@ -21,26 +21,6 @@ export const getStaticProps: GetStaticProps = async () => {
   return {
     props: {
       fallback: {
-        [unstable_serialize_infinite(() => getPoolsUrl(defaultPoolsArgs))]: pools,
-        [unstable_serialize({
-          url: '/analytics/api/tokens',
-          args: {
-            sorting: [
-              {
-                id: 'liquidityUSD',
-                desc: true,
-              },
-            ],
-            selectedNetworks: SUPPORTED_CHAIN_IDS,
-            pagination: {
-              pageIndex: 0,
-              pageSize: 20,
-            },
-            query: '',
-            extraQuery: '',
-          },
-        })]: tokens,
-
         [unstable_serialize({
           url: '/analytics/api/charts',
           args: {
@@ -48,7 +28,27 @@ export const getStaticProps: GetStaticProps = async () => {
           },
         })]: charts,
         [getPoolCountUrl(defaultPoolsArgs)]: poolCount,
-        [`/analytics/api/tokens/count`]: tokenCount,
+        [unstable_serialize_infinite(() => getPoolsUrl(defaultPoolsArgs))]: pools,
+        [unstable_serialize_infinite(() => getPoolsUrl(defaultUnverifiedPoolsArgs))]: pools,
+        // [unstable_serialize({
+        //   url: '/analytics/api/tokens',
+        //   args: {
+        //     sorting: [
+        //       {
+        //         id: 'liquidityUSD',
+        //         desc: true,
+        //       },
+        //     ],
+        //     selectedNetworks: SUPPORTED_CHAIN_IDS,
+        //     pagination: {
+        //       pageIndex: 0,
+        //       pageSize: 20,
+        //     },
+        //     query: '',
+        //     extraQuery: '',
+        //   },
+        // })]: tokens,
+        // [`/analytics/api/tokens/count`]: tokenCount,
         [`/analytics/api/bundles`]: bundles,
       },
     },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for displaying unverified pools in the analytics section of the app.

### Detailed summary
- Added `Verified Pools` and `Unverified Pools` as options in the pool table selection
- Added `defaultUnverifiedPoolsArgs` constant to `constants.ts`
- Modified `PoolTable` component to accept `isWhitelisted` prop and pass it to `usePoolsInfinite`
- Modified `TableSection` component to render two `PoolTable` components with different `isWhitelisted` props
- Modified `getStaticProps` function in `index.tsx` to fetch and serialize data for unverified pools

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->