### PR TITLE
chore(formatter): prettier -> rome

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,19 +5,19 @@
   "editor.formatOnPaste": false,
   "editor.formatOnSave": false,
   "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.defaultFormatter": "rome.rome",
     "editor.formatOnSave": true
   },
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.defaultFormatter": "rome.rome",
     "editor.formatOnSave": true
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.defaultFormatter": "rome.rome",
     "editor.formatOnSave": true
   },
   "[solidity]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rome.rome"
   },
   "eslint.packageManager": "pnpm"
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR changes the default code formatter for JavaScript, TypeScript, TypeScriptReact, and Solidity files to `rome.rome` and enables formatting on save. It also sets the `eslint.packageManager` to `pnpm`.

### Detailed summary
- Changes default code formatter for JavaScript, TypeScript, TypeScriptReact, and Solidity files to `rome.rome`.
- Enables formatting on save for the above file types.
- Sets `eslint.packageManager` to `pnpm`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->