### PR TITLE
fix(app/earn): amounts columns in v2 swap tx table

### DIFF
--- a/apps/earn/components/PoolSection/V2/PoolTransactionsV2/columns.tsx
+++ b/apps/earn/components/PoolSection/V2/PoolTransactionsV2/columns.tsx
@@ -40,17 +40,13 @@ export const AMOUNT_IN_COLUMN = (
   cell: (props) => {
     const row = props.row.original
     switch (row.type) {
-      case TransactionType.Swap: {
-        const amounts = row.amount0 < 0 ? [row.amount0, row.amount1] : [row.amount1, row.amount0]
-        const tokens = row.amount0 < 0 ? [row.pool.token0, row.pool.token1] : [row.pool.token1, row.pool.token0]
-
+      case TransactionType.Swap:
         return (
           <span className="font-normal">
-            <span className="font-semibold">{Math.abs(amounts[0]).toPrecision(6)}</span>{' '}
-            <span className="text-gray-600 dark:text-slate-400">{tokens[0].symbol}</span>
+            <span className="font-semibold">{(row.amountIn).toPrecision(2)}</span>{' '}
+            <span className="text-gray-600 dark:text-slate-400">{row.tokenIn.symbol}</span>
           </span>
         )
-      }
       case TransactionType.Mint:
       case TransactionType.Burn:
         return (
@@ -74,17 +70,13 @@ export const AMOUNT_OUT_COLUMN = (
   cell: (props) => {
     const row = props.row.original
     switch (row.type) {
-      case TransactionType.Swap: {
-        const amounts = row.amount0 < 0 ? [row.amount0, row.amount1] : [row.amount1, row.amount0]
-        const tokens = row.amount0 < 0 ? [row.pool.token0, row.pool.token1] : [row.pool.token1, row.pool.token0]
-
+      case TransactionType.Swap:
         return (
           <span className="font-normal">
-            <span className="font-semibold">{Math.abs(amounts[1]).toFixed(2)}</span>{' '}
-            <span className="text-gray-600 dark:text-slate-400">{tokens[1].symbol}</span>
+            <span className="font-semibold">{Math.abs(row.amountOut).toFixed(2)}</span>{' '}
+            <span className="text-gray-600 dark:text-slate-400">{row.tokenOut.symbol}</span>
           </span>
         )
-      }
       case TransactionType.Mint:
       case TransactionType.Burn:
         return (

--- a/apps/earn/components/PoolSection/V2/PoolTransactionsV2/useTransactionsV2.ts
+++ b/apps/earn/components/PoolSection/V2/PoolTransactionsV2/useTransactionsV2.ts
@@ -160,12 +160,16 @@ function useTransactionsV2(pool: Pool | undefined | null, poolId: string, opts: 
         const mints = (transaction.mints as NonNullable<(typeof transaction.mints)[0]>[]).map((mint) => ({
           ...mint,
           sender: String(mint.sender),
+          amount0: Number(mint.amount0),
+          amount1: Number(mint.amount1),
           type: TransactionType.Mint as const,
         }))
 
         const burns = (transaction.burns as NonNullable<(typeof transaction.burns)[0]>[]).map((burn) => ({
           ...burn,
           sender: String(burn.sender),
+          amount0: Number(burn.amount0),
+          amount1: Number(burn.amount1),
           type: TransactionType.Burn as const,
         }))
 
@@ -173,8 +177,8 @@ function useTransactionsV2(pool: Pool | undefined | null, poolId: string, opts: 
           ...swap,
           sender: String(swap.sender),
           to: String(swap.to),
-          amount0: Number(swap.amountIn),
-          amount1: Number(swap.amountOut),
+          amountIn: Number(swap.amountIn),
+          amountOut: Number(swap.amountOut),
           type: TransactionType.Swap as const,
         }))
 
@@ -185,8 +189,6 @@ function useTransactionsV2(pool: Pool | undefined | null, poolId: string, opts: 
             createdAtTimestamp: Number(transaction.createdAtTimestamp),
             createdAtBlock: Number(transaction.createdAtBlock),
             ...subtransaction,
-            amount0: Number(subtransaction.amount0), // Amount.fromRawAmount(pool.token0, subtransaction.amount0),
-            amount1: Number(subtransaction.amount1), // Amount.fromRawAmount(pool.token1, subtransaction.amount1),
             amountUSD: Number(subtransaction.amountUSD),
             logIndex: Number(subtransaction.logIndex),
           }))

--- a/packages/graph-client/queries/pairs.graphql
+++ b/packages/graph-client/queries/pairs.graphql
@@ -164,7 +164,13 @@ query V2Transactions($first: Int = 100, $skip: Int = 0, $orderBy: Transaction_or
       sender
       to
       amountIn
+      tokenIn {
+        symbol
+      }
       amountOut
+      tokenOut {
+        symbol
+      }
       amountUSD
       logIndex
     }
@@ -211,7 +217,13 @@ query V2Swaps($first: Int = 100, $skip: Int = 0, $orderBy: Swap_orderBy = timest
     sender
     to
     amountIn
+    tokenIn {
+      symbol
+    }
     amountOut
+    tokenOut {
+      symbol
+    }
     amountUSD
     logIndex
     transaction {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for token symbols in the `useTransactionsV2` hook and changes the way amount in and amount out are displayed in the `PoolTransactionsV2` component. 

### Detailed summary
- Adds `symbol` field for `tokenIn` and `tokenOut` in `pairs.graphql`
- Adds `amount0` and `amount1` fields in `useTransactionsV2.ts`
- Changes `amountIn` and `amountOut` in `useTransactionsV2.ts` to match `amount0` and `amount1`
- Displays `amountIn` and `tokenIn.symbol` instead of `amount0` and `pool.token0.symbol` in `PoolTransactionsV2` component
- Displays `amountOut` and `tokenOut.symbol` instead of `amount1` and `pool.token1.symbol` in `PoolTransactionsV2` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->