### PR TITLE
fix(packages/wagmi): sort tokens with balances but no prices

### DIFF
--- a/packages/wagmi/hooks/useSortedTokensByQuery.ts
+++ b/packages/wagmi/hooks/useSortedTokensByQuery.ts
@@ -56,14 +56,19 @@ export const tokenComparator = (
   pricesMap: Record<string, Fraction> | undefined
 ) => {
   return (tokenA: Token, tokenB: Token): number => {
-    const balanceA = pricesMap?.[tokenA.address]
+    const priceA = pricesMap?.[tokenA.address]
       ? balancesMap?.[tokenA.address]?.multiply(pricesMap[tokenA.address])
       : undefined
-    const balanceB = pricesMap?.[tokenB.address]
+    const priceB = pricesMap?.[tokenB.address]
       ? balancesMap?.[tokenB.address]?.multiply(pricesMap[tokenB.address])
       : undefined
 
-    const balanceComp = balanceComparator(balanceA, balanceB)
+    const priceComp = balanceComparator(priceA, priceB)
+    if (priceComp !== 0) {
+      return priceComp
+    }
+
+    const balanceComp = balanceComparator(balancesMap?.[tokenA.address], balancesMap?.[tokenB.address])
     if (balanceComp !== 0) {
       return balanceComp
     }


### PR DESCRIPTION
Handles tokens with user balances, but without prices when sorting in useSortedTokensByQuery.

Before:
<img width="460" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/12a7dcdc-f8e9-4bee-9e32-0c062ab830d2">

After:
<img width="459" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/d744d46a-3d89-4766-a491-94a887e68f23">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the sorting of tokens by adding a new sorting parameter based on token prices. 

### Detailed summary
- Adds a new sorting parameter based on token prices.
- Replaces the old parameter based on token balances with the new one.
- Renames variables to reflect the new sorting parameter.
- Includes a conditional statement to prioritize sorting by token prices over balances.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->