### PR TITLE
fix: stupid default

### DIFF
--- a/apps/evm/app/pool/add/page.tsx
+++ b/apps/evm/app/pool/add/page.tsx
@@ -15,6 +15,7 @@ import { computePoolAddress } from '@sushiswap/v3-sdk'
 import { useAccount } from '@sushiswap/wagmi'
 import { useConcentratedLiquidityPool, useConcentratedPositionInfo } from '@sushiswap/wagmi/future/hooks'
 import { getV3FactoryContractConfig } from '@sushiswap/wagmi/future/hooks/contracts/useV3FactoryContract'
+import { SUPPORTED_CHAIN_IDS } from 'config'
 import { useTokenAmountDollarValues } from 'lib/hooks'
 import Link from 'next/link'
 import React, { FC, useMemo, useState } from 'react'
@@ -193,7 +194,7 @@ const _Add: FC = () => {
         </div>
       </div>
       <div className="flex flex-col order-3 gap-[64px]  pb-40 sm:order-2">
-        <SelectNetworkWidget selectedNetwork={chainId} onSelect={setNetwork} />
+        <SelectNetworkWidget selectedNetwork={chainId} onSelect={setNetwork} networks={SUPPORTED_CHAIN_IDS} />
         <SelectTokensWidget
           chainId={chainId}
           token0={token0}

--- a/apps/evm/ui/pool/NewPositionSection/SelectNetworkWidget.tsx
+++ b/apps/evm/ui/pool/NewPositionSection/SelectNetworkWidget.tsx
@@ -3,13 +3,12 @@ import { NetworkSelector } from '@sushiswap/ui'
 import { Button } from '@sushiswap/ui/components/button'
 import { NetworkIcon } from '@sushiswap/ui/components/icons'
 import { SelectIcon } from '@sushiswap/ui/components/select'
-import { SUSHISWAP_V3_SUPPORTED_CHAIN_IDS } from '@sushiswap/v3-sdk'
 import React, { FC, memo } from 'react'
 
 import { ContentBlock } from '../AddPage/ContentBlock'
 
 interface SelectNetworkWidgetProps {
-  networks?: ChainId[]
+  networks: ChainId[]
   selectedNetwork: ChainId
   onSelect(chainId: ChainId): void
 }
@@ -28,11 +27,7 @@ export const SelectNetworkWidget: FC<SelectNetworkWidgetProps> = memo(function S
       }
     >
       <div className="flex relative z-[100]">
-        <NetworkSelector
-          networks={networks ?? SUSHISWAP_V3_SUPPORTED_CHAIN_IDS}
-          selected={selectedNetwork}
-          onSelect={onSelect}
-        >
+        <NetworkSelector networks={networks} selected={selectedNetwork} onSelect={onSelect}>
           <Button variant="secondary" className="!font-medium">
             <NetworkIcon chainId={selectedNetwork} width={16} height={16} />
             {chainName?.[selectedNetwork]}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added import for `SUPPORTED_CHAIN_IDS` from 'config' in `apps/evm/app/pool/add/page.tsx`
- Removed import for `SUSHISWAP_V3_SUPPORTED_CHAIN_IDS` from '@sushiswap/v3-sdk' in `apps/evm/ui/pool/NewPositionSection/SelectNetworkWidget.tsx`
- Changed the prop type of `networks` in `SelectNetworkWidgetProps` to be required and of type `ChainId[]`
- Updated the usage of `SelectNetworkWidget` in `apps/evm/app/pool/add/page.tsx` by passing `networks={SUPPORTED_CHAIN_IDS}` to the component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->