### PR TITLE
fix(apps/earn): setting slippage tolerance when removing liquidity

### DIFF
--- a/apps/earn/components/RemoveSection/RemoveSectionWidget.tsx
+++ b/apps/earn/components/RemoveSection/RemoveSectionWidget.tsx
@@ -115,9 +115,9 @@ export const RemoveSectionWidget: FC<RemoveSectionWidgetProps> = ({
                       <SettingsOverlay
                         options={{
                           slippageTolerance: {
-                            storageKey: 'addLiquidity',
+                            storageKey: 'removeLiquidity',
                             defaultValue: '0.5',
-                            title: 'Add Liquidity Slippage',
+                            title: 'Remove Liquidity Slippage',
                           },
                         }}
                         modules={[SettingsModule.CustomTokens, SettingsModule.SlippageTolerance]}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR changes the slippage tolerance storage key and title for the Remove Liquidity feature in the RemoveSectionWidget component.

### Detailed summary
- Changes the storage key for slippage tolerance from 'addLiquidity' to 'removeLiquidity'
- Changes the title for slippage tolerance from 'Add Liquidity Slippage' to 'Remove Liquidity Slippage'
- Includes SettingsModule.CustomTokens and SettingsModule.SlippageTolerance modules

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->