### PR TITLE
feat(apps/swap): thundercore banner

### DIFF
--- a/apps/_root/ui/swap/widget/ThunderCoreBanner.tsx
+++ b/apps/_root/ui/swap/widget/ThunderCoreBanner.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export const ThunderCoreBanner = () => {
+  return (
+    <div className="rounded-[10px] py-4 px-6 bg-gradient-to-r from-[#2d68af] to-[#479dbb] space-y-3 mt-4">
+      <div className="space-y-1">
+        <div className="-skew-x-[8deg] text-sm font-bold">Join the Thundercore Trading Competition</div>
+        <div className="-skew-x-[8deg] text-lg font-black">Grab a Share of $5,500 in Token Airdrop!</div>
+      </div>
+      <div className="font-medium text-[9px] ">Campaign Period: 6/13 08:00 (UTC) — 6/21 08:00 (UTC)</div>
+    </div>
+  )
+}

--- a/apps/_root/ui/swap/widget/Widget.tsx
+++ b/apps/_root/ui/swap/widget/Widget.tsx
@@ -13,6 +13,7 @@ import { useSwapState } from '../trade/TradeProvider'
 import { AppType } from '@sushiswap/ui'
 import { SwapButtonCrossChain } from './SwapButtonCrossChain'
 import { SettingsModule, SettingsOverlay } from '@sushiswap/ui/future/components/settings'
+import { ThunderCoreBanner } from './ThunderCoreBanner'
 
 export const Widget: FC = () => {
   const { appType } = useSwapState()
@@ -36,6 +37,7 @@ export const Widget: FC = () => {
         <SwitchTokensButton />
         <SwapCurrencyOutput />
         {appType === AppType.Swap ? <SwapButton /> : <SwapButtonCrossChain />}
+        <ThunderCoreBanner />
       </UIWidget.Content>
     </div>
   )


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a ThunderCore trading competition banner to the Swap widget.

### Detailed summary
- Adds a new component `ThunderCoreBanner` to `apps/_root/ui/swap/widget/ThunderCoreBanner.tsx`.
- Imports `ThunderCoreBanner` into `apps/_root/ui/swap/widget/Widget.tsx`.
- Renders `ThunderCoreBanner` component in `Widget` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->