### PR TITLE
feat(apps/partner): add missing networks

### DIFF
--- a/apps/_root/app/partner/config.ts
+++ b/apps/_root/app/partner/config.ts
@@ -23,6 +23,10 @@ export const SUPPORTED_CHAINS = [
   ChainId.ARBITRUM_NOVA,
   ChainId.THUNDERCORE,
   ChainId.OPTIMISM,
+  ChainId.MOONBEAM,
+  ChainId.BOBA_BNB,
+  ChainId.BTTC,
+  ChainId.POLYGON_ZKEVM,
 ] as const
 
 export type SupportedChainIds = typeof SUPPORTED_CHAINS

--- a/config/graph/src/index.ts
+++ b/config/graph/src/index.ts
@@ -101,6 +101,7 @@ export const CHAIN_NAME: Record<number, string> = {
   [ChainId.BOBA_BNB]: 'Boba BNB',
   [ChainId.BTTC]: 'BitTorrent',
   [ChainId.THUNDERCORE]: 'ThunderCore',
+  [ChainId.POLYGON_ZKEVM]: 'Polygon zkEVM',
 } as const
 
 export const SUBGRAPH_HOST = {
@@ -178,7 +179,6 @@ export const BLOCKS_SUBGRAPH_NAME: Record<number, string> = {
   [ChainId.BTTC]: 'sushiswap/blocks-bttc',
   [ChainId.THUNDERCORE]: 'sushiswap/blocks-thundercore',
 } as const
-
 
 export const SECONDS_BETWEEN_BLOCKS: Record<number, number> = {
   [ChainId.ETHEREUM]: 12,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for several new blockchain networks including Moonbeam and Boba BNB, as well as updates the names of existing networks in the codebase. 

### Detailed summary
- Added support for Moonbeam, Boba BNB, BTTC, and Polygon zkEVM blockchain networks
- Updated the name of the Polygon zkEVM network
- Updated the name of the ThunderCore network in SUBGRAPH_HOST and BLOCKS_SUBGRAPH_NAME dictionaries

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->