### PR TITLE
fix(apps/pools): rewards icon

### DIFF
--- a/apps/earn/components/PoolsSection/Tables/SharedCells/PoolNameCell.tsx
+++ b/apps/earn/components/PoolsSection/Tables/SharedCells/PoolNameCell.tsx
@@ -56,6 +56,13 @@ export const PoolNameCell: FC<Row<Pool>> = ({ row }) => {
           <div className="bg-gray-200 text-gray-700 dark:bg-slate-800 dark:text-slate-300 text-[10px] px-2 rounded-full">
             {formatNumber(row.swapFee * 100)}%
           </div>
+          {row.incentives && row.incentives.length > 0 && (
+            <Tooltip description="Farm rewards available">
+              <div className="bg-green/20 text-green text-[10px] px-2 rounded-full">
+                🧑‍🌾 {row.incentives.length > 1 ? `x ${row.incentives.length}` : ''}{' '}
+              </div>
+            </Tooltip>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a tooltip to display farm rewards available in the `PoolNameCell` component of the `PoolsSection` table.

### Detailed summary
- Added a tooltip to show farm rewards available
- Tooltip is displayed when `row.incentives` is not null and has a length greater than 0
- Tooltip displays a green badge with a farmer emoji and the number of rewards available (if greater than 1)

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->