### PR TITLE
DES-81 - Make no results found in token search more explicit

### DIFF
--- a/packages/wagmi/future/components/TokenSelector/TokenSelector.tsx
+++ b/packages/wagmi/future/components/TokenSelector/TokenSelector.tsx
@@ -150,7 +150,10 @@ export const TokenSelector: FC<TokenSelectorProps> = ({ id, selected, onSelect, 
                       <div className="flex flex-col items-center justify-center gap-1">
                         <span className="flex items-center text-xs text-gray-500 dark:text-slate-500">
                           No tokens found on <NetworkIcon type="naked" width={20} height={20} chainId={chainId} />{' '}
-                          <span className="font-medium">{chainName[chainId]}</span>
+                          <span className="font-medium">{chainName[chainId]}</span>.
+                        </span>
+                        <span className="text-xs text-gray-500 dark:text-slate-500">
+                          Did you try searching with the token address?
                         </span>
                       </div>
                     </div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new message to the TokenSelector component when no tokens are found on a particular network.

### Detailed summary
- Adds a new message to the TokenSelector component when no tokens are found on a particular network.
- The message suggests trying to search with the token address.
- Changes the formatting of a text element to match the new message.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->