### PR TITLE
fix: issue with images on the blog and hoist some next config

### DIFF
--- a/apps/_root/app/(landing)/components/BuildWealth.tsx
+++ b/apps/_root/app/(landing)/components/BuildWealth.tsx
@@ -1,5 +1,5 @@
 import { Container, Typography } from '@sushiswap/ui'
-import Image from "next/legacy/image";
+import Image from 'next/legacy/image'
 import React, { FC } from 'react'
 
 import { ExpandableCard } from './ExpandableCard'

--- a/apps/_root/next.config.mjs
+++ b/apps/_root/next.config.mjs
@@ -7,17 +7,16 @@ import { withAxiom } from 'next-axiom'
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   ...defaultNextConfig,
-  eslint: {
-    dirs: [
-      // ...
-      'app',
-      'components',
-      'functions',
-      'lib',
-      'pages',
-      'providers',
-      'types',
-      'ui',
+  images: {
+    loader: 'cloudinary',
+    path: 'https://cdn.sushi.com/image/upload/',
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+        port: '',
+        pathname: '/sushi-cdn/**',
+      },
     ],
   },
   transpilePackages: ['@sushiswap/ui', '@sushiswap/wagmi'],

--- a/apps/blog/components/Image.tsx
+++ b/apps/blog/components/Image.tsx
@@ -1,5 +1,5 @@
 import { classNames } from '@sushiswap/ui'
-import NextImage from 'next/image'
+import NextImage from 'next/legacy/image'
 import { FC } from 'react'
 import { Image as ImageType } from 'types'
 
@@ -54,8 +54,8 @@ export const Image: FC<ImageProps> = ({
       quality={quality}
       className={className}
       layout={layout}
-      width={width || _width || 640}
-      height={height || _height || 400}
+      width={layout !== 'fill' ? width || _width || 640 : undefined}
+      height={layout !== 'fill' ? height || _height || 400 : undefined}
       objectFit={objectFit}
       src={getOptimizedMedia({
         metadata: image.attributes.provider_metadata,

--- a/config/nextjs/index.js
+++ b/config/nextjs/index.js
@@ -9,17 +9,22 @@ const defaultNextConfig = {
     esmExternals: 'loose',
   },
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'res.cloudinary.com',
-        port: '',
-        pathname: '/sushi-cdn/**',
-      },
-    ],
     loader: 'cloudinary',
     path: 'https://res.cloudinary.com/sushi-cdn/image/fetch/',
     // path: 'https://cdn.sushi.com/image/fetch/',
+  },
+  eslint: {
+    dirs: [
+      // ...
+      'app',
+      'components',
+      'functions',
+      'lib',
+      'pages',
+      'providers',
+      'types',
+      'ui',
+    ],
   },
   webpack: (config, { isServer }) => {
     // If client-side, don't polyfill `fs`


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates image loading and adds eslint configuration. 

### Detailed summary
- Updates `next/image` to `next/legacy/image` in `BuildWealth.tsx` and `Image.tsx`
- Adds `images` object to `next.config.mjs` with `loader`, `path`, and `remotePatterns` properties
- Adds `eslint` configuration to include specific directories in `next.config.mjs`
- Removes `remotePatterns` property from `images` object in `index.js`
- Modifies `width` and `height` props in `Image.tsx` to only apply when `layout` is not `fill`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->