### PR TITLE
fix(config/graph): boba block timer

### DIFF
--- a/config/graph/src/index.ts
+++ b/config/graph/src/index.ts
@@ -201,7 +201,7 @@ export const SECONDS_BETWEEN_BLOCKS: Record<number, number> = {
   [ChainId.KAVA]: 6.3,
   [ChainId.METIS]: 4.5,
   [ChainId.ARBITRUM_NOVA]: 1,
-  [ChainId.BOBA]: 1,
+  [ChainId.BOBA]: 250,
   [ChainId.BOBA_AVAX]: 612,
   [ChainId.BOBA_BNB]: 0.5,
   [ChainId.BTTC]: 2,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adjusts the values of different chain IDs. 

### Detailed summary:
- `ChainId.BOBA` SECONDS_BETWEEN_BLOCK is changed from `1` to `250`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->