### PR TITLE
fix: slippage handling

### DIFF
--- a/apps/earn/components/AddPage/AddSectionConfirmModalConcentrated.tsx
+++ b/apps/earn/components/AddPage/AddSectionConfirmModalConcentrated.tsx
@@ -61,7 +61,7 @@ export const AddSectionConfirmModalConcentrated: FC<AddSectionConfirmModalConcen
   const hasExistingPosition = !!existingPosition
 
   const slippagePercent = useMemo(() => {
-    return new Percent(Math.floor(+slippageTolerance * 100), 10_000)
+    return new Percent(Math.floor(+(slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance) * 100), 10_000)
   }, [slippageTolerance])
 
   const onSettled = useCallback(

--- a/apps/earn/components/AddPage/AddSectionReviewModalLegacy.tsx
+++ b/apps/earn/components/AddPage/AddSectionReviewModalLegacy.tsx
@@ -46,7 +46,7 @@ export const AddSectionReviewModalLegacy: FC<AddSectionReviewModalLegacyProps> =
   const contract = useSushiSwapRouterContract(chainId)
   const [slippageTolerance] = useSlippageTolerance('addLiquidity')
   const slippagePercent = useMemo(() => {
-    return new Percent(Math.floor(+slippageTolerance * 100), 10_000)
+    return new Percent(Math.floor(+(slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance) * 100), 10_000)
   }, [slippageTolerance])
 
   const onSettled = useCallback(

--- a/apps/earn/components/AddPage/AddSectionReviewModalTrident.tsx
+++ b/apps/earn/components/AddPage/AddSectionReviewModalTrident.tsx
@@ -73,7 +73,7 @@ export const AddSectionReviewModalTrident: FC<AddSectionReviewModalTridentProps>
   const contract = useTridentRouterContract(chainId)
   const [slippageTolerance] = useSlippageTolerance('addLiquidity')
   const slippagePercent = useMemo(() => {
-    return new Percent(Math.floor(+slippageTolerance * 100), 10_000)
+    return new Percent(Math.floor(+(slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance) * 100), 10_000)
   }, [slippageTolerance])
 
   const [minAmount0, minAmount1] = useMemo(() => {

--- a/apps/earn/components/AddSection/AddSectionReviewModalLegacy.tsx
+++ b/apps/earn/components/AddSection/AddSectionReviewModalLegacy.tsx
@@ -56,7 +56,7 @@ export const AddSectionReviewModalLegacy: FC<AddSectionReviewModalLegacyProps> =
   const { approved } = useApproved(APPROVE_TAG_ADD_LEGACY)
   const [slippageTolerance] = useSlippageTolerance('addLiquidity')
   const slippagePercent = useMemo(() => {
-    return new Percent(Math.floor(+slippageTolerance * 100), 10_000)
+    return new Percent(Math.floor(+(slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance) * 100), 10_000)
   }, [slippageTolerance])
 
   const onSettled = useCallback(

--- a/apps/earn/components/AddSection/AddSectionReviewModalTrident.tsx
+++ b/apps/earn/components/AddSection/AddSectionReviewModalTrident.tsx
@@ -79,7 +79,7 @@ export const AddSectionReviewModalTrident: FC<AddSectionReviewModalTridentProps>
   const contract = useTridentRouterContract(chainId)
   const [slippageTolerance] = useSlippageTolerance('addLiquidity')
   const slippagePercent = useMemo(() => {
-    return new Percent(Math.floor(+slippageTolerance * 100), 10_000)
+    return new Percent(Math.floor(+(slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance) * 100), 10_000)
   }, [slippageTolerance])
 
   const [minAmount0, minAmount1] = useMemo(() => {
@@ -258,7 +258,13 @@ export const AddSectionReviewModalTrident: FC<AddSectionReviewModalTridentProps>
 
   return (
     <AddSectionReviewModal chainId={chainId} input0={input0} input1={input1} open={open} close={close}>
-      <Button size="xl" disabled={isWritePending} fullWidth onClick={() => sendTransaction?.()} testdata-id="confirm-add-liquidity-button">
+      <Button
+        size="xl"
+        disabled={isWritePending}
+        fullWidth
+        onClick={() => sendTransaction?.()}
+        testdata-id="confirm-add-liquidity-button"
+      >
         {isWritePending ? <Dots>Confirm transaction</Dots> : 'Add'}
       </Button>
     </AddSectionReviewModal>

--- a/apps/earn/components/ConcentratedLiquidityRemoveWidget.tsx
+++ b/apps/earn/components/ConcentratedLiquidityRemoveWidget.tsx
@@ -41,7 +41,7 @@ export const ConcentratedLiquidityRemoveWidget: FC<ConcentratedLiquidityRemoveWi
   const { data: deadline } = useTransactionDeadline({ chainId })
 
   const slippagePercent = useMemo(() => {
-    return new Percent(Math.floor(+slippageTolerance * 100), 10_000)
+    return new Percent(Math.floor(+(slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance) * 100), 10_000)
   }, [slippageTolerance])
 
   const _onChange = useCallback(

--- a/apps/earn/components/PoolPage/MigrateTab.tsx
+++ b/apps/earn/components/PoolPage/MigrateTab.tsx
@@ -49,7 +49,7 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
   const [invertPrice, setInvertPrice] = useState(false)
   const [slippageTolerance] = useSlippageTolerance('addLiquidity')
   const slippagePercent = useMemo(() => {
-    return new Percent(Math.floor(+slippageTolerance * 100), 10_000)
+    return new Percent(Math.floor(+(slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance) * 100), 10_000)
   }, [slippageTolerance])
 
   const {

--- a/apps/earn/components/PoolsSection/Tables/SharedCells/PoolNameCellV3.tsx
+++ b/apps/earn/components/PoolsSection/Tables/SharedCells/PoolNameCellV3.tsx
@@ -12,6 +12,7 @@ import { ChainId } from '@sushiswap/chain'
 import { Type } from '@sushiswap/currency'
 
 export const PoolNameCellV3: FC<Row<ConcentratedLiquidityPositionWithV3Pool>> = ({ row }) => {
+  console.log({ row })
   const [_token0, _token1]: Type[] = useMemo(() => [unwrapToken(row.pool.token0), unwrapToken(row.pool.token1)], [row])
 
   return (

--- a/apps/earn/components/RemoveSection/RemoveSectionLegacy.tsx
+++ b/apps/earn/components/RemoveSection/RemoveSectionLegacy.tsx
@@ -45,7 +45,7 @@ export const RemoveSectionLegacy: FC<RemoveSectionLegacyProps> = withCheckerRoot
   const contract = useSushiSwapRouterContract(_pool.chainId as UniswapV2Router02ChainId)
   const [slippageTolerance] = useSlippageTolerance('removeLiquidity')
   const slippagePercent = useMemo(() => {
-    return new Percent(Math.floor(+slippageTolerance * 100), 10_000)
+    return new Percent(Math.floor(+(slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance) * 100), 10_000)
   }, [slippageTolerance])
 
   const [percentage, setPercentage] = useState<string>('')

--- a/apps/earn/components/RemoveSection/RemoveSectionTrident.tsx
+++ b/apps/earn/components/RemoveSection/RemoveSectionTrident.tsx
@@ -55,7 +55,7 @@ export const RemoveSectionTrident: FC<RemoveSectionTridentProps> = withCheckerRo
   const [permit, setPermit] = useState<Signature>()
   const [slippageTolerance] = useSlippageTolerance('removeLiquidity')
   const slippagePercent = useMemo(() => {
-    return new Percent(Math.floor(+slippageTolerance * 100), 10_000)
+    return new Percent(Math.floor(+(slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance) * 100), 10_000)
   }, [slippageTolerance])
 
   const [percentage, setPercentage] = useState<string>('')

--- a/apps/earn/lib/hooks/useSlippageTolerance.ts
+++ b/apps/earn/lib/hooks/useSlippageTolerance.ts
@@ -1,3 +1,5 @@
 import { useLocalStorage } from '@sushiswap/hooks'
 
-export const useSlippageTolerance = (key: string | undefined = 'swapSlippage') => useLocalStorage(key, '0.5')
+export const useSlippageTolerance = (key: string | undefined = 'swapSlippage') => {
+  return useLocalStorage<number | string>(key, 0.5)
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a change in how slippage tolerance is handled across multiple components.

### Detailed summary
- `useSlippageTolerance` hook now returns a number or a string instead of just a string.
- `slippagePercent` calculation now includes a fallback value of 0.5 in case of 'AUTO' slippage tolerance.
- Multiple components (`ConcentratedLiquidityRemoveWidget`, `AddSectionConfirmModalConcentrated`, `MigrateTab`, `AddSectionReviewModalLegacy`, `AddSectionReviewModalTrident`, `RemoveSectionLegacy`, `RemoveSectionTrident`) have been updated to use the new `useSlippageTolerance` hook and the updated `slippagePercent` calculation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->