### PR TITLE
fix(jobs/pool): add steer prefix

### DIFF
--- a/jobs/pool/.graphclientrc.yml
+++ b/jobs/pool/.graphclientrc.yml
@@ -63,6 +63,11 @@ sources:
       graphql:
         endpoint: https://{context.host:api.thegraph.com/subgraphs/name}/{context.name:steerprotocol/steer-protocol-polygon}
         retry: 3
+    transforms:
+      - prefix:
+          value: Steer_
+          includeRootOperations: true
+          includeTypes: true
 
 additionalTypeDefs: |
   # Type Extensions

--- a/jobs/pool/query.graphql
+++ b/jobs/pool/query.graphql
@@ -298,7 +298,7 @@ query CurrentBlock($first: Int = 1000, $skip: Int = 0) {
 }
 
 query SteerVaults($first: Int = 1000, $skip: Int = 0) {
-  Steer_vaults(first: $first, skip: $skip) {
+  vaults: Steer_vaults(first: $first, skip: $skip) {
     id
     feeTier
     reserve0: totalAmount0

--- a/jobs/pool/query.graphql
+++ b/jobs/pool/query.graphql
@@ -298,7 +298,7 @@ query CurrentBlock($first: Int = 1000, $skip: Int = 0) {
 }
 
 query SteerVaults($first: Int = 1000, $skip: Int = 0) {
-  vaults(first: $first, skip: $skip) {
+  Steer_vaults(first: $first, skip: $skip) {
     id
     feeTier
     reserve0: totalAmount0

--- a/jobs/pool/src/steer.ts
+++ b/jobs/pool/src/steer.ts
@@ -51,7 +51,7 @@ async function getPayload(ipfsHash: string): Promise<Payload> {
 async function extractChain(chainId: SteerChainId) {
   const sdk = getBuiltGraphSDK({ host: SUBGRAPH_HOST[chainId], name: STEER_SUBGRAPGH_NAME[chainId] })
 
-  const { Steer_vaults: vaults } = await sdk.SteerVaults()
+  const { vaults } = await sdk.SteerVaults()
   const vaultsWithPayloads = await Promise.allSettled(
     vaults.map(async (vault) => {
       try {

--- a/jobs/pool/src/steer.ts
+++ b/jobs/pool/src/steer.ts
@@ -51,7 +51,7 @@ async function getPayload(ipfsHash: string): Promise<Payload> {
 async function extractChain(chainId: SteerChainId) {
   const sdk = getBuiltGraphSDK({ host: SUBGRAPH_HOST[chainId], name: STEER_SUBGRAPGH_NAME[chainId] })
 
-  const { vaults } = await sdk.SteerVaults()
+  const { Steer_vaults: vaults } = await sdk.SteerVaults()
   const vaultsWithPayloads = await Promise.allSettled(
     vaults.map(async (vault) => {
       try {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the GraphQL query and configuration files in the `jobs/pool` directory.

### Detailed summary:
- In the `jobs/pool/query.graphql` file:
  - The `vaults` query is updated to `Steer_vaults` query.
  - The `reserve0` field is renamed to `totalAmount0`.

- In the `jobs/pool/.graphclientrc.yml` file:
  - A new `transforms` section is added.
  - A `prefix` transform is added with the value `Steer_`.
  - The `includeRootOperations` and `includeTypes` options are set to `true`.

- A new `additionalTypeDefs` section is added with some comment text.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->