### PR TITLE
fix: token pricing on migration page

### DIFF
--- a/apps/evm/ui/pool/PoolPage/MigrateTab.tsx
+++ b/apps/evm/ui/pool/PoolPage/MigrateTab.tsx
@@ -315,10 +315,10 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
               >
                 <SwitchHorizontalIcon width={16} height={16} />
                 <div className="flex items-baseline gap-1.5">
-                  1 {invertPrice ? token1.symbol : token0.symbol} ={' '}
+                  1 {invertPrice ? _token1.symbol : _token0.symbol} ={' '}
                   {invertPrice
-                    ? `${v2SpotPrice?.invert()?.toSignificant(6)} ${token0.symbol}`
-                    : `${v2SpotPrice?.toSignificant(6)} ${token1.symbol}`}
+                    ? `${v2SpotPrice?.invert()?.toSignificant(6)} ${_token0.symbol}`
+                    : `${v2SpotPrice?.toSignificant(6)} ${_token1.symbol}`}
                 </div>
               </div>
             ) : (
@@ -337,10 +337,10 @@ export const MigrateTab: FC<{ pool: Pool }> = withCheckerRoot(({ pool }) => {
               >
                 <SwitchHorizontalIcon width={16} height={16} />
                 <div className="flex items-baseline gap-1.5">
-                  1 {invertPrice ? token1.symbol : token0.symbol} ={' '}
+                  1 {invertPrice ? _token1.symbol : _token0.symbol} ={' '}
                   {invertPrice
-                    ? `${v3SpotPrice?.invert()?.toSignificant(6)} ${token0.symbol}`
-                    : `${v3SpotPrice?.toSignificant(6)} ${token1.symbol}`}
+                    ? `${v3SpotPrice?.invert()?.toSignificant(6)} ${_token0.symbol}`
+                    : `${v3SpotPrice?.toSignificant(6)} ${_token1.symbol}`}
                 </div>
               </div>
             ) : (


### PR DESCRIPTION
Switching the base currency on the migration page causes the token prices to be incorrect.

Before:
<img width="527" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/0c2fdd80-ddc1-4349-80ab-ccd4769d7d10">


After:
<img width="436" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/2a227088-41f9-4e74-83b9-721c3bd933bb">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the symbol references in the MigrateTab component in the PoolPage. 

### Detailed summary
- Replaced references to `token0` and `token1` with `_token0` and `_token1` respectively.
- Updated the displayed symbol in the UI based on the updated references.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->