### PR TITLE
fix(apps/landing): furo link

### DIFF
--- a/apps/evm/app/(landing)/header.tsx
+++ b/apps/evm/app/(landing)/header.tsx
@@ -51,7 +51,7 @@ export const Header: FC = () => {
               </Link>
             </NavigationMenuItem>
             <NavigationMenuItem className="hidden md:block">
-              <Link href="/pay" legacyBehavior passHref>
+              <Link href="/furo" legacyBehavior passHref>
                 <NavigationMenuLink className={navigationMenuTriggerStyle()}>Pay</NavigationMenuLink>
               </Link>
             </NavigationMenuItem>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary:
- The focus of this PR is to update the link in the header component from "/pay" to "/furo".

- Updated the `href` attribute of the `Link` component in the `NavigationMenuItem` from `"/pay"` to `"/furo"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->