### PR TITLE
fix(apps/earn): apr column id in pools table

### DIFF
--- a/apps/earn/components/PoolsSection/Tables/PoolsTable/Cells/columns.tsx
+++ b/apps/earn/components/PoolsSection/Tables/PoolsTable/Cells/columns.tsx
@@ -57,7 +57,7 @@ export const TVL_COLUMN: ColumnDef<Pool, unknown> = {
 }
 
 export const APR_COLUMN: ColumnDef<Pool, unknown> = {
-  id: 'totalApr',
+  id: 'totalApr1d',
   header: () => (
     <div className="flex items-center gap-1">
       APR


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR changes the ID of a column in the PoolsTable component of the Earn app. 

### Detailed summary
- Changes the ID of the APR column from 'totalApr' to 'totalApr1d'
- No other notable changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->