### PR TITLE
fix: apr

### DIFF
--- a/jobs/pool/src/pools.ts
+++ b/jobs/pool/src/pools.ts
@@ -481,34 +481,34 @@ function transformLegacyOrTrident(queryResult: { chainId: ChainId; data: V2Data 
           throw new Error('Unknown pool type')
         }
 
+        const currentVolumeUSD = Number(pair.volumeUSD)
+        const currentLiquidityUSD = Number(pair.liquidityUSD)
+        const currentFeesUSD = Number(pair.feesUSD)
+
         const feeApr1h = calculateFeeApr(
           AprTimeRange.ONE_HOUR,
-          oneHourData.get(pair.id)?.feesUSD ?? 0,
+          oneHourData.get(pair.id)?.feesUSD ?? currentFeesUSD,
           pair.feesUSD,
           pair.liquidityUSD
         )
         const feeApr1d = calculateFeeApr(
           AprTimeRange.ONE_DAY,
-          oneDayData.get(pair.id)?.feesUSD ?? 0,
+          oneDayData.get(pair.id)?.feesUSD ?? currentFeesUSD,
           pair.feesUSD,
           pair.liquidityUSD
         )
         const feeApr1w = calculateFeeApr(
           AprTimeRange.ONE_WEEK,
-          oneWeekData.get(pair.id)?.feesUSD ?? 0,
+          oneWeekData.get(pair.id)?.feesUSD ?? currentFeesUSD,
           pair.feesUSD,
           pair.liquidityUSD
         )
         const feeApr1m = calculateFeeApr(
           AprTimeRange.ONE_MONTH,
-          oneMonthData.get(pair.id)?.feesUSD ?? 0,
+          oneMonthData.get(pair.id)?.feesUSD ?? currentFeesUSD,
           pair.feesUSD,
           pair.liquidityUSD
         )
-
-        const currentVolumeUSD = Number(pair.volumeUSD)
-        const currentLiquidityUSD = Number(pair.liquidityUSD)
-        const currentFeesUSD = Number(pair.feesUSD)
 
         const fees1h = oneHourData.has(pair.id) ? currentFeesUSD - oneHourData.get(pair.id).feesUSD : currentFeesUSD
         const fees1d = oneDayData.has(pair.id) ? currentFeesUSD - oneDayData.get(pair.id).feesUSD : currentFeesUSD


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on calculating fee APR based on different time ranges. 

### Detailed summary
- Added variables `currentVolumeUSD`, `currentLiquidityUSD`, and `currentFeesUSD` to store the current values of volume, liquidity, and fees in USD.
- Modified the calculation of `feeApr1h`, `feeApr1d`, `feeApr1w`, and `feeApr1m` to include the current fees if available.
- Removed the redundant assignment of `currentVolumeUSD`, `currentLiquidityUSD`, and `currentFeesUSD`.
- Modified the calculation of `fees1h`, `fees1d`, and `fees1w` to calculate the difference between the current fees and the fees from previous data if available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->