### PR TITLE
fix(apps/earn): also show rewards for active distros

### DIFF
--- a/apps/earn/components/RewardsSection/RewardsSection.tsx
+++ b/apps/earn/components/RewardsSection/RewardsSection.tsx
@@ -45,7 +45,12 @@ export const RewardsSection: FC = () => {
       .filter((el) => chainIds.includes(el.chainId))
       .map((el) => {
         return Object.values(el.pools ?? {})
-          .filter((el) => Object.keys(el.rewardsPerToken).length + Object.keys(el.distributionData).length > 0)
+          .filter(
+            (el) =>
+              Object.keys(el.rewardsPerToken).length +
+                Object.keys(el.distributionData.filter((el) => el.end * 1000 >= Date.now())).length >
+              0
+          )
           .filter((el) =>
             _tokenSymbols.length > 0
               ? _tokenSymbols.some((symbol) => {

--- a/apps/earn/components/RewardsSection/RewardsSection.tsx
+++ b/apps/earn/components/RewardsSection/RewardsSection.tsx
@@ -45,7 +45,7 @@ export const RewardsSection: FC = () => {
       .filter((el) => chainIds.includes(el.chainId))
       .map((el) => {
         return Object.values(el.pools ?? {})
-          .filter((el) => +(el.userTVL ?? 0) > 0)
+          .filter((el) => el.userTotalBalance0 + el.userTotalBalance1 > 0)
           .filter((el) =>
             _tokenSymbols.length > 0
               ? _tokenSymbols.some((symbol) => {

--- a/apps/earn/components/RewardsSection/RewardsSection.tsx
+++ b/apps/earn/components/RewardsSection/RewardsSection.tsx
@@ -45,12 +45,7 @@ export const RewardsSection: FC = () => {
       .filter((el) => chainIds.includes(el.chainId))
       .map((el) => {
         return Object.values(el.pools ?? {})
-          .filter(
-            (el) =>
-              Object.keys(el.rewardsPerToken).length +
-                Object.keys(el.distributionData.filter((el) => el.end * 1000 >= Date.now())).length >
-              0
-          )
+          .filter((el) => +(el.userTVL ?? 0) > 0)
           .filter((el) =>
             _tokenSymbols.length > 0
               ? _tokenSymbols.some((symbol) => {

--- a/apps/earn/components/RewardsSection/RewardsSection.tsx
+++ b/apps/earn/components/RewardsSection/RewardsSection.tsx
@@ -108,6 +108,7 @@ export const RewardsSection: FC = () => {
           placeholder="No positions found"
           pageSize={positions?.length ? positions.length : 1}
           HoverElement={isMd ? RewardsTableV3RowPopover : undefined}
+          HoverElementWidth={420}
           onClick={!isMd ? setClickedRow : undefined}
           linkFormatter={rowLink}
         />

--- a/apps/earn/components/RewardsSection/RewardsSection.tsx
+++ b/apps/earn/components/RewardsSection/RewardsSection.tsx
@@ -45,7 +45,7 @@ export const RewardsSection: FC = () => {
       .filter((el) => chainIds.includes(el.chainId))
       .map((el) => {
         return Object.values(el.pools ?? {})
-          .filter((el) => Object.keys(el.rewardsPerToken).length > 0)
+          .filter((el) => Object.keys(el.rewardsPerToken).length + Object.keys(el.distributionData).length > 0)
           .filter((el) =>
             _tokenSymbols.length > 0
               ? _tokenSymbols.some((symbol) => {

--- a/apps/earn/components/RewardsSection/RewardsSection.tsx
+++ b/apps/earn/components/RewardsSection/RewardsSection.tsx
@@ -45,7 +45,7 @@ export const RewardsSection: FC = () => {
       .filter((el) => chainIds.includes(el.chainId))
       .map((el) => {
         return Object.values(el.pools ?? {})
-          .filter((el) => el.userTotalBalance0 + el.userTotalBalance1 > 0)
+          .filter((el) => el.userTotalBalance0 + el.userTotalBalance1 > 0 || Object.keys(el.rewardsPerToken).length > 0)
           .filter((el) =>
             _tokenSymbols.length > 0
               ? _tokenSymbols.some((symbol) => {

--- a/apps/earn/components/RewardsSection/Tables/RewardsTableV3/RewardsTableV3RowPopover.tsx
+++ b/apps/earn/components/RewardsSection/Tables/RewardsTableV3/RewardsTableV3RowPopover.tsx
@@ -46,6 +46,7 @@ export const RewardsTableV3RowPopover: FC<RewardTableV3CellProps> = ({ row }) =>
               </List.Label>
               <List.KeyValue
                 flex
+                className="!items-start"
                 title={
                   <div className="flex gap-1 items-center">
                     Reward
@@ -70,7 +71,7 @@ export const RewardsTableV3RowPopover: FC<RewardTableV3CellProps> = ({ row }) =>
                   {unwrapToken(token).symbol}
                 </div>
               </List.KeyValue>
-              <List.KeyValue flex title="Duration">
+              <List.KeyValue className="!items-start" flex title="Duration">
                 <div className="flex flex-col">
                   <span className="font-mediumt">{Math.floor((end - Date.now() / 1000) / 3600 / 24)} days left</span>
                   <span className="text-xs text-gray-500 dark:text-slate-500">
@@ -80,6 +81,7 @@ export const RewardsTableV3RowPopover: FC<RewardTableV3CellProps> = ({ row }) =>
               </List.KeyValue>
               <List.KeyValue
                 flex
+                className="!items-start"
                 title={
                   <div className="flex gap-1 items-center">
                     Details

--- a/apps/earn/components/RewardsSection/Tables/RewardsTableV3/RewardsTableV3RowPopover.tsx
+++ b/apps/earn/components/RewardsSection/Tables/RewardsTableV3/RewardsTableV3RowPopover.tsx
@@ -10,7 +10,7 @@ import { Explainer } from '@sushiswap/ui/future/components/Explainer'
 import { rewardPerDay } from './utils'
 
 export const RewardsTableV3RowPopover: FC<RewardTableV3CellProps> = ({ row }) => {
-  const ongoingFarms = row.distributionData.filter((el) => el.end * 1000 >= Date.now())
+  const ongoingFarms = row.distributionData.filter((el) => el.isLive)
   return (
     <div className="p-2">
       <div className="flex items-center gap-4">

--- a/packages/react-query/src/hooks/rewards/validator.ts
+++ b/packages/react-query/src/hooks/rewards/validator.ts
@@ -11,6 +11,7 @@ export const angleRewardsPoolsValidator = z.object({
             breakdown: z.record(z.string(), z.number()),
             end: z.number(),
             isOutOfRangeIncentivized: z.boolean(),
+            isLive: z.boolean(),
             propFees: z.number(),
             propToken0: z.number(),
             propToken1: z.number(),

--- a/packages/ui/future/components/table/GenericTable.tsx
+++ b/packages/ui/future/components/table/GenericTable.tsx
@@ -12,6 +12,7 @@ import { useIsMounted } from '@sushiswap/hooks'
 interface GenericTableProps<C> {
   table: ReactTableType<C>
   HoverElement?: React.FunctionComponent<{ row: C }>
+  HoverElementWidth?: number
   loading?: boolean
   placeholder: ReactNode
   pageSize: number
@@ -33,6 +34,7 @@ declare module '@tanstack/react-table' {
 export const GenericTable = <T extends { id: string }>({
   table,
   HoverElement,
+  HoverElementWidth,
   loading,
   placeholder,
   pageSize,
@@ -117,7 +119,7 @@ export const GenericTable = <T extends { id: string }>({
                             name: 'sameWidth',
                             enabled: true,
                             fn: ({ state }) => {
-                              state.styles.popper.width = '320px'
+                              state.styles.popper.width = HoverElementWidth ? `${HoverElementWidth}px` : '320px'
                             },
                             phase: 'beforeWrite',
                             requires: ['computeStyles'],


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new `isLive` property to the `validator` object, updates the `RewardsSection` and `RewardsTableV3RowPopover` components to use it, and adds a new `HoverElementWidth` prop to `GenericTable`.

### Detailed summary
- Added `isLive` property to `validator` object
- Updated `RewardsSection` and `RewardsTableV3RowPopover` to use `isLive` property
- Added `HoverElementWidth` prop to `GenericTable`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->