### PR TITLE
feat(apps/earn): concentrated selected %

### DIFF
--- a/apps/earn/components/NewPositionSection/SelectFeeConcentratedWidget.tsx
+++ b/apps/earn/components/NewPositionSection/SelectFeeConcentratedWidget.tsx
@@ -1,11 +1,13 @@
 import { RadioGroup } from '@headlessui/react'
-import { classNames } from '@sushiswap/ui'
-import React, { Dispatch, FC, memo, SetStateAction } from 'react'
+import { classNames, Skeleton } from '@sushiswap/ui'
+import React, { Dispatch, FC, memo, SetStateAction, useMemo } from 'react'
 
 import { ContentBlock } from '../AddPage/ContentBlock'
 import { FeeAmount } from '@sushiswap/v3-sdk'
 import { useConcentratedLiquidityURLState } from '../ConcentratedLiquidityURLStateProvider'
 import { Type } from '@sushiswap/currency'
+import { usePoolsByTokenPair } from 'lib/hooks/usePoolsByTokenPair'
+import { formatPercent } from '@sushiswap/format'
 
 export const FEE_OPTIONS = [
   {
@@ -39,6 +41,26 @@ export const SelectFeeConcentratedWidget: FC<SelectFeeConcentratedWidget> = memo
   token0,
   token1,
 }) {
+  const { data: pools, isLoading } = usePoolsByTokenPair(token0?.wrapped.id, token1?.wrapped.id)
+
+  const tvlDistribution = useMemo(() => {
+    const tvlDistribution = new Map<(typeof FEE_OPTIONS)[number]['value'], number>()
+
+    if (!pools) return tvlDistribution
+
+    const totalTvl = pools?.reduce((acc, pool) => acc + Number(pool.totalValueLockedUSD), 0)
+
+    pools?.forEach((pool) => {
+      if (!FEE_OPTIONS.find((option) => option.value === Number(pool.feeTier))) return
+
+      const tvlShare = pool.totalValueLockedUSD / totalTvl
+      if (isNaN(tvlShare)) return
+      tvlDistribution.set(Number(pool.feeTier), tvlShare)
+    })
+
+    return tvlDistribution
+  }, [pools])
+
   return (
     <ContentBlock
       disabled={!token0 || !token1}
@@ -66,9 +88,20 @@ export const SelectFeeConcentratedWidget: FC<SelectFeeConcentratedWidget> = memo
               )
             }
           >
-            <div className="flex flex-col">
-              <span className="flex gap-4 font-medium text-gray-900 dark:text-slate-50">
-                {option.value / 10000}% Fees{' '}
+            <div className="flex flex-col space-y-1">
+              <span className="flex items-center space-x-2">
+                <div className="font-medium text-gray-900 dark:text-slate-50">{option.value / 10000}% Fees </div>{' '}
+                {!isLoading ? (
+                  <>
+                    {tvlDistribution.get(option.value) && (
+                      <div className="px-2 py-1 text-xs text-gray-700 bg-gray-200 dark:bg-gray-700 dark:text-gray-200 rounded-[20px]">
+                        {(tvlDistribution.get(option.value)! * 100)?.toFixed(0)}% Selected
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <Skeleton.Box className="w-[90px] h-[24px] rounded-[20px]" />
+                )}
               </span>
               <span className="text-sm text-gray-500 dark:text-slate-400 text-slate-600">{option.subtitle}</span>
             </div>

--- a/apps/earn/lib/api.ts
+++ b/apps/earn/lib/api.ts
@@ -94,7 +94,7 @@ export const getAllV3Ticks = async (id: string) => {
   return ticks
 }
 
-export const getCollectsByTokenPair = async (tokenId0: string, tokenId1: string) => {
+export const getPoolsByTokenPair = async (tokenId0: string, tokenId1: string) => {
   const [chainId0, tokenAddress0] = tokenId0.split(':')
   if (!chainId0 || !tokenAddress0) throw Error('Invalid token0 id')
 

--- a/apps/earn/lib/hooks/usePoolsByTokenPair.ts
+++ b/apps/earn/lib/hooks/usePoolsByTokenPair.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
+import { getPoolsByTokenPair } from 'lib/api'
+
+function usePoolsByTokenPair(tokenId0?: string, tokenId1?: string) {
+  return useQuery({
+    queryKey: ['poolsByTokenPair', tokenId0, tokenId1],
+    queryFn: () => {
+      if (!tokenId0 || !tokenId1) return []
+
+      return getPoolsByTokenPair(tokenId0.toLowerCase(), tokenId1.toLowerCase())
+    },
+    enabled: !!tokenId0 && !!tokenId1,
+  })
+}
+
+export { usePoolsByTokenPair }

--- a/packages/graph-client/resolvers/concentrated/poolsByTokenPair.ts
+++ b/packages/graph-client/resolvers/concentrated/poolsByTokenPair.ts
@@ -1,4 +1,4 @@
-import { CONCENTRATED_SUBGRAPH_NAME, SUBGRAPH_HOST } from '@sushiswap/graph-config'
+import { SUBGRAPH_HOST, SUSHISWAP_V3_SUBGRAPH_NAME } from '@sushiswap/graph-config'
 
 import { Query, QueryResolvers } from '../../.graphclient/index.js'
 
@@ -32,7 +32,7 @@ export const poolsByTokenPair: QueryResolvers['poolsByTokenPair'] = async (
       context: {
         ...context,
         chainId: Number(chainId),
-        subgraphName: CONCENTRATED_SUBGRAPH_NAME[chainId],
+        subgraphName: SUSHISWAP_V3_SUBGRAPH_NAME[chainId],
         subgraphHost: SUBGRAPH_HOST[chainId],
       },
       info,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR changes the name of a function and adds a new function to get pools by token pair. It also updates a resolver to use the new subgraph name and adds a new feature to display the TVL distribution of each fee tier. 

### Detailed summary
- Renames `getCollectsByTokenPair` to `getPoolsByTokenPair`
- Adds a new function `getPoolsByTokenPair` to fetch pools by token pair
- Updates `poolsByTokenPair` resolver to use the new subgraph name
- Adds a new feature to display the TVL distribution of each fee tier in `SelectFeeConcentratedWidget` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->