### PR TITLE
fix(packages/wagmi): pending spinner position on erc20 approval button

### DIFF
--- a/packages/wagmi/src/future/systems/Checker/ApproveERC20.tsx
+++ b/packages/wagmi/src/future/systems/Checker/ApproveERC20.tsx
@@ -55,15 +55,17 @@ export const Component: FC<ApproveERC20Props> = ({
     return <>{children}</>
   }
 
+  const loading = [ApprovalState.UNKNOWN, ApprovalState.LOADING, ApprovalState.PENDING].includes(state)
+
   return (
     <Button
       as={as}
       disabled={state !== ApprovalState.NOT_APPROVED}
-      loading={[ApprovalState.UNKNOWN, ApprovalState.LOADING, ApprovalState.PENDING].includes(state)}
+      loading={loading}
       testdata-id={id}
       variant={variant}
       size={size}
-      className={classNames(className, 'group relative pr-16')}
+      className={classNames(className, 'group relative', !loading && 'pr-16' )}
       fullWidth={fullWidth}
       onClick={() => write?.()}
       type={type}


### PR DESCRIPTION
Before:
![image](https://github.com/sushiswap/sushiswap/assets/82962873/3f762ec3-bb80-421a-8bb5-6f119316bed2)

After:
<img width="531" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/830065b8-6f92-4dbf-8e84-9ed641e2e82e">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the loading state of the `ApproveERC20` component in `Checker`. 

### Detailed summary:
- Added `loading` variable to simplify code and improve readability
- Replaced inline ternary expression with `loading` variable
- Added `!loading` condition to `className` to prevent unnecessary padding when loading

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->