### PR TITLE
chore: publish hardhat-config & chain pkgs

### DIFF
--- a/.changeset/cool-trees-press.md
+++ b/.changeset/cool-trees-press.md
@@ -1,0 +1,5 @@
+---
+'@sushiswap/chain': patch
+---
+
+update files

--- a/.changeset/rude-tools-sparkle.md
+++ b/.changeset/rude-tools-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@sushiswap/hardhat-config': patch
+---
+
+update scripts

--- a/config/hardhat/package.json
+++ b/config/hardhat/package.json
@@ -24,8 +24,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external hardhat,ethers",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
-    "postinstall": "pnpm build"
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "jest": {
     "preset": "@sushiswap/jest-config/node"

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -14,7 +14,8 @@
   "license": "MIT",
   "author": "Matthew Lilley <hello@matthewLilley.com>",
   "files": [
-    "dist"
+    "dist",
+    "scripts"
   ],
   "main": "dist/index.js",
   "source": "src/index.ts",


### PR DESCRIPTION
The latest versions of both packages fail during install

hardhat-config:
<img width="947" alt="Screenshot 2023-06-19 at 2 08 32 PM" src="https://github.com/sushiswap/sushiswap/assets/82962873/9b6488f1-261a-452f-b999-f190d644489d">

chains:
<img width="990" alt="Screenshot 2023-06-19 at 2 12 22 PM" src="https://github.com/sushiswap/sushiswap/assets/82962873/175fe4ad-e054-4982-9441-7f6e6cd1638f">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@sushiswap/chain` and `@sushiswap/hardhat-config` packages, as well as the `package.json` and `config/hardhat/package.json` files.

### Detailed summary:
- Updated `@sushiswap/chain` and `@sushiswap/hardhat-config` packages
- Added `scripts` to the `files` array in `packages/chain/package.json`
- Removed `postinstall` script from `config/hardhat/package.json`
- Removed `pnpm` from `clean` script in `config/hardhat/package.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->