### PR TITLE
EGN-546 - set correct log after a trade has been made

### DIFF
--- a/apps/evm/ui/swap/ConfirmationDialog.tsx
+++ b/apps/evm/ui/swap/ConfirmationDialog.tsx
@@ -207,6 +207,12 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ children }) =>
   } = useContractWrite({
     ...config,
     ...(config.request && { request: { ...config.request, gasLimit: config.request.gasLimit.mul(120).div(100) } }),
+    onMutate: () => {
+      // Set reference of current trade
+      if (tradeRef && trade) {
+        tradeRef.current = trade
+      }
+    },
     onSuccess: async (data) => {
       setReview(false)
 
@@ -378,11 +384,6 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ children }) =>
     if (dialogState === ConfirmationDialogState.Pending) {
       setOpen(true)
     } else if (review) {
-      // Set reference of current trade
-      if (tradeRef && trade) {
-        tradeRef.current = trade
-      }
-
       const promise = writeAsync?.()
       if (promise) {
         promise
@@ -398,7 +399,7 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ children }) =>
     } else {
       setReview(true)
     }
-  }, [dialogState, onComplete, review, setReview, trade, writeAsync])
+  }, [dialogState, onComplete, review, setReview, writeAsync])
 
   return (
     <>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the ConfirmationDialog component in the EVM UI swap feature. 

### Detailed summary
- Imported `UseTradeReturn` from `@sushiswap/react-query`
- Added `tradeRef` useRef to store the current trade
- Added `onMutate` function to set the reference of the current trade in `tradeRef`
- Updated `onSuccess` function to retrieve the current trade from `tradeRef`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->