### PR TITLE
EGN-362 - Make skeletons more performant + deprecate old UI components

### DIFF
--- a/apps/earn/components/PoolSection/V3/PoolTransactionsV3/columns.tsx
+++ b/apps/earn/components/PoolSection/V3/PoolTransactionsV3/columns.tsx
@@ -2,7 +2,7 @@ import { ColumnDef } from '@tanstack/react-table'
 import { Transaction, TransactionType } from './useTransactionsV3'
 import { formatUSD } from '@sushiswap/format'
 import formatDistance from 'date-fns/formatDistance/index.js'
-import { Skeleton } from '@sushiswap/ui'
+import { Skeleton } from '@sushiswap/ui/future/components/skeleton'
 import { useMemo } from 'react'
 import { ChevronRightIcon } from '@heroicons/react/solid'
 

--- a/apps/furo/components/Table/constants.tsx
+++ b/apps/furo/components/Table/constants.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@sushiswap/ui'
+import { Skeleton } from '@sushiswap/ui/future/components/skeleton'
 import { ColumnDef } from '@tanstack/react-table'
 import React from 'react'
 

--- a/packages/ui/animation/AppearOnMount/AppearOnMount.tsx
+++ b/packages/ui/animation/AppearOnMount/AppearOnMount.tsx
@@ -10,6 +10,9 @@ interface AppearOnMount {
   className?: string
 }
 
+/**
+ * @deprecated
+ */
 export const AppearOnMount: FC<AppearOnMount> = ({ as = 'div', show, children, enabled = true, className }) => {
   const isMounted = useIsMounted()
 

--- a/packages/ui/animation/Collapsible/Collapsible.tsx
+++ b/packages/ui/animation/Collapsible/Collapsible.tsx
@@ -8,6 +8,9 @@ interface Collapsible {
   className?: string
 }
 
+/**
+ * @deprecated
+ */
 export const Collapsible: FC<Collapsible> = ({ className, open, children }) => {
   const { ref, height } = useResizeObserver()
 

--- a/packages/ui/animation/SlideIn/SlideIn.tsx
+++ b/packages/ui/animation/SlideIn/SlideIn.tsx
@@ -31,6 +31,9 @@ export const useSlideInContext = () => {
   return useContext(SlideInContext)
 }
 
+/**
+ * @deprecated
+ */
 export const SlideIn: FC<RootProps> & {
   FromLeft: FC<FromLeft>
   FromRight: FC<FromRight>

--- a/packages/ui/app/index.ts
+++ b/packages/ui/app/index.ts
@@ -16,6 +16,9 @@ export type AppProps = {
   NavItemList: NavItemListProps
 }
 
+/**
+ * @deprecated
+ */
 export const App = {
   Header,
   Shell,

--- a/packages/ui/backdrop/Backdrop.tsx
+++ b/packages/ui/backdrop/Backdrop.tsx
@@ -5,6 +5,9 @@ type Props = {
   backdrop?: React.ReactNode
 }
 
+/**
+ * @deprecated
+ */
 export function Backdrop({ children, backdrop }: Props): JSX.Element {
   return (
     <>

--- a/packages/ui/badge/Badge.tsx
+++ b/packages/ui/badge/Badge.tsx
@@ -7,6 +7,9 @@ interface Badge {
   className?: string
 }
 
+/**
+ * @deprecated
+ */
 export const Badge: FC<Badge> = ({ badgeContent, children, className }) => {
   return (
     <div className="relative">

--- a/packages/ui/breadcrumb/Breadcrumb.tsx
+++ b/packages/ui/breadcrumb/Breadcrumb.tsx
@@ -13,6 +13,9 @@ interface Breadcrumb {
   links: BreadcrumbLink[]
 }
 
+/**
+ * @deprecated
+ */
 export const Breadcrumb: FC<Breadcrumb> = ({ links, home }) => {
   return (
     <div className="flex items-center gap-2 mt-4">

--- a/packages/ui/checkbox/Checkbox.tsx
+++ b/packages/ui/checkbox/Checkbox.tsx
@@ -4,6 +4,9 @@ export interface CheckboxProps {
   set?: (value: boolean) => void
 }
 
+/**
+ * @deprecated
+ */
 export function Checkbox({
   set,
   className = '',

--- a/packages/ui/chip/Chip.tsx
+++ b/packages/ui/chip/Chip.tsx
@@ -42,6 +42,9 @@ export interface ChipProps {
   id?: string
 }
 
+/**
+ * @deprecated
+ */
 export const Chip: FC<ChipProps> = ({
   label,
   color = 'default',

--- a/packages/ui/combobox/Combobox.tsx
+++ b/packages/ui/combobox/Combobox.tsx
@@ -38,6 +38,9 @@ const ComboboxRoot: FC<ComboboxProps> = ({ className, value, onChange, disabled,
   )
 }
 
+/**
+ * @deprecated
+ */
 export const Combobox: FunctionComponent<ComboboxProps> & {
   Input: FC<ComboboxInputProps>
   Label: FC<ComboboxLabelProps>

--- a/packages/ui/container/Container.tsx
+++ b/packages/ui/container/Container.tsx
@@ -30,6 +30,9 @@ interface Props {
 type ContainerProps<C extends React.ElementType> = PolymorphicComponentPropsWithRef<C, Props>
 type ContainerComponent = <C extends React.ElementType = 'div'>(props: ContainerProps<C>) => React.ReactElement | null
 
+/**
+ * @deprecated
+ */
 export const Container: ContainerComponent = forwardRef(
   <Tag extends React.ElementType = 'div'>(
     { as, children, maxWidth = '2xl', className = '', id, ...rest }: ContainerProps<Tag>,

--- a/packages/ui/copy/Copy.tsx
+++ b/packages/ui/copy/Copy.tsx
@@ -10,6 +10,9 @@ export interface CopyHelperProps {
   hideIcon?: boolean
 }
 
+/**
+ * @deprecated
+ */
 export const CopyHelper: FC<CopyHelperProps> = ({ className, toCopy, hideIcon = false, children }) => {
   const [isCopied, setCopied] = useCopyClipboard()
 

--- a/packages/ui/currency/index.ts
+++ b/packages/ui/currency/index.ts
@@ -10,6 +10,9 @@ type Currency = {
   IconList: FC<IconListProps>
 }
 
+/**
+ * @deprecated
+ */
 export const Currency: Currency = {
   List,
   Icon,

--- a/packages/ui/date/TimeAgo.tsx
+++ b/packages/ui/date/TimeAgo.tsx
@@ -2,6 +2,9 @@ import { useInterval } from '@sushiswap/hooks'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import React, { FC, useState } from 'react'
 
+/**
+ * @deprecated
+ */
 export const TimeAgo: FC<{ date: Date }> = ({ date }) => {
   const [distance, setDistance] = useState<string>(formatDistanceToNow(date, { addSuffix: true, includeSeconds: true }))
 

--- a/packages/ui/dialog/Dialog.tsx
+++ b/packages/ui/dialog/Dialog.tsx
@@ -75,6 +75,9 @@ const DialogRoot: FC<DialogRootProps> = ({ open, onClose, children, afterLeave, 
   )
 }
 
+/**
+ * @deprecated
+ */
 export const Dialog: FunctionComponent<DialogRootProps> & {
   Description: FunctionComponent<DialogDescriptionProps>
   Header: FunctionComponent<DialogHeaderProps>

--- a/packages/ui/dots/Dots.tsx
+++ b/packages/ui/dots/Dots.tsx
@@ -7,6 +7,9 @@ interface DotsProps {
   className?: string
 }
 
+/**
+ * @deprecated
+ */
 export const Dots: FC<DotsProps> = ({ children = <span />, className }) => {
   return (
     <span

--- a/packages/ui/drawer/Drawer.tsx
+++ b/packages/ui/drawer/Drawer.tsx
@@ -31,6 +31,9 @@ interface ProviderProps {
   children: (({ open, setOpen }: { open: boolean; setOpen(open: boolean): void }) => ReactNode) | ReactNode
 }
 
+/**
+ * @deprecated
+ */
 export const DrawerRoot: FC<ProviderProps> = ({ children }) => {
   const ref = useRef<HTMLDivElement>(null)
   const [open, setOpen] = useState(false)

--- a/packages/ui/dropzone/Dropzone.tsx
+++ b/packages/ui/dropzone/Dropzone.tsx
@@ -8,6 +8,9 @@ interface Dropzone extends DropzoneProps {
   label?: string
 }
 
+/**
+ * @deprecated
+ */
 export const Dropzone: FC<Dropzone> = ({ label = 'Select a CSV file to upload', onDrop, ...rest }) => {
   return (
     <ReactDropzone onDrop={onDrop} {...rest}>

--- a/packages/ui/form/Form.tsx
+++ b/packages/ui/form/Form.tsx
@@ -31,6 +31,9 @@ const FormRoot: FormRootComponent = ({ header, children, as, ...rest }) => {
   )
 }
 
+/**
+ * @deprecated
+ */
 export const Form: typeof FormRoot & {
   Buttons: typeof FormButtons
   Control: typeof FormControl

--- a/packages/ui/future/components/skeleton/Box.tsx
+++ b/packages/ui/future/components/skeleton/Box.tsx
@@ -2,5 +2,13 @@ import classNames from 'classnames'
 import { FC, HTMLProps } from 'react'
 
 export const Box: FC<HTMLProps<HTMLDivElement>> = (props) => {
-  return <div {...props} className={classNames(props.className, 'rounded-lg overflow-hidden shimmer')} />
+  return (
+    <div
+      {...props}
+      className={classNames(
+        props.className,
+        'rounded-lg overflow-hidden animate-pulse bg-black/[0.10] dark:bg-white/[0.10]'
+      )}
+    />
+  )
 }

--- a/packages/ui/future/components/skeleton/Circle.tsx
+++ b/packages/ui/future/components/skeleton/Circle.tsx
@@ -16,7 +16,10 @@ export const Circle: FC<CircleProps> = (props) => {
         width: props.radius,
         height: props.radius,
       }}
-      className={classNames(props.className, 'rounded-full overflow-hidden shimmer')}
+      className={classNames(
+        props.className,
+        'rounded-full overflow-hidden animate-pulse bg-black/[0.10] dark:bg-white/[0.10]'
+      )}
     />
   )
 }

--- a/packages/ui/future/components/skeleton/Skeleton.css
+++ b/packages/ui/future/components/skeleton/Skeleton.css
@@ -1,3 +1,0 @@
-.shimmer {
-  @apply animate-skeleton bg-gradient-to-r from-gray-50 via-gray-200 to-gray-50 dark:from-slate-800 dark:via-slate-700 dark:to-slate-800 bg-[length:400%_100%]
-}

--- a/packages/ui/future/components/skeleton/Text.tsx
+++ b/packages/ui/future/components/skeleton/Text.tsx
@@ -22,7 +22,7 @@ export interface TextProps extends Omit<HTMLProps<HTMLDivElement>, 'size'> {
 const STYLES = {
   'text-xs': 'h-[18px]',
   'text-sm': 'h-5',
-  'text-base': 'h-[22px]',
+  'text-base': 'h-[24px]',
   'text-lg': 'h-[28px]',
   'text-xl': 'h-[28px]',
   'text-2xl': 'h-[44px]',
@@ -60,7 +60,12 @@ const ALIGN = {
 export const Text: FC<TextProps> = ({ align = 'left', className, fontSize = 'text-base', ...props }) => {
   return (
     <div {...props} className={classNames(ALIGN[align], STYLES[fontSize], PADDING[fontSize], 'flex w-full')}>
-      <div className={classNames(className, 'flex w-full h-full rounded-md overflow-hidden shimmer')} />
+      <div
+        className={classNames(
+          className,
+          'flex w-full h-full rounded-md overflow-hidden animate-pulse bg-black/[0.10] dark:bg-white/[0.10]'
+        )}
+      />
     </div>
   )
 }

--- a/packages/ui/iconbutton/IconButton.tsx
+++ b/packages/ui/iconbutton/IconButton.tsx
@@ -13,6 +13,9 @@ export type IconButtonComponent = <C extends React.ElementType = 'button'>(
   props: IconButtonProps<C>
 ) => React.ReactElement | null
 
+/**
+ * @deprecated
+ */
 export const IconButton: IconButtonComponent = React.forwardRef(
   <Tag extends React.ElementType = 'button'>(
     { as, children, className, description, ...rest }: IconButtonProps<Tag>,

--- a/packages/ui/index.css
+++ b/packages/ui/index.css
@@ -9,9 +9,7 @@
 @import './variables.css';
 @import './tooltip/Tooltip.css';
 @import './input/Input.css';
-@import './skeleton/Skeleton.css';
 @import './input/DatePicker.css';
-@import "./future/components/skeleton/Skeleton.css";
 @import "./future/components/networkselector/styles.css";
 
 *,

--- a/packages/ui/input/index.ts
+++ b/packages/ui/input/index.ts
@@ -45,6 +45,9 @@ export const DEFAULT_INPUT_CLASSNAME = classNames(
   DEFAULT_INPUT_PADDING
 )
 
+/**
+ * @deprecated
+ */
 export const Input = {
   Address,
   DatetimeLocal,

--- a/packages/ui/link/index.ts
+++ b/packages/ui/link/index.ts
@@ -8,4 +8,7 @@ export type LinkProps = {
   Internal: FC<InternalLinkProps>
 }
 
+/**
+ * @deprecated
+ */
 export const Link: LinkProps = { External, Internal }

--- a/packages/ui/loader/Loader.tsx
+++ b/packages/ui/loader/Loader.tsx
@@ -3,8 +3,7 @@ import { FC } from 'react'
 import { LoaderProps } from './types'
 
 /**
- * Takes in custom size and stroke for circle color, default to primary color as fill,
- * need ...rest for layered styles on top
+ * @deprecated
  */
 export const Loader: FC<LoaderProps> = ({ size = 16 }) => {
   return (

--- a/packages/ui/loader/LogoLoader.tsx
+++ b/packages/ui/loader/LogoLoader.tsx
@@ -3,6 +3,9 @@ import React, { FC } from 'react'
 import { SushiIcon } from '../icons'
 import { LoaderProps } from './types'
 
+/**
+ * @deprecated
+ */
 export const LogoLoader: FC<LoaderProps> = (props) => {
   return <SushiIcon className="animate-heartbeat" {...props} />
 }

--- a/packages/ui/loader/LogoOverlay.tsx
+++ b/packages/ui/loader/LogoOverlay.tsx
@@ -3,6 +3,9 @@ import React, { FC, Fragment } from 'react'
 
 import { LogoLoader } from './LogoLoader'
 
+/**
+ * @deprecated
+ */
 export const LoadingOverlay: FC<{ show?: boolean }> = ({ show }) => {
   return (
     <Transition

--- a/packages/ui/menu/Menu.tsx
+++ b/packages/ui/menu/Menu.tsx
@@ -44,6 +44,9 @@ const MenuRoot: FC<MenuProps> = ({ className, button, appearOnMount = false, chi
   )
 }
 
+/**
+ * @deprecated
+ */
 export const Menu: FunctionComponent<MenuProps> & {
   Item: FC<MenuItem>
   Items: FC<MenuItems>

--- a/packages/ui/network/index.ts
+++ b/packages/ui/network/index.ts
@@ -8,6 +8,9 @@ type Network = {
   SelectorMenu: FC<SelectorMenuProps>
 }
 
+/**
+ * @deprecated
+ */
 export const Network: Network = {
   Selector,
   SelectorMenu,

--- a/packages/ui/overlay/index.ts
+++ b/packages/ui/overlay/index.ts
@@ -2,4 +2,7 @@ import { Actions } from './Actions'
 import { Content } from './Content'
 import { Header } from './Header'
 
+/**
+ * @deprecated
+ */
 export const Overlay = { Content, Header, Actions }

--- a/packages/ui/progressbar/ProgressBar.tsx
+++ b/packages/ui/progressbar/ProgressBar.tsx
@@ -17,6 +17,9 @@ interface ProgressBarProps {
   showLabel?: boolean
 }
 
+/**
+ * @deprecated
+ */
 export const ProgressBar: FC<ProgressBarProps> = ({ progress, color, showLabel = true, className }) => {
   let fromColor
   let toColor

--- a/packages/ui/select/Select.tsx
+++ b/packages/ui/select/Select.tsx
@@ -51,6 +51,9 @@ const SelectRoot: FC<SelectProps> = ({
   )
 }
 
+/**
+ * @deprecated
+ */
 export const Select: FC<SelectProps> & {
   Button: FC<SelectButtonProps>
   Label: FC<SelectLabelProps>

--- a/packages/ui/skeleton/Skeleton.css
+++ b/packages/ui/skeleton/Skeleton.css
@@ -1,7 +1,0 @@
-.shimmer {
-  @apply relative after:absolute after:inset-0 after:translate-x-[-100%] after:animate-wave after:content-[''] after:bg-shimmer-gradient;
-}
-
-.shimmer-dark {
-  @apply relative after:absolute after:inset-0 after:translate-x-[-100%] after:animate-wave after:content-[''] after:bg-shimmer-gradient-dark;
-}

--- a/packages/ui/skeleton/index.ts
+++ b/packages/ui/skeleton/index.ts
@@ -3,6 +3,9 @@ import { FC, HTMLProps } from 'react'
 import { Box } from './Box'
 import { Circle, CircleProps } from './Circle'
 
+/**
+ * @deprecated
+ */
 export const Skeleton: {
   Box: FC<HTMLProps<HTMLDivElement>>
   Circle: FC<CircleProps>

--- a/packages/ui/stepper/index.ts
+++ b/packages/ui/stepper/index.ts
@@ -4,4 +4,7 @@ export type Stepper = {
   Vertical: typeof VerticalStepper
 }
 
+/**
+ * @deprecated
+ */
 export const Stepper: Stepper = { Vertical: VerticalStepper }

--- a/packages/ui/switch/Switch.tsx
+++ b/packages/ui/switch/Switch.tsx
@@ -31,6 +31,9 @@ const WIDTH = {
   md: 65,
 }
 
+/**
+ * @deprecated
+ */
 export const Switch: FC<SwitchProps> = ({
   size = 'md',
   checked,

--- a/packages/ui/table/GenericTable.tsx
+++ b/packages/ui/table/GenericTable.tsx
@@ -23,6 +23,9 @@ declare module '@tanstack/react-table' {
   }
 }
 
+/**
+ * @deprecated
+ */
 export const GenericTable = <T extends { id: string }>({
   table,
   HoverElement,

--- a/packages/ui/tailwind.js
+++ b/packages/ui/tailwind.js
@@ -45,16 +45,10 @@ module.exports = {
         'spin-slow': 'spin 2s linear infinite',
         heartbeat: 'heartbeat 1s ease 0.2s infinite normal forwards',
         rotate: 'rotate360 1s cubic-bezier(0.83, 0, 0.17, 1) infinite',
-        wave: 'shimmer 1.25s cubic-bezier(0.4, 0, 0.6, 1) infinite',
-        'wave-fast': 'shimmer 1s cubic-bezier(0.4, 0, 0.6, 1) infinite',
         dash: 'dash 1.5s 2s ease-out infinite',
         'dash-check': 'dash-check 1.5s 2s ease-out infinite',
-        skeleton: 'skeleton 8s ease-in-out infinite',
       },
       keyframes: {
-        shimmer: {
-          '100%': { transform: 'translateX(100%)' },
-        },
         ellipsis: {
           '0%': { content: '"."' },
           '33%': { content: '".."' },
@@ -102,14 +96,6 @@ module.exports = {
           },
           '100%': {
             strokeDashoffset: 900,
-          },
-        },
-        skeleton: {
-          '0%': {
-            backgroundPosition: '200% 0',
-          },
-          '100%': {
-            backgroundPosition: '-200% 0',
           },
         },
       },

--- a/packages/ui/tooltip/Tooltip.tsx
+++ b/packages/ui/tooltip/Tooltip.tsx
@@ -8,6 +8,9 @@ interface ExtendTooltipProps extends Omit<TooltipProps, 'overlay' | 'arrowConten
   naked?: boolean
 }
 
+/**
+ * @deprecated
+ */
 export const Tooltip: FC<ExtendTooltipProps> = ({
   button,
   panel,


### PR DESCRIPTION
fix(packages/ui): optimize skeleton loader performance

<!-- start pr-codex -->

---

## PR-Codex overview
This PR deprecates various UI components and removes their associated CSS files. It also adds a new `animate-pulse` animation class and updates the `tailwind.js` file. 

### Detailed summary
- Deprecates UI components: `App`, `Input`, `Currency`, `Link`, `Checkbox`, `Network`, `Chip`, `Stepper`, `Switch`, `Tooltip`, `Overlay`, `GenericTable`, `Backdrop`, `Dots`, `Menu`, `Form`, `Select`, `SlideIn`, `Badge`, `Combobox`, `Breadcrumb`, `Skeleton`, `Loader`, `IconButton`, `TimeAgo`, `Box`, `Text`
- Removes associated CSS files: `Skeleton.css`, `Skeleton.css`
- Adds new `animate-pulse` animation class
- Updates `tailwind.js` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->