### PR TITLE
feat(database): steer

### DIFF
--- a/config/graph/src/index.ts
+++ b/config/graph/src/index.ts
@@ -74,6 +74,8 @@ export const PENDING_METIS_HOST = 'andromeda.thegraph.metis.io/subgraphs/id'
 export const POLYGON_ZKEVM_HOST = 'api.studio.thegraph.com/query/32073'
 export const THUNDERCORE_HOST = 'graph-node.thundercore.com/subgraphs/name'
 
+export const SUSHI_HOST = 'subgraphs.sushi.com/subgraphs/name'
+
 export const CHAIN_NAME: Record<number, string> = {
   [ChainId.ARBITRUM]: 'Arbitrum',
   [ChainId.AVALANCHE]: 'Avalanche',
@@ -106,7 +108,7 @@ export const CHAIN_NAME: Record<number, string> = {
 
 export const SUBGRAPH_HOST: Record<number, string> = {
   [ChainId.ARBITRUM]: GRAPH_HOST,
-  [ChainId.ARBITRUM_NOVA]: 'subgraphs.sushi.com/subgraphs/name',
+  [ChainId.ARBITRUM_NOVA]: SUSHI_HOST,
   [ChainId.AVALANCHE]: GRAPH_HOST,
   [ChainId.BSC]: GRAPH_HOST,
   [ChainId.CELO]: GRAPH_HOST,
@@ -120,13 +122,13 @@ export const SUBGRAPH_HOST: Record<number, string> = {
   [ChainId.METIS]: METIS_HOST,
   [ChainId.MOONBEAM]: GRAPH_HOST,
   [ChainId.MOONRIVER]: GRAPH_HOST,
-  [ChainId.OPTIMISM]: 'api.thegraph.com/subgraphs/name',
+  [ChainId.OPTIMISM]: GRAPH_HOST,
   [ChainId.POLYGON]: GRAPH_HOST,
   [ChainId.POLYGON_ZKEVM]: POLYGON_ZKEVM_HOST,
   [ChainId.BOBA]: GRAPH_HOST,
-  [ChainId.BOBA_AVAX]: 'subgraphs.sushi.com/subgraphs/name',
-  [ChainId.BOBA_BNB]: 'subgraphs.sushi.com/subgraphs/name',
-  [ChainId.BTTC]: 'subgraphs.sushi.com/subgraphs/name',
+  [ChainId.BOBA_AVAX]: SUSHI_HOST,
+  [ChainId.BOBA_BNB]: SUSHI_HOST,
+  [ChainId.BTTC]: SUSHI_HOST,
   [ChainId.OKEX]: '',
   [ChainId.HECO]: '',
   [ChainId.KOVAN]: '',
@@ -349,6 +351,27 @@ export const CONCENTRATED_SUBGRAPH_NAME: Record<number, string> = {
   [ChainId.ETHEREUM]: 'uniswap/uniswap-v3',
   [ChainId.ARBITRUM]: 'ianlapham/arbitrum-minimal',
 }
+
+export const STEER_ENABLED_NETWORKS = [
+  ChainId.POLYGON,
+  ChainId.AVALANCHE,
+  ChainId.OPTIMISM,
+  ChainId.BSC,
+  ChainId.CELO,
+] as const
+
+export type SteerChainId = (typeof STEER_ENABLED_NETWORKS)[number]
+
+export const STEER_SUBGRAPGH_NAME: Record<SteerChainId, string> = {
+  [ChainId.POLYGON]: 'steerprotocol/steer-protocol-polygon',
+  [ChainId.AVALANCHE]: 'steerprotocol/steer-protocol-avalanche',
+  [ChainId.OPTIMISM]: 'steerprotocol/steer-protocol-optimism',
+  [ChainId.BSC]: 'steerprotocol/steer-protocol-bsc',
+  // [ChainId.THUNDERCORE]: 'steerprotocol/steer-thundercore', // https://subgraph.steer.finance/thundercore/subgraphs/name/steerprotocol/steer-thundercore
+  [ChainId.CELO]: 'steerprotocol/steer-protocol-celo',
+  // [ChainId.METIS]: 'steerprotocol/steer-protocol-metis', // https://subgraph.satsuma-prod.com/769a117cc018/steer/steer-protocol-metis/api
+  // [ChainId.POLYGON_ZKEVM]: 'steerprotocol/steer-zkevm', // https://subgraph.steer.finance/zkevm/subgraphs/name/steerprotocol/steer-zkevm
+} as const
 
 export const DEFAULT_CHAIN_ID = ChainId.ETHEREUM
 export const DEFAULT_CHAIN_NAME = CHAIN_NAME[DEFAULT_CHAIN_ID]

--- a/jobs/pool/.graphclientrc.yml
+++ b/jobs/pool/.graphclientrc.yml
@@ -58,6 +58,11 @@ sources:
       graphql:
         endpoint: https://{context.subgraphHost:api.thegraph.com/subgraphs/name}/{context.subgraphName:blocklytics/ethereum-blocks}
         retry: 3
+  - name: Steer
+    handler:
+      graphql:
+        endpoint: https://{context.host:api.thegraph.com/subgraphs/name}/{context.name:steerprotocol/steer-protocol-polygon}
+        retry: 3
 
 additionalTypeDefs: |
   # Type Extensions

--- a/jobs/pool/query.graphql
+++ b/jobs/pool/query.graphql
@@ -289,10 +289,44 @@ query CustomBlocks($timestamp: Int!, $chainIds: [Int!]!) {
   }
 }
 
-query CurrentBlock($first: Int = 1000 $skip: Int = 0) {
+query CurrentBlock($first: Int = 1000, $skip: Int = 0) {
   _meta {
     block {
       number
     }
+  }
+}
+
+query SteerVaults($first: Int = 1000, $skip: Int = 0) {
+  vaults(first: $first, skip: $skip) {
+    id
+    feeTier
+    reserve0: totalAmount0
+    reserve1: totalAmount1
+    pool
+    state
+    payloadIpfs
+    strategyToken {
+      id
+      executionBundle
+      name # "Elastic Expansion Strategy"
+    #   # creator: {
+    #   #     id
+    #   # }
+    }
+    positions(first: 1000) {
+      lowerTick
+      upperTick
+    }
+    createdAt
+    annualPercentageYield
+    annualPercentageDailyYield
+    annualPercentageMonthlyYield
+    annualPercentageYearlyYield
+    annualFeeARR
+    token0
+    token1
+    fees0
+    fees1
   }
 }

--- a/jobs/pool/src/etl/pool/load.ts
+++ b/jobs/pool/src/etl/pool/load.ts
@@ -41,7 +41,7 @@ export async function upsertPools(pools: Prisma.SushiPoolCreateManyInput[]) {
     }
     poolsToCreate.push(pool)
   }
-  
+
   const feeApr1h = poolsToUpdate
     .filter((p) => p.feeApr1h)
     .map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.feeApr1h}`)
@@ -295,7 +295,7 @@ export async function upsertPools(pools: Prisma.SushiPoolCreateManyInput[]) {
       END,`
     : Prisma.empty
 
-    const query = Prisma.sql`
+  const query = Prisma.sql`
     UPDATE SushiPool
     SET 
       reserve0 = CASE 
@@ -400,9 +400,7 @@ export async function upsertPools(pools: Prisma.SushiPoolCreateManyInput[]) {
     WHERE id IN (${Prisma.join(poolsToUpdate.map((update) => update.id))});
 `
   const [updated, created] = await Promise.all([
-    poolsToUpdate.length
-      ? client.$executeRaw`${query}`
-      : Promise.resolve(0),
+    poolsToUpdate.length ? client.$executeRaw`${query}` : Promise.resolve(0),
     client.sushiPool.createMany({
       data: poolsToCreate,
       skipDuplicates: true,

--- a/jobs/pool/src/etl/steer/index.ts
+++ b/jobs/pool/src/etl/steer/index.ts
@@ -1,0 +1,1 @@
+export * from './load.js'

--- a/jobs/pool/src/etl/steer/load.ts
+++ b/jobs/pool/src/etl/steer/load.ts
@@ -1,160 +1,178 @@
 import { createClient, Prisma } from '@sushiswap/database'
 
 export async function upsertVaults(vaults: Prisma.SteerVaultCreateManyInput[]) {
-  if (vaults.length === 0) return
   const client = await createClient()
+
+  const vaultTokens = vaults.flatMap((vault) => [vault.token0Id, vault.token1Id])
+  const dbTokens = (
+    await client.token.findMany({
+      select: {
+        id: true,
+      },
+      where: {
+        id: {
+          in: vaultTokens,
+        },
+      },
+    })
+  ).map((token) => token.id)
+  const vaultsToUpdate = vaults.filter(
+    (vault) => dbTokens.includes(vault.token0Id) && dbTokens.includes(vault.token1Id)
+  )
+
+  if (vaultsToUpdate.length === 0) return
 
   const query = Prisma.sql`
     UPDATE SteerVault
     SET
       poolId = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.poolId}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.poolId}`),
           ' '
         )}
         ELSE poolId
       END,
       feeTier = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.feeTier}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.feeTier}`),
           ' '
         )}
         ELSE feeTier
       END,
       apr = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr}`),
           ' '
         )}
         ELSE apr
       END,
       apr1d = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr1d}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr1d}`),
           ' '
         )}
         ELSE apr1d
       END,
       apr1m = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr1m}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr1m}`),
           ' '
         )}
         ELSE apr1m
       END,
       apr1y = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr1y}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr1y}`),
           ' '
         )}
         ELSE apr1y
       END,
       token0Id = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.token0Id}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.token0Id}`),
           ' '
         )}
         ELSE token0Id
       END,
       reserve0 = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.reserve0}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.reserve0}`),
           ' '
         )}
         ELSE reserve0
       END,
       fees0 = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.fees0}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.fees0}`),
           ' '
         )}
         ELSE fees0
       END,
       token1Id = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.token1Id}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.token1Id}`),
           ' '
         )}
         ELSE token1Id
       END,
       reserve1 = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.reserve1}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.reserve1}`),
           ' '
         )}
         ELSE reserve1
       END,
       fees1 = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.fees1}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.fees1}`),
           ' '
         )}
         ELSE fees1
       END,
       strategy = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.strategy}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.strategy}`),
           ' '
         )}
         ELSE strategy
       END,
       description = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.description}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.description}`),
           ' '
         )}
         ELSE description
       END,
       state = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.state}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.state}`),
           ' '
         )}
         ELSE state
       END,
       performanceFee = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.performanceFee}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.performanceFee}`),
           ' '
         )}
         ELSE performanceFee
       END,
       lowerTick = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.lowerTick}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.lowerTick}`),
           ' '
         )}
         ELSE lowerTick
       END,
       upperTick = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.upperTick}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.upperTick}`),
           ' '
         )}
         ELSE upperTick
       END,
       adjustmentFrequency = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.adjustmentFrequency}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.adjustmentFrequency}`),
           ' '
         )}
         ELSE adjustmentFrequency
       END,
       lastAdjustmentTimestamp = CASE
         ${Prisma.join(
-          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.lastAdjustmentTimestamp}`),
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.lastAdjustmentTimestamp}`),
           ' '
         )}
         ELSE lastAdjustmentTimestamp
       END,
       updatedAt = NOW()
-    WHERE id IN (${Prisma.join(vaults.map((update) => Prisma.sql`${update.id}`))});
+    WHERE id IN (${Prisma.join(vaultsToUpdate.map((update) => Prisma.sql`${update.id}`))});
   `
 
   const [updated, created] = await Promise.all([
-    vaults.length ? client.$executeRaw`${query}` : Promise.resolve(0),
+    vaultsToUpdate.length ? client.$executeRaw`${query}` : Promise.resolve(0),
     client.steerVault.createMany({
-      data: vaults,
+      data: vaultsToUpdate,
       skipDuplicates: true,
     }),
   ])

--- a/jobs/pool/src/etl/steer/load.ts
+++ b/jobs/pool/src/etl/steer/load.ts
@@ -16,8 +16,23 @@ export async function upsertVaults(vaults: Prisma.SteerVaultCreateManyInput[]) {
       },
     })
   ).map((token) => token.id)
+
+  const vaultPools = vaults.map((vault) => vault.poolId)
+  const dbPools = (
+    await client.sushiPool.findMany({
+      select: {
+        id: true,
+      },
+      where: {
+        id: {
+          in: vaultPools,
+        },
+      },
+    })
+  ).map((pool) => pool.id)
+
   const vaultsToUpdate = vaults.filter(
-    (vault) => dbTokens.includes(vault.token0Id) && dbTokens.includes(vault.token1Id)
+    (vault) => dbTokens.includes(vault.token0Id) && dbTokens.includes(vault.token1Id) && dbPools.includes(vault.poolId)
   )
 
   if (vaultsToUpdate.length === 0) return

--- a/jobs/pool/src/etl/steer/load.ts
+++ b/jobs/pool/src/etl/steer/load.ts
@@ -1,0 +1,163 @@
+import { createClient, Prisma } from '@sushiswap/database'
+
+export async function upsertVaults(vaults: Prisma.SteerVaultCreateManyInput[]) {
+  if (vaults.length === 0) return
+  const client = await createClient()
+
+  const query = Prisma.sql`
+    UPDATE SteerVault
+    SET
+      poolId = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.poolId}`),
+          ' '
+        )}
+        ELSE poolId
+      END,
+      feeTier = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.feeTier}`),
+          ' '
+        )}
+        ELSE feeTier
+      END,
+      apr = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr}`),
+          ' '
+        )}
+        ELSE apr
+      END,
+      apr1d = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr1d}`),
+          ' '
+        )}
+        ELSE apr1d
+      END,
+      apr1m = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr1m}`),
+          ' '
+        )}
+        ELSE apr1m
+      END,
+      apr1y = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.apr1y}`),
+          ' '
+        )}
+        ELSE apr1y
+      END,
+      token0Id = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.token0Id}`),
+          ' '
+        )}
+        ELSE token0Id
+      END,
+      reserve0 = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.reserve0}`),
+          ' '
+        )}
+        ELSE reserve0
+      END,
+      fees0 = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.fees0}`),
+          ' '
+        )}
+        ELSE fees0
+      END,
+      token1Id = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.token1Id}`),
+          ' '
+        )}
+        ELSE token1Id
+      END,
+      reserve1 = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.reserve1}`),
+          ' '
+        )}
+        ELSE reserve1
+      END,
+      fees1 = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.fees1}`),
+          ' '
+        )}
+        ELSE fees1
+      END,
+      strategy = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.strategy}`),
+          ' '
+        )}
+        ELSE strategy
+      END,
+      description = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.description}`),
+          ' '
+        )}
+        ELSE description
+      END,
+      state = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.state}`),
+          ' '
+        )}
+        ELSE state
+      END,
+      performanceFee = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.performanceFee}`),
+          ' '
+        )}
+        ELSE performanceFee
+      END,
+      lowerTick = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.lowerTick}`),
+          ' '
+        )}
+        ELSE lowerTick
+      END,
+      upperTick = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.upperTick}`),
+          ' '
+        )}
+        ELSE upperTick
+      END,
+      adjustmentFrequency = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.adjustmentFrequency}`),
+          ' '
+        )}
+        ELSE adjustmentFrequency
+      END,
+      lastAdjustmentTimestamp = CASE
+        ${Prisma.join(
+          vaults.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.lastAdjustmentTimestamp}`),
+          ' '
+        )}
+        ELSE lastAdjustmentTimestamp
+      END,
+      updatedAt = NOW()
+    WHERE id IN (${Prisma.join(vaults.map((update) => Prisma.sql`${update.id}`))});
+  `
+
+  const [updated, created] = await Promise.all([
+    vaults.length ? client.$executeRaw`${query}` : Promise.resolve(0),
+    client.steerVault.createMany({
+      data: vaults,
+      skipDuplicates: true,
+    }),
+  ])
+
+  console.log(`LOAD - Updated ${updated} and created ${created.count} vaults. `)
+}

--- a/jobs/pool/src/server.ts
+++ b/jobs/pool/src/server.ts
@@ -7,6 +7,7 @@ import { execute as incentives } from './incentives.js'
 import { execute as merklIncentives } from './merkl-incentives.js'
 import { execute as pools } from './pools.js'
 import { prices } from './price.js'
+import { steer } from './steer.js'
 
 const app = express()
 
@@ -69,6 +70,20 @@ app.get(
     req.setTimeout(600_000)
     try {
       await prices()
+      res.sendStatus(200)
+    } catch (err) {
+      res.status(500).send(err)
+    }
+  },
+  timeout('600s')
+)
+
+app.get(
+  '/steer',
+  async (req, res) => {
+    req.setTimeout(600_000)
+    try {
+      await steer()
       res.sendStatus(200)
     } catch (err) {
       res.status(500).send(err)

--- a/jobs/pool/src/steer.ts
+++ b/jobs/pool/src/steer.ts
@@ -1,0 +1,129 @@
+import { Prisma, SteerStrategy, VaultState } from '@sushiswap/database'
+import { STEER_ENABLED_NETWORKS, STEER_SUBGRAPGH_NAME, SteerChainId, SUBGRAPH_HOST } from '@sushiswap/graph-config'
+import { isPromiseFulfilled } from '@sushiswap/validate'
+
+import { getBuiltGraphSDK } from '../.graphclient/index.js'
+import { upsertVaults } from './etl/steer/load.js'
+
+export async function steer() {
+  // const client = new PrismaClient()
+  try {
+    const startTime = performance.now()
+    const chainsWithVaults = await extract()
+
+    const transformed = transform(chainsWithVaults)
+
+    await upsertVaults(transformed)
+
+    const endTime = performance.now()
+    console.log(`COMPLETE - Script ran for ${((endTime - startTime) / 1000).toFixed(1)} seconds. `)
+  } catch (e) {
+    console.error(e)
+    // await client.$disconnect()
+  } finally {
+    // await client.$disconnect()
+  }
+}
+
+interface Payload {
+  strategyConfigData: {
+    period: number
+    standardDeviations: number
+    poolFee: number
+    epochStart: number
+    epochLength: string
+    name: string
+    description: string
+    appImgUrl: string
+  }
+  vaultPayload: {
+    fee: number
+    slippage: number
+    ratioErrorTolerance: number
+    maxTicksChange: number
+    twapInterval: number
+  }
+}
+
+async function getPayload(ipfsHash: string): Promise<Payload> {
+  const response = await fetch(`https://ipfs.io/ipfs/${ipfsHash}`)
+  return response.json()
+}
+
+async function extractChain(chainId: SteerChainId) {
+  const sdk = getBuiltGraphSDK({ host: SUBGRAPH_HOST[chainId], name: STEER_SUBGRAPGH_NAME[chainId] })
+
+  const { vaults } = await sdk.SteerVaults()
+  const vaultsWithPayloads = await Promise.all(
+    vaults.map(async (vault) => {
+      const payload = await getPayload(vault.payloadIpfs)
+      return { ...vault, payload }
+    })
+  )
+
+  return { chainId, vaults: vaultsWithPayloads }
+}
+
+async function extract() {
+  const result = await Promise.allSettled(STEER_ENABLED_NETWORKS.map(extractChain))
+  return result.filter(isPromiseFulfilled).map((r) => r.value)
+}
+
+const StrategyTypes: Record<string, SteerStrategy> = {
+  'Classic Rebalance Strategy': SteerStrategy.ClassicRebalance,
+  'Delta Neutral - Stables': SteerStrategy.DeltaNeutralStables,
+  'Elastic Expansion Strategy': SteerStrategy.ElasticExpansion,
+  'High Low Channel Strategy': SteerStrategy.HighLowChannel,
+  'Moving Volatility Channel Strategy - Medium': SteerStrategy.MovingVolatilityChannelMedium,
+  'Static Stable Strategy': SteerStrategy.StaticStable,
+}
+
+function transform(chainsWithVaults: Awaited<ReturnType<typeof extract>>): Prisma.SteerVaultCreateManyInput[] {
+  return chainsWithVaults.flatMap(({ chainId, vaults }) =>
+    vaults.flatMap((vault) => {
+      const lowestTick = vault.positions.reduce(
+        (lowest, position) => (Number(position.lowerTick) < lowest ? Number(position.lowerTick) : lowest),
+        0
+      )
+      const highestTick = vault.positions.reduce(
+        (highest, position) => (Number(position.upperTick) > highest ? Number(position.upperTick) : highest),
+        0
+      )
+
+      // ! Missing strategies will be ignored
+      const strategyType = StrategyTypes[vault.payload.strategyConfigData.name]
+      if (!strategyType) return []
+
+      return {
+        id: `${chainId}:${vault.id}`,
+        poolId: `${chainId}:${vault.pool}`,
+        feeTier: Number(vault.feeTier) / 1000000,
+
+        apr: Number(vault.annualFeeARR),
+        apr1d: Number(vault.annualPercentageDailyYield),
+        apr1m: Number(vault.annualPercentageMonthlyYield),
+        apr1y: Number(vault.annualPercentageYearlyYield),
+
+        token0Id: vault.token0,
+        reserve0: vault.reserve0 as string,
+        fees0: vault.fees0 as string,
+
+        token1Id: vault.token1,
+        reserve1: vault.reserve1 as string,
+        fees1: vault.fees1 as string,
+
+        strategy: strategyType,
+        description: vault.payload.strategyConfigData.description,
+        state: Object.values(VaultState)[vault.state],
+
+        performanceFee: 0.15, // currently constant
+
+        lowerTick: lowestTick,
+        upperTick: highestTick,
+
+        adjustmentFrequency: Number(vault.payload.strategyConfigData.epochLength),
+        lastAdjustmentTimestamp: Math.floor(vault.payload.strategyConfigData.epochStart),
+      }
+    })
+  )
+}

--- a/jobs/pool/src/steer.ts
+++ b/jobs/pool/src/steer.ts
@@ -6,7 +6,6 @@ import { getBuiltGraphSDK } from '../.graphclient/index.js'
 import { upsertVaults } from './etl/steer/load.js'
 
 export async function steer() {
-  // const client = new PrismaClient()
   try {
     const startTime = performance.now()
     const chainsWithVaults = await extract()
@@ -19,9 +18,6 @@ export async function steer() {
     console.log(`COMPLETE - Script ran for ${((endTime - startTime) / 1000).toFixed(1)} seconds. `)
   } catch (e) {
     console.error(e)
-    // await client.$disconnect()
-  } finally {
-    // await client.$disconnect()
   }
 }
 
@@ -95,8 +91,8 @@ function transform(chainsWithVaults: Awaited<ReturnType<typeof extract>>): Prism
       if (!strategyType) return []
 
       return {
-        id: `${chainId}:${vault.id}`,
-        poolId: `${chainId}:${vault.pool}`,
+        id: `${chainId}:${vault.id}`.toLowerCase(),
+        poolId: `${chainId}:${vault.pool}`.toLowerCase(),
         feeTier: Number(vault.feeTier) / 1000000,
 
         apr: Number(vault.annualFeeARR),
@@ -104,11 +100,11 @@ function transform(chainsWithVaults: Awaited<ReturnType<typeof extract>>): Prism
         apr1m: Number(vault.annualPercentageMonthlyYield),
         apr1y: Number(vault.annualPercentageYearlyYield),
 
-        token0Id: vault.token0,
+        token0Id: `${chainId}:${vault.token0}`.toLowerCase(),
         reserve0: vault.reserve0 as string,
         fees0: vault.fees0 as string,
 
-        token1Id: vault.token1,
+        token1Id: `${chainId}:${vault.token1}`.toLowerCase(),
         reserve1: vault.reserve1 as string,
         fees1: vault.fees1 as string,
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -27,7 +27,7 @@
     "check": "tsc --pretty --noEmit",
     "clean": "rm -rf .turbo node_modules dist",
     "dev": "tsc -w",
-    "generate": "prisma generate --data-proxy",
+    "generate": "prisma generate",
     "lint": "TIMING=1 eslint src",
     "lint:fix": "TIMING=1 eslint src --fix",
     "prepublishOnly": "pnpm build",

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -52,11 +52,13 @@ model Token {
   generatedAt DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  pools0      Pool[]      @relation("token0")
-  pools1      Pool[]      @relation("token1")
-  sushiPools0 SushiPool[] @relation("token0")
-  sushiPools1 SushiPool[] @relation("token1")
-  incentives  Incentive[]
+  pools0        Pool[]      @relation("token0")
+  pools1        Pool[]      @relation("token1")
+  sushiPools0   SushiPool[] @relation("token0")
+  sushiPools1   SushiPool[] @relation("token1")
+  steerVaults0  SteerVault[] @relation("token0")
+  steerVaults1  SteerVault[] @relation("token1")
+  incentives    Incentive[]
 
   @@unique([chainId, address])
   @@index(fields: [id])
@@ -166,6 +168,9 @@ model SushiPool {
   wasIncentivized Boolean     @default(false)
   incentives      Incentive[]
 
+  hasSteerVault        Boolean @default(false)
+  steerVaults          SteerVault[]
+
   createdAtBlockNumber BigInt   @db.UnsignedBigInt
   isBlacklisted        Boolean  @default(false)
   generatedAt          DateTime @default(now())
@@ -201,4 +206,64 @@ model Incentive {
   @@index(fields: [poolId])
   @@index(fields: [rewardTokenId])
   @@index(fields: [chainId, rewardTokenId])
+}
+
+enum SteerStrategy {
+  DeltaNeutralStables
+  ElasticExpansion
+  MovingVolatilityChannelMedium
+  HighLowChannel
+  StaticStable
+  ClassicRebalance
+}
+
+enum VaultState {
+  PendingApproval
+  PendingThreshold
+  Paused
+  Active
+  Retired
+}
+
+model SteerVault {
+  id                      String      @id // chainId:address
+  
+  pool                    SushiPool   @relation(fields: [poolId], references: [id])
+  poolId                  String
+  feeTier                 Float
+  
+  apr                     Float
+  apr1d                   Float
+  apr1m                   Float
+  apr1y                   Float
+
+  token0                  Token       @relation("token0", fields: [token0Id], references: [id])
+  token0Id                String
+  reserve0                String
+  fees0                   String
+
+  token1                  Token       @relation("token1", fields: [token1Id], references: [id])
+  token1Id                String 
+  reserve1                String
+  fees1                   String
+
+  strategy                SteerStrategy
+  description             String @db.Text
+  state                   VaultState
+
+  performanceFee          Float
+
+  lowerTick               Int
+  upperTick               Int
+
+  adjustmentFrequency     Int
+  lastAdjustmentTimestamp Int
+
+  generatedAt             DateTime @default(now())
+  updatedAt               DateTime    @updatedAt
+
+  @@index(fields: [id])
+  @@index(fields: [poolId])
+  @@index(fields: [token0Id])
+  @@index(fields: [token1Id])
 }


### PR DESCRIPTION
can only merge after schemas get merged on planetscale

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding support for Steer Vaults to the codebase.

### Detailed summary:
- Added `steer` module to handle Steer Vaults functionality.
- Added `getPayload` function to fetch payload data from IPFS.
- Added `extractChain` function to extract Steer Vaults data from the subgraph.
- Added `extract` function to extract Steer Vaults data from multiple chains.
- Added `transform` function to transform extracted data into the required format.
- Updated `steer` module to handle the extraction and transformation of Steer Vaults data.
- Updated `server.ts` to include a new route for Steer Vaults.
- Updated `query.graphql` to include a new query for Steer Vaults.
- Updated `load.ts` to include support for updating Steer Vaults data in the database.
- Updated `schema.prisma` to include the `SteerVault` model.
- Updated `index.ts` to include constants and configurations related to Steer Vaults.
- Updated `package.json` to modify the `generate` script for Prisma.
- Updated `.graphclientrc.yml` to include a new endpoint for Steer Vaults.
- Updated `config/graph/src/index.ts` to include the `SUSHI_HOST` constant.
- Updated `.gitignore` to ignore `.graphclient` directory.
- Added necessary imports and dependencies for Steer Vaults functionality.

> The following files were skipped due to too many changes: `jobs/pool/src/steer.ts`, `jobs/pool/src/etl/steer/load.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->