### PR TITLE
steer backend - was/isEnabled

### DIFF
--- a/jobs/pool/query.graphql
+++ b/jobs/pool/query.graphql
@@ -310,6 +310,11 @@ query SteerVaults($first: Int = 1000, $skip: Int = 0) {
       id
       executionBundle
       name # "Elastic Expansion Strategy"
+
+      creator {
+        id
+      }
+      admin
     #   # creator: {
     #   #     id
     #   # }
@@ -328,5 +333,7 @@ query SteerVaults($first: Int = 1000, $skip: Int = 0) {
     token1
     fees0
     fees1
+
+    manager: vaultManager
   }
 }

--- a/jobs/pool/src/etl/steer/load.ts
+++ b/jobs/pool/src/etl/steer/load.ts
@@ -180,6 +180,27 @@ export async function upsertVaults(vaults: Prisma.SteerVaultCreateManyInput[]) {
         )}
         ELSE lastAdjustmentTimestamp
       END,
+      creator = CASE
+        ${Prisma.join(
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.creator}`),
+          ' '
+        )}
+        ELSE creator
+      END,
+      admin = CASE
+        ${Prisma.join(
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.admin}`),
+          ' '
+        )}
+        ELSE admin
+      END,
+      manager = CASE
+        ${Prisma.join(
+          vaultsToUpdate.map((update) => Prisma.sql`WHEN id = ${update.id} THEN ${update.manager}`),
+          ' '
+        )}
+        ELSE manager
+      END,
       updatedAt = NOW()
     WHERE id IN (${Prisma.join(vaultsToUpdate.map((update) => Prisma.sql`${update.id}`))});
   `

--- a/jobs/pool/src/etl/steer/load.ts
+++ b/jobs/pool/src/etl/steer/load.ts
@@ -192,5 +192,26 @@ export async function upsertVaults(vaults: Prisma.SteerVaultCreateManyInput[]) {
     }),
   ])
 
+  const currentVaults = await client.steerVault.findMany({
+    select: {
+      id: true,
+    },
+    where: {
+      isEnabled: true,
+      wasEnabled: false,
+    },
+  })
+
+  await client.steerVault.updateMany({
+    where: {
+      id: { in: currentVaults.map((vault) => vault.id) },
+    },
+    data: {
+      wasEnabled: true,
+    },
+  })
+
+  await client.$disconnect()
+
   console.log(`LOAD - Updated ${updated} and created ${created.count} vaults. `)
 }

--- a/jobs/pool/src/steer.ts
+++ b/jobs/pool/src/steer.ts
@@ -125,7 +125,11 @@ function transform(chainsWithVaults: Awaited<ReturnType<typeof extract>>): Prism
 
         adjustmentFrequency: Number(vault.payload.strategyConfigData.epochLength),
         lastAdjustmentTimestamp: Math.floor(vault.payload.strategyConfigData.epochStart),
-      }
+
+        admin: vault.strategyToken.admin,
+        creator: vault.strategyToken.creator.id,
+        manager: vault.manager,
+      } satisfies Prisma.SteerVaultCreateManyInput
     })
   )
 }

--- a/jobs/pool/src/steer.ts
+++ b/jobs/pool/src/steer.ts
@@ -3,6 +3,7 @@ import { STEER_ENABLED_NETWORKS, STEER_SUBGRAPGH_NAME, SteerChainId, SUBGRAPH_HO
 import { isPromiseFulfilled } from '@sushiswap/validate'
 
 import { getBuiltGraphSDK } from '../.graphclient/index.js'
+import { updatePoolsWithSteerVaults } from './etl/pool/load.js'
 import { upsertVaults } from './etl/steer/load.js'
 
 export async function steer() {
@@ -13,6 +14,7 @@ export async function steer() {
     const transformed = transform(chainsWithVaults)
 
     await upsertVaults(transformed)
+    await updatePoolsWithSteerVaults()
 
     const endTime = performance.now()
     console.log(`COMPLETE - Script ran for ${((endTime - startTime) / 1000).toFixed(1)} seconds. `)

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -168,8 +168,9 @@ model SushiPool {
   wasIncentivized Boolean     @default(false)
   incentives      Incentive[]
 
-  hasSteerVault        Boolean @default(false)
-  steerVaults          SteerVault[]
+  hasEnabledSteerVault  Boolean @default(false)
+  hadEnabledSteerVault  Boolean @default(false)
+  steerVaults           SteerVault[]
 
   createdAtBlockNumber BigInt   @db.UnsignedBigInt
   isBlacklisted        Boolean  @default(false)
@@ -258,6 +259,9 @@ model SteerVault {
 
   adjustmentFrequency     Int
   lastAdjustmentTimestamp Int
+
+  isEnabled               Boolean @default(false)
+  wasEnabled              Boolean @default(false)
 
   generatedAt             DateTime @default(now())
   updatedAt               DateTime    @updatedAt

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -263,6 +263,10 @@ model SteerVault {
   isEnabled               Boolean @default(false)
   wasEnabled              Boolean @default(false)
 
+  creator                 String
+  admin                   String
+  manager                 String
+
   generatedAt             DateTime @default(now())
   updatedAt               DateTime    @updatedAt
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `creator` and `admin` fields to the `SteerVault` GraphQL query.
- Added `isEnabled`, `wasEnabled`, `creator`, `admin`, and `manager` fields to the `SteerVault` Prisma model.
- Added `updatePoolsWithSteerVaults` function to update pools with steer vaults.
- Added `creator`, `admin`, and `manager` fields to the `transform` function.
- Added `updatePoolsWithSteerVaults` function to the `steer` function.
- Added `updatePoolsWithSteerVaults` function to the `load` module.
- Added `creator`, `admin`, and `manager` fields to the `load` module.
- Added `currentVaults` query and update logic to the `upsertVaults` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->