### PR TITLE
fix: filter testnet chain ids

### DIFF
--- a/apps/evm/config.ts
+++ b/apps/evm/config.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@sushiswap/chain'
+import { ChainId, TESTNET_CHAIN_IDS } from '@sushiswap/chain'
 import { TridentChainIds } from '@sushiswap/trident-sdk'
 import { SushiSwapV2ChainIds } from '@sushiswap/v2-sdk'
 import { SushiSwapV3ChainIds } from '@sushiswap/v3-sdk'
@@ -13,35 +13,37 @@ export type SwapApiEnabledChainId = (typeof SWAP_API_ENABLED_NETWORKS)[number]
 
 export const SUPPORTED_CHAIN_IDS = Array.from(
   new Set([...TridentChainIds, ...SushiSwapV2ChainIds, ...SushiSwapV3ChainIds])
-).sort((a: number, b: number) => {
-  // Sort Thundercore
-  if (
-    (
-      [
-        ChainId.ETHEREUM,
-        ChainId.ARBITRUM,
-        ChainId.POLYGON,
-        ChainId.OPTIMISM,
-        ChainId.AVALANCHE,
-        ChainId.FANTOM,
-        ChainId.BSC,
-        ChainId.GNOSIS,
-      ] as number[]
-    ).includes(b) &&
-    a === ChainId.THUNDERCORE
-  )
-    return 1
-  if (a === ChainId.THUNDERCORE) return -1
+)
+  .filter((c) => !TESTNET_CHAIN_IDS.includes(c))
+  .sort((a: number, b: number) => {
+    // Sort Thundercore
+    if (
+      (
+        [
+          ChainId.ETHEREUM,
+          ChainId.ARBITRUM,
+          ChainId.POLYGON,
+          ChainId.OPTIMISM,
+          ChainId.AVALANCHE,
+          ChainId.FANTOM,
+          ChainId.BSC,
+          ChainId.GNOSIS,
+        ] as number[]
+      ).includes(b) &&
+      a === ChainId.THUNDERCORE
+    )
+      return 1
+    if (a === ChainId.THUNDERCORE) return -1
 
-  // Sort optimism
-  if (
-    ([ChainId.ETHEREUM, ChainId.ARBITRUM, ChainId.POLYGON, ChainId.OPTIMISM] as number[]).includes(b) &&
-    a === ChainId.OPTIMISM
-  )
-    return 1
-  if (a === ChainId.OPTIMISM) return -1
+    // Sort optimism
+    if (
+      ([ChainId.ETHEREUM, ChainId.ARBITRUM, ChainId.POLYGON, ChainId.OPTIMISM] as number[]).includes(b) &&
+      a === ChainId.OPTIMISM
+    )
+      return 1
+    if (a === ChainId.OPTIMISM) return -1
 
-  return 1
-})
+    return 1
+  })
 
 export type SupportedChainId = (typeof SUPPORTED_CHAIN_IDS)[number]

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -113,6 +113,21 @@ export const ChainId = {
 } as const
 export type ChainId = (typeof ChainId)[keyof typeof ChainId]
 
+export const TESTNET_CHAIN_IDS = [
+  ChainId.ARBITRUM_TESTNET,
+  ChainId.AVALANCHE_TESTNET,
+  ChainId.BSC_TESTNET,
+  ChainId.FANTOM_TESTNET,
+  ChainId.HECO_TESTNET,
+  ChainId.HARMONY_TESTNET,
+  ChainId.OKEX_TESTNET,
+  ChainId.POLYGON_TESTNET,
+  ChainId.ROPSTEN,
+  ChainId.RINKEBY,
+  ChainId.GÖRLI,
+  ChainId.KOVAN,
+]
+
 // export const isChainId = (chainId: number): chainId is ChainId => Object.values(ChainId).includes(chainId as ChainId)
 
 export const ChainKey = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding testnet chain IDs and updating the sorting logic for supported chain IDs.

### Detailed summary:
- Added `TESTNET_CHAIN_IDS` array with multiple testnet chain IDs.
- Updated the `SUPPORTED_CHAIN_IDS` array to exclude testnet chain IDs.
- Updated the sorting logic for supported chain IDs, considering Thundercore and Optimism chains.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->