### PR TITLE
fix(package/router): handle v3 pools with tick = 0

### DIFF
--- a/packages/router/src/liquidity-providers/UniswapV3Base.ts
+++ b/packages/router/src/liquidity-providers/UniswapV3Base.ts
@@ -31,7 +31,9 @@ interface V3Pool {
 export const NUMBER_OF_SURROUNDING_TICKS = 1000 // 10% price impact
 
 const getActiveTick = (tickCurrent: number, feeAmount: FeeAmount) =>
-  tickCurrent && feeAmount ? Math.floor(tickCurrent / TICK_SPACINGS[feeAmount]) * TICK_SPACINGS[feeAmount] : undefined
+  typeof tickCurrent === 'number' && feeAmount
+    ? Math.floor(tickCurrent / TICK_SPACINGS[feeAmount]) * TICK_SPACINGS[feeAmount]
+    : undefined
 
 const bitmapIndex = (tick: number, tickSpacing: number) => {
   return Math.floor(tick / tickSpacing / 256)
@@ -112,9 +114,9 @@ export abstract class UniswapV3BaseProvider extends LiquidityProvider {
       if (slot0 === undefined || !slot0[i]) return
       const sqrtPriceX96 = slot0[i].result?.[0]
       const tick = slot0[i].result?.[1]
-      if (!sqrtPriceX96 || sqrtPriceX96 === 0n || !tick) return
+      if (!sqrtPriceX96 || sqrtPriceX96 === 0n || typeof tick !== 'number') return
       const activeTick = getActiveTick(tick, pool.fee)
-      if (!activeTick) return
+      if (typeof activeTick !== 'number') return
       existingPools.push({
         ...pool,
         sqrtPriceX96,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR refactors the `getActiveTick` function and adds type checks to ensure that the `tick` variable is a number. 

### Detailed summary
- Refactors `getActiveTick` function to use a ternary operator 
- Adds type check to ensure `tickCurrent` is a number 
- Adds type check to ensure `tick` in `existingPools` is a number

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->