### PR TITLE
feat(pkgs/graph-client): add v3 to daysnapshots

### DIFF
--- a/packages/graph-client/queries/sushiswap-v3.graphql
+++ b/packages/graph-client/queries/sushiswap-v3.graphql
@@ -126,3 +126,16 @@ query SushiSwapV3Pool(
     }
   }
 }
+
+query SushiSwapV3DayDatas($first: Int = 1000, $skip: Int, $orderBy: UniswapDayData_orderBy, $orderDirection: OrderDirection, $where: UniswapDayData_filter) {
+  uniswapDayDatas(first: $first, skip: $skip, orderBy: $orderBy, orderDirection: $orderDirection, where: $where) {
+    id
+    date
+    volumeETH
+    volumeUSD
+    volumeUSDUntracked
+    feesUSD
+    txCount
+    tvlUSD
+  }
+}

--- a/packages/graph-client/resolvers/factories/factoryDaySnapshotsByChainIds.ts
+++ b/packages/graph-client/resolvers/factories/factoryDaySnapshotsByChainIds.ts
@@ -1,72 +1,125 @@
-// @ts-nocheck
-
-import { chainName, chainShortName } from '@sushiswap/chain'
+import { ChainId, chainName, chainShortName } from '@sushiswap/chain'
 import {
   SUBGRAPH_HOST,
-  SUSHISWAP_ENABLED_NETWORKS,
   SUSHISWAP_SUBGRAPH_NAME,
-  TRIDENT_ENABLED_NETWORKS,
+  SUSHISWAP_V3_SUBGRAPH_NAME,
+  SushiSwapV3ChainId,
   TRIDENT_SUBGRAPH_NAME,
 } from '@sushiswap/graph-config'
+import { isSushiSwapChain, isSushiSwapV3Chain, isTridentChain } from '@sushiswap/validate'
 
-import { FactoryDaySnapshot, Query, QueryResolvers } from '../../.graphclient/index.js'
+import {
+  FactoryDaySnapshot,
+  getBuiltGraphSDK,
+  Query,
+  QueryResolvers,
+  SushiSwapV3DayDatasQuery,
+} from '../../.graphclient/index.js'
+
+const transformV3DayToSnapshot = (
+  days: SushiSwapV3DayDatasQuery['uniswapDayDatas'],
+  chainId: number
+): Query['factoryDaySnapshotsByChainIds'] =>
+  days.map((day) => ({
+    chainId: chainId,
+    id: day.id,
+    date: day.date,
+    volumeNative: day.volumeETH,
+    volumeUSD: day.volumeUSD,
+    untrackedVolumeUSD: day.volumeUSDUntracked,
+    liquidityNative: 0,
+    liquidityUSD: day.tvlUSD,
+    feesNative: 0,
+    feesUSD: day.feesUSD,
+    transactionCount: day.txCount,
+    factory: null,
+  }))
 
 export const factoryDaySnapshotsByChainIds: QueryResolvers['factoryDaySnapshotsByChainIds'] = async (
   root,
   args,
   context,
   info
-): Promise<Query['factoryDaySnapshotsByChainIds']> =>
-  Promise.all<Query['factoryDaySnapshotsByChainIds'][]>([
-    ...args.chainIds
-      .filter((el): el is (typeof TRIDENT_ENABLED_NETWORKS)[number] => TRIDENT_ENABLED_NETWORKS.includes(el))
-      .map((chainId) =>
-        context.Trident.Query.factoryDaySnapshots({
-          root,
-          args,
-          context: {
-            ...context,
-            chainId,
-            chainName: chainName[chainId],
-            chainShortName: chainShortName[chainId],
-            subgraphName: TRIDENT_SUBGRAPH_NAME[chainId],
-            subgraphHost: SUBGRAPH_HOST[chainId],
-          },
-          info,
-        }).then((snapshots: FactoryDaySnapshot[]) => {
-          return snapshots.map((snapshot) => ({
-            ...snapshot,
-            chainId,
-            chainName: chainName[chainId],
-            chainShortName: chainShortName[chainId],
-          }))
-        })
-      ),
-    ...args.chainIds
-      .filter((el): el is (typeof SUSHISWAP_ENABLED_NETWORKS)[number] => SUSHISWAP_ENABLED_NETWORKS.includes(el))
-      .map((chainId) =>
-        context.SushiSwap.Query.factoryDaySnapshots({
-          root,
-          args,
-          context: {
-            ...context,
-            chainId,
-            chainName: chainName[chainId],
-            chainShortName: chainShortName[chainId],
-            subgraphName: SUSHISWAP_SUBGRAPH_NAME[chainId],
-            subgraphHost: SUBGRAPH_HOST[chainId],
-          },
-          info,
-        }).then((snapshots: FactoryDaySnapshot[]) => {
-          if (!Array.isArray(snapshots)) {
-            // console.log({ snapshots })
-          }
-          return snapshots.map((snapshot) => ({
-            ...snapshot,
-            chainId,
-            chainName: chainName[chainId],
-            chainShortName: chainShortName[chainId],
-          }))
-        })
-      ),
-  ]).then((snapshots) => snapshots.flat())
+): Promise<Query['factoryDaySnapshotsByChainIds']> => {
+  const fetchTridentSnapshots = async (chainId: number) => {
+    const snapshots: FactoryDaySnapshot[] = await context.Trident.Query.factoryDaySnapshots({
+      root,
+      args,
+      context: {
+        ...context,
+        chainId,
+        chainName: chainName[chainId],
+        chainShortName: chainShortName[chainId],
+        subgraphName: TRIDENT_SUBGRAPH_NAME[chainId],
+        subgraphHost: SUBGRAPH_HOST[chainId],
+      },
+      info,
+    })
+
+    return snapshots.map((snapshot) => ({
+      ...snapshot,
+      chainId,
+      chainName: chainName[chainId],
+      chainShortName: chainShortName[chainId],
+    }))
+  }
+
+  const fetchSushiSwapV2Snapshots = async (chainId: number) => {
+    const snapshots: FactoryDaySnapshot[] = await context.SushiSwap.Query.factoryDaySnapshots({
+      root,
+      args,
+      context: {
+        ...context,
+        chainId,
+        chainName: chainName[chainId],
+        chainShortName: chainShortName[chainId],
+        subgraphName: SUSHISWAP_SUBGRAPH_NAME[chainId],
+        subgraphHost: SUBGRAPH_HOST[chainId],
+      },
+      info,
+    })
+
+    return snapshots.map((snapshot) => ({
+      ...snapshot,
+      chainId,
+      chainName: chainName[chainId],
+      chainShortName: chainShortName[chainId],
+    }))
+  }
+
+  const fetchSushiSwapV3Snapshots = async (chainId: SushiSwapV3ChainId) => {
+    const sdk = getBuiltGraphSDK({
+      subgraphName: SUSHISWAP_V3_SUBGRAPH_NAME[chainId],
+      subgraphHost: SUBGRAPH_HOST[chainId],
+    })
+
+    const { uniswapDayDatas } = await sdk.SushiSwapV3DayDatas({
+      first: args.first,
+      skip: args.skip,
+      orderBy: args.orderBy === 'liquidityUSD' ? 'tvlUSD' : 'date',
+      orderDirection: args.orderDirection,
+    })
+
+    return transformV3DayToSnapshot(uniswapDayDatas, chainId)
+  }
+
+  const queries = args.chainIds.flatMap((chainId: ChainId) => {
+    const queries: Promise<Query['factoryDaySnapshotsByChainIds']>[] = []
+
+    if (isTridentChain(chainId)) {
+      queries.push(fetchTridentSnapshots(chainId))
+    }
+
+    if (isSushiSwapChain(chainId)) {
+      queries.push(fetchSushiSwapV2Snapshots(chainId))
+    }
+
+    if (isSushiSwapV3Chain(chainId)) {
+      queries.push(fetchSushiSwapV3Snapshots(chainId))
+    }
+
+    return queries
+  })
+
+  return Promise.all(queries).then((snapshots) => snapshots.flat())
+}

--- a/packages/validate/src/isTridentChain.ts
+++ b/packages/validate/src/isTridentChain.ts
@@ -1,4 +1,5 @@
-import { SushiSwapChainId, TRIDENT_SUBGRAPH_NAME, TridentChainId } from '@sushiswap/graph-config'
+import { ChainId } from '@sushiswap/chain'
+import { TRIDENT_SUBGRAPH_NAME, TridentChainId } from '@sushiswap/graph-config'
 
-export const isTridentChain = (chainId: SushiSwapChainId | TridentChainId): chainId is TridentChainId =>
+export const isTridentChain = (chainId: ChainId): chainId is TridentChainId =>
   Object.keys(TRIDENT_SUBGRAPH_NAME).map(Number).includes(chainId)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for SushiSwap V3 to the `factoryDaySnapshotsByChainIds` resolver and refactors related code. 

### Detailed summary
- Adds `SushiSwapV3DayDatas` query to `sushiswap-v3.graphql`
- Adds `isTridentChain`, `isSushiSwapChain` and `isSushiSwapV3Chain` functions to `validate` package
- Refactors `factoryDaySnapshotsByChainIds` resolver in `graph-client` package to fetch snapshots from SushiSwap V3 subgraph and filter by chain type using the new validation functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->