### PR TITLE
feature(apps/earn): toggle base currency when adding v3 liquidity

### DIFF
--- a/apps/earn/components/NewPositionSection/SelectPricesWidget.tsx
+++ b/apps/earn/components/NewPositionSection/SelectPricesWidget.tsx
@@ -117,7 +117,7 @@ export const SelectPricesWidget: FC<SelectPricesWidget> = ({
                 </div>
               </div>
             )}
-            {!noLiquidity && !isLoading && (
+            {!noLiquidity && (
               <>
                 <LiquidityChartRangeInput
                   chainId={chainId}

--- a/apps/earn/components/PoolPage/MigrateTab.tsx
+++ b/apps/earn/components/PoolPage/MigrateTab.tsx
@@ -47,18 +47,34 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
   const [feeAmount, setFeeAmount] = useState<FeeAmount>(FeeAmount.LOWEST)
   const { approved } = useApproved(APPROVE_TAG_UNSTAKE)
   const [invertPrice, setInvertPrice] = useState(false)
+  const [invertTokens, setInvertTokens] = useState(false)
   const [slippageTolerance] = useSlippageTolerance('addLiquidity')
   const slippagePercent = useMemo(() => {
     return new Percent(Math.floor(+(slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance) * 100), 10_000)
   }, [slippageTolerance])
 
   const {
-    data: { token0, token1, liquidityToken },
+    data: { token0: _token0, token1: _token1, liquidityToken },
   } = useGraphPool(pool)
+
+  const {
+    value0: _value0,
+    value1: _value1,
+    underlying0: _underlying0,
+    underlying1: _underlying1,
+    isLoading,
+    balance
+  } = usePoolPosition()
+
+  const [token0, token1, value0, value1, underlying0, underlying1] = useMemo(
+    () => invertTokens
+      ? [_token1, _token0, _value1, _value0, _underlying1, _underlying0]
+      : [_token0, _token1, _value0, _value1, _underlying0, _underlying1],
+    [invertTokens, _token0, _token1, _value0, _value1, _underlying0, _underlying1]
+  )
 
   const { data: pair } = usePair(pool.chainId as UniswapV2Router02ChainId, token0, token1)
   const totalSupply = useTotalSupply(liquidityToken)
-  const { value0, value1, underlying0, underlying1, isLoading, balance } = usePoolPosition()
 
   // Harvest & Withdraw
   const {
@@ -83,11 +99,14 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
   // this is just getLiquidityValue with the fee off, but for the passed pair
   const token0Value = useMemo(
     () =>
-      token0 && pair?.[1]?.reserve0 && totalSupply && balance
+      token0 && pair?.[1] && totalSupply && balance
         ? Amount.fromRawAmount(
             token0?.wrapped,
             JSBI.divide(
-              JSBI.multiply(balance[FundSource.WALLET].quotient, pair[1].reserve0.quotient),
+              JSBI.multiply(
+                balance[FundSource.WALLET].quotient,
+                token0.wrapped.equals(pair[1].token0) ? pair[1].reserve0.quotient : pair[1].reserve1.quotient
+              ),
               totalSupply.quotient
             )
           )
@@ -101,7 +120,10 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
         ? Amount.fromRawAmount(
             token1?.wrapped,
             JSBI.divide(
-              JSBI.multiply(balance[FundSource.WALLET].quotient, pair[1].reserve1.quotient),
+              JSBI.multiply(
+                balance[FundSource.WALLET].quotient,
+                token1.wrapped.equals(pair[1].token1) ? pair[1].reserve1.quotient : pair[1].reserve0.quotient
+              ),
               totalSupply.quotient
             )
           )
@@ -134,10 +156,10 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
   const v3SpotPrice = useMemo(() => (v3Pool ? v3Pool?.token0Price : undefined), [v3Pool])
   const v2SpotPrice = useMemo(
     () =>
-      token0 && token1 && pair?.[1]?.reserve0 && pair?.[1]?.reserve1
-        ? new Price(token0.wrapped, token1.wrapped, pair[1].reserve0.quotient, pair[1].reserve1.quotient)
+      _token0 && _token1 && pair?.[1]?.reserve0 && pair?.[1]?.reserve1
+        ? new Price(_token0.wrapped, _token1.wrapped, pair[1].reserve0.quotient, pair[1].reserve1.quotient)
         : undefined,
-    [token0, token1, pair]
+    [_token0, _token1, pair]
   )
 
   let priceDifferenceFraction: Fraction | undefined =
@@ -170,40 +192,47 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
             pool: v3Pool ?? new V3Pool(token0.wrapped, token1.wrapped, feeAmount, sqrtPrice, 0, tick, []),
             tickLower,
             tickUpper,
-            amount0: token0Value.quotient,
-            amount1: token1Value.quotient,
+            amount0: token0.wrapped.sortsBefore(token1.wrapped) ? token0Value.quotient : token1Value.quotient,
+            amount1: token0.wrapped.sortsBefore(token1.wrapped) ? token1Value.quotient : token0Value.quotient,
             useFullPrecision: true, // we want full precision for the theoretical position
           })
         : undefined,
     [feeAmount, invalidRange, sqrtPrice, tick, tickLower, tickUpper, token0, token0Value, token1, token1Value, v3Pool]
   )
 
-  const { amount0: v3Amount0Min, amount1: v3Amount1Min } = useMemo(
+  const { amount0, amount1 } = useMemo(
     () => (position ? position.mintAmountsWithSlippage(slippagePercent) : { amount0: undefined, amount1: undefined }),
     [position, slippagePercent]
   )
 
+  const [positionAmount0, positionAmount1, v3Amount0Min, v3Amount1Min] = useMemo(() =>
+    invertTokens
+      ? [position?.amount1, position?.amount0, amount1, amount0]
+      : [position?.amount0, position?.amount1, amount0, amount1],
+    [invertTokens, position?.amount0, position?.amount1, amount0, amount1]
+  )
+
   const refund0 = useMemo(
     () =>
-      position &&
+      positionAmount0 &&
       token0 &&
       token0Value &&
-      Amount.fromRawAmount(token0, JSBI.subtract(token0Value.quotient, position.amount0.quotient)),
+      Amount.fromRawAmount(token0, JSBI.subtract(token0Value.quotient, positionAmount0.quotient)),
     [token0Value, position, token0]
   )
 
   const refund1 = useMemo(
     () =>
-      position &&
+      positionAmount1 &&
       token1 &&
       token1Value &&
-      Amount.fromRawAmount(token1, JSBI.subtract(token1Value.quotient, position.amount1.quotient)),
+      Amount.fromRawAmount(token1, JSBI.subtract(token1Value.quotient, positionAmount1.quotient)),
     [token1Value, position, token1]
   )
 
   const [v3FiatValue0, v3FiatValue1, refund0FiatValue, refund1FiatValue] = useTokenAmountDollarValues({
     chainId: pool.chainId as V3ChainId,
-    amounts: [position?.amount0, position?.amount1, refund0, refund1],
+    amounts: [positionAmount0, positionAmount1, refund0, refund1],
   })
 
   const { [Field.CURRENCY_A]: input0, [Field.CURRENCY_B]: input1 } = parsedAmounts
@@ -464,12 +493,12 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
                 <List.KeyValue flex title={<span className="font-semibold text-base">Migration</span>}>
                   <span className="font-semibold text-base">{formatUSD(v3FiatValue0 + v3FiatValue1)}</span>
                 </List.KeyValue>
-                {position?.amount0 && (
-                  <List.KeyValue flex title={`${position.amount0.currency.symbol}`} className="!items-start">
+                {positionAmount0 && (
+                  <List.KeyValue flex title={`${positionAmount0.currency.symbol}`} className="!items-start">
                     <div className="flex flex-col gap-0.5">
                       <div className="flex items-center gap-2">
-                        <Currency.Icon currency={unwrapToken(position.amount0.currency)} width={18} height={18} />
-                        {position.amount0?.toSignificant(6)} {unwrapToken(position.amount0.currency).symbol}
+                        <Currency.Icon currency={unwrapToken(positionAmount0.currency)} width={18} height={18} />
+                        {positionAmount0.toSignificant(6)} {unwrapToken(positionAmount0.currency).symbol}
                       </div>
                       <span className="text-gray-600 dark:text-slate-400 text-xs font-normal">
                         {formatUSD(v3FiatValue0)}
@@ -477,12 +506,12 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
                     </div>
                   </List.KeyValue>
                 )}
-                {position?.amount1 && (
-                  <List.KeyValue flex title={`${position.amount1.currency.symbol}`} className="!items-start">
+                {positionAmount1 && (
+                  <List.KeyValue flex title={`${positionAmount1.currency.symbol}`} className="!items-start">
                     <div className="flex flex-col gap-0.5">
                       <div className="flex items-center gap-2">
-                        <Currency.Icon currency={unwrapToken(position.amount1.currency)} width={18} height={18} />
-                        {position.amount1?.toSignificant(6)} {unwrapToken(position.amount1.currency).symbol}
+                        <Currency.Icon currency={unwrapToken(positionAmount1.currency)} width={18} height={18} />
+                        {positionAmount1.toSignificant(6)} {unwrapToken(positionAmount1.currency).symbol}
                       </div>
                       <span className="text-gray-600 dark:text-slate-400 text-xs font-normal">
                         {formatUSD(v3FiatValue1)}
@@ -547,6 +576,7 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
             feeAmount={feeAmount}
             tokenId={undefined}
             showStartPrice={false}
+            switchTokens={() => setInvertTokens((prev) => !prev)}
           >
             {outOfRange && (
               <div className="p-6 font-medium bg-yellow/10 text-yellow rounded-xl">
@@ -578,7 +608,7 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
               >
                 <Checker.Custom
                   showGuardIfTrue={Boolean(
-                    !position || position.amount0.equalTo(ZERO) || position.amount1.equalTo(ZERO)
+                    !position || positionAmount0?.equalTo(ZERO) || positionAmount1?.equalTo(ZERO)
                   )}
                   guard={
                     <Button size="xl" fullWidth>
@@ -681,7 +711,7 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
               </List>
               <List>
                 <List.Control>
-                  {position?.amount0 && (
+                  {positionAmount0 && (
                     <List.KeyValue
                       flex
                       title={`Migration`}
@@ -690,8 +720,8 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
                     >
                       <div className="flex flex-col gap-0.5">
                         <div className="flex items-center gap-2">
-                          <Currency.Icon currency={unwrapToken(position.amount0.currency)} width={18} height={18} />
-                          {position.amount0?.toSignificant(6)} {unwrapToken(position.amount0.currency).symbol}
+                          <Currency.Icon currency={unwrapToken(positionAmount0.currency)} width={18} height={18} />
+                          {positionAmount0.toSignificant(6)} {unwrapToken(positionAmount0.currency).symbol}
                         </div>
                         <span className="text-gray-600 dark:text-slate-400 text-xs font-normal">
                           {formatUSD(v3FiatValue0)}
@@ -699,12 +729,12 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
                       </div>
                     </List.KeyValue>
                   )}
-                  {position?.amount1 && (
+                  {positionAmount1 && (
                     <List.KeyValue flex title={``} className="!items-start">
                       <div className="flex flex-col gap-0.5">
                         <div className="flex items-center gap-2">
-                          <Currency.Icon currency={unwrapToken(position.amount1.currency)} width={18} height={18} />
-                          {position.amount1?.toSignificant(6)} {unwrapToken(position.amount1.currency).symbol}
+                          <Currency.Icon currency={unwrapToken(positionAmount1.currency)} width={18} height={18} />
+                          {positionAmount1.toSignificant(6)} {unwrapToken(positionAmount1.currency).symbol}
                         </div>
                         <span className="text-gray-600 dark:text-slate-400 text-xs font-normal">
                           {formatUSD(v3FiatValue1)}

--- a/apps/earn/components/PoolPageV3.tsx
+++ b/apps/earn/components/PoolPageV3.tsx
@@ -83,6 +83,7 @@ const Pool: FC = () => {
     activeTab,
   } = queryParamsSchema.parse(query)
 
+  const [invertTokens, setInvertTokens] = useState(false)
   const [tab, setTab] = useState<SelectedTab>(
     activeTab === 'new'
       ? SelectedTab.NewPosition
@@ -107,11 +108,15 @@ const Pool: FC = () => {
   const fiatValuesIncentives = useTokenAmountDollarValues({ chainId, amounts: incentiveAmounts })
 
   const [_token0, _token1] = useMemo(
-    () => [
-      poolStats?.token0 ? unwrapToken(poolStats.token0) : undefined,
-      poolStats?.token1 ? unwrapToken(poolStats.token1) : undefined,
-    ],
-    [poolStats?.token0, poolStats?.token1]
+    () => {
+      const tokens = [
+        poolStats?.token0 ? unwrapToken(poolStats.token0) : undefined,
+        poolStats?.token1 ? unwrapToken(poolStats.token1) : undefined,
+      ]
+
+      return invertTokens ? tokens.reverse() : tokens
+    },
+    [invertTokens, poolStats?.token0, poolStats?.token1]
   )
 
   return (
@@ -376,6 +381,7 @@ const Pool: FC = () => {
               token1={_token1}
               feeAmount={poolStats?.feeAmount}
               tokenId={undefined}
+              switchTokens={() => setInvertTokens((prev) => !prev)}
             />
           </div>
           <div className="flex flex-col gap-3">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the ability to switch the order of tokens in the UI for two different components in the app.

### Detailed summary
- Adds the ability to switch the order of tokens in the `SelectPricesWidget` component.
- Adds the ability to switch the order of tokens in the `MigrateTab` component.
- The order of tokens is switched when a button is clicked.
- The new order of tokens affects the display and calculations in the affected components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->