### PR TITLE
EGN-361 - Adds a simple cache to filter out non-existing pools

### DIFF
--- a/packages/wagmi/future/hooks/pools/actions/getAllPoolsCodeMap.ts
+++ b/packages/wagmi/future/hooks/pools/actions/getAllPoolsCodeMap.ts
@@ -30,7 +30,10 @@ export const getAllPoolsCodeMap = async ({ currencyA, currencyB, chainId }: Omit
     liquidityProviders.push(LiquidityProviders.SushiSwapV3)
   }
   dataFetcher.startDataFetching(liquidityProviders)
-  await dataFetcher.fetchPoolsForToken(currencyA, currencyB)
+  if (currencyA.chainId === currencyB.chainId) {
+    await dataFetcher.fetchPoolsForToken(currencyA, currencyB)
+  }
+
   dataFetcher.stopDataFetching()
   return dataFetcher.getCurrentPoolCodeMap(currencyA, currencyB)
 }


### PR DESCRIPTION
Adds items to a cache whenever a currencycombination is being fetched that returned a null result to reduce rpc calls on next iteration