### PR TITLE
fix(apps/landing): show "-" instead of 0

### DIFF
--- a/apps/evm/app/(landing)/api/stats/route.ts
+++ b/apps/evm/app/(landing)/api/stats/route.ts
@@ -113,25 +113,25 @@ export async function GET() {
   return NextResponse.json({
     stats: {
       price: {
-        formatted: formatUSD(sushiPrice),
+        formatted: !sushiPrice ? '-' : formatUSD(sushiPrice),
         number: Number(sushiPrice),
         title: '$SUSHI Price',
         decimalPlaces: 2,
       },
       liquidity: {
-        formatted: formatUSD(totalTVL),
+        formatted: !totalTVL ? '-' : formatUSD(totalTVL),
         number: totalTVL,
         title: 'Total Liquidity',
         decimalPlaces: 0,
       },
       volume: {
-        formatted: formatUSD(totalVolume),
+        formatted: !totalVolume ? '-' : formatUSD(totalVolume),
         number: totalVolume,
         title: 'Total Volume',
         decimalPlaces: 0,
       },
       pairs: {
-        formatted: formatNumber(totalPoolCount),
+        formatted: !totalPoolCount ? '-' : formatNumber(totalPoolCount),
         number: totalPoolCount,
         title: 'Total Pairs',
         decimalPlaces: 0,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the formatting of certain values in the `stats` object to display a dash (`-`) when the value is not available.

### Detailed summary:
- Updated the `formatted` property of the `price`, `liquidity`, `volume`, and `pairs` objects in the `stats` object to display a dash (`-`) when the corresponding value is not available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->