### PR TITLE
only use recommended rpc

### DIFF
--- a/config/viem/src/index.ts
+++ b/config/viem/src/index.ts
@@ -528,15 +528,15 @@ const thundercore = {
   rpcUrls: {
     default: {
       http: [
-        'https://mainnet-rpc.thundercore.io',
         'https://mainnet-rpc.thundercore.com',
-        'https://mainnet-rpc.thundertoken.net',
+        // 'https://mainnet-rpc.thundercore.io',
+        // 'https://mainnet-rpc.thundertoken.net',
       ],
     },
     public: {
       http: [
-        'https://mainnet-rpc.thundercore.io',
         'https://mainnet-rpc.thundercore.com',
+        'https://mainnet-rpc.thundercore.io',
         'https://mainnet-rpc.thundertoken.net',
       ],
     },

--- a/config/wagmi/src/chains.ts
+++ b/config/wagmi/src/chains.ts
@@ -629,15 +629,15 @@ export const otherChains: Chain[] = [
     rpcUrls: {
       default: {
         http: [
-          'https://mainnet-rpc.thundercore.io',
           'https://mainnet-rpc.thundercore.com',
-          'https://mainnet-rpc.thundertoken.net',
+          // 'https://mainnet-rpc.thundercore.io',
+          // 'https://mainnet-rpc.thundertoken.net',
         ],
       },
       public: {
         http: [
-          'https://mainnet-rpc.thundercore.io',
           'https://mainnet-rpc.thundercore.com',
+          'https://mainnet-rpc.thundercore.io',
           'https://mainnet-rpc.thundertoken.net',
         ],
       },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes `https://mainnet-rpc.thundertoken.net` from the list of available RPC endpoints in the `default` configuration, and adds it to the `public` configuration. It also comments out `https://mainnet-rpc.thundercore.io` in both configurations and replaces it with `https://mainnet-rpc.thundercore.com` in the `public` configuration.

### Detailed summary
- Removed `https://mainnet-rpc.thundertoken.net` from `default` configuration
- Added `https://mainnet-rpc.thundertoken.net` to `public` configuration
- Commented out `https://mainnet-rpc.thundercore.io` in both configurations
- Replaced `https://mainnet-rpc.thundercore.io` with `https://mainnet-rpc.thundercore.com` in `public` configuration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->