### PR TITLE
chore: init analytics2 app dir

### DIFF
--- a/apps/evm/app/analytics/layout.tsx
+++ b/apps/evm/app/analytics/layout.tsx
@@ -1,7 +1,0 @@
-export const metadata = {
-  title: 'SushiAnalytics 📈',
-}
-
-export default function AnalyticsLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>
-}

--- a/apps/evm/app/analytics2/header.tsx
+++ b/apps/evm/app/analytics2/header.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { GlobalNav } from '@sushiswap/ui/components/GlobalNav'
+import React, { FC } from 'react'
+
+export const Header: FC = () => {
+  return <GlobalNav />
+}

--- a/apps/evm/app/analytics2/layout.tsx
+++ b/apps/evm/app/analytics2/layout.tsx
@@ -1,0 +1,20 @@
+import { HotJar } from '@sushiswap/ui/components/scripts'
+
+import { Header } from './header'
+import { Providers } from './providers'
+
+export const metadata = {
+  title: 'SushiAnalytics 📈',
+}
+
+export default function AnalyticsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Providers>
+        <Header />
+        {children}
+      </Providers>
+      <HotJar />
+    </>
+  )
+}

--- a/apps/evm/app/analytics2/page.tsx
+++ b/apps/evm/app/analytics2/page.tsx
@@ -3,5 +3,5 @@ export const metadata = {
 }
 
 export default function AnalyticsPage() {
-  return <h1>SushiVault 🏦</h1>
+  return <h1>SushiAnalytics 📈</h1>
 }

--- a/apps/evm/app/analytics2/providers.tsx
+++ b/apps/evm/app/analytics2/providers.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ThemeProvider } from '@sushiswap/ui'
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the analytics module in the EVM app. It includes changes to the layout, header, and page components, as well as the addition of providers and a global navigation component.

### Detailed summary:
- Deleted `apps/evm/app/analytics/layout.tsx` and `apps/evm/app/analytics2/header.tsx`
- Added `use client` import
- Added `GlobalNav` import from `@sushiswap/ui/components/GlobalNav`
- Added `Header` component
- Updated the `AnalyticsPage` component to display "SushiAnalytics 📈" instead of "SushiVault 🏦"
- Added `Providers` component
- Added `ThemeProvider` import from `@sushiswap/ui`
- Added `metadata` object with title "SushiAnalytics 📈"
- Added `AnalyticsLayout` component
- Added `HotJar` import from `@sushiswap/ui/components/scripts`
- Wrapped the content of `AnalyticsLayout` component with `Providers` component
- Added `children` prop to `AnalyticsLayout` component
- Added `HotJar` component as a sibling to the wrapped content in `AnalyticsLayout` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->