### PR TITLE
fix(apps/furo): vesting withdrawal bug

### DIFF
--- a/apps/furo/components/vesting/WithdrawModal.tsx
+++ b/apps/furo/components/vesting/WithdrawModal.tsx
@@ -101,7 +101,7 @@ export const WithdrawModal: FC<WithdrawModalProps> = ({ vesting, chainId, childr
           <Checker.Connect size="xl" fullWidth>
             <Checker.Network size="xl" fullWidth chainId={chainId}>
               <Checker.Custom
-                showGuardIfTrue={Boolean(balance?.greaterThan(ZERO))}
+                showGuardIfTrue={Boolean(!balance?.greaterThan(ZERO))}
                 guard={
                   <Button size="xl" fullWidth>
                     Not enough available


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the WithdrawModal component in the Vesting feature of the Furo app. It changes the condition for showing a guard button when the user's balance is zero.

### Detailed summary
- Changed the condition for showing the guard button to `!balance?.greaterThan(ZERO)`
- Previously the condition was `balance?.greaterThan(ZERO)`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->