### PR TITLE
first 24h apr

### DIFF
--- a/apps/evm/ui/pool/PoolsSection/Tables/SharedCells/PoolAPRCell.tsx
+++ b/apps/evm/ui/pool/PoolsSection/Tables/SharedCells/PoolAPRCell.tsx
@@ -4,10 +4,10 @@ import { FC } from 'react'
 
 import { Row } from './types'
 
-export const PoolAPRCell: FC<Row<{ totalApr1d: number; incentives: Pool['incentives'] }>> = ({ row }) => {
+export const PoolAPRCell: FC<Row<{ totalApr1h: number; incentives: Pool['incentives'] }>> = ({ row }) => {
   return (
     <span className="flex items-center justify-end gap-1 text-sm text-gray-900 dark:text-slate-50">
-      {formatPercent(row.totalApr1d)}
+      {formatPercent(row.totalApr1h)}
     </span>
   )
 }

--- a/jobs/pool/src/pools.ts
+++ b/jobs/pool/src/pools.ts
@@ -485,35 +485,16 @@ function transformLegacyOrTrident(queryResult: { chainId: ChainId; data: V2Data 
         const currentLiquidityUSD = Number(pair.liquidityUSD)
         const currentFeesUSD = Number(pair.feesUSD)
 
-        const feeApr1h = calculateFeeApr(
-          AprTimeRange.ONE_HOUR,
-          oneHourData.get(pair.id)?.feesUSD ?? currentFeesUSD,
-          pair.feesUSD,
-          pair.liquidityUSD
-        )
-        const feeApr1d = calculateFeeApr(
-          AprTimeRange.ONE_DAY,
-          oneDayData.get(pair.id)?.feesUSD ?? currentFeesUSD,
-          pair.feesUSD,
-          pair.liquidityUSD
-        )
-        const feeApr1w = calculateFeeApr(
-          AprTimeRange.ONE_WEEK,
-          oneWeekData.get(pair.id)?.feesUSD ?? currentFeesUSD,
-          pair.feesUSD,
-          pair.liquidityUSD
-        )
-        const feeApr1m = calculateFeeApr(
-          AprTimeRange.ONE_MONTH,
-          oneMonthData.get(pair.id)?.feesUSD ?? currentFeesUSD,
-          pair.feesUSD,
-          pair.liquidityUSD
-        )
-
         const fees1h = oneHourData.has(pair.id) ? currentFeesUSD - oneHourData.get(pair.id).feesUSD : currentFeesUSD
         const fees1d = oneDayData.has(pair.id) ? currentFeesUSD - oneDayData.get(pair.id).feesUSD : currentFeesUSD
         const fees1w = oneWeekData.has(pair.id) ? currentFeesUSD - oneWeekData.get(pair.id).feesUSD : currentFeesUSD
         const fees1m = oneMonthData.has(pair.id) ? currentFeesUSD - oneMonthData.get(pair.id).feesUSD : currentFeesUSD
+
+        const feeApr1h = calculateFeeApr(AprTimeRange.ONE_HOUR, fees1h, pair.feesUSD, pair.liquidityUSD)
+        const feeApr1d = calculateFeeApr(AprTimeRange.ONE_DAY, fees1d, pair.feesUSD, pair.liquidityUSD)
+        const feeApr1w = calculateFeeApr(AprTimeRange.ONE_WEEK, fees1w, pair.feesUSD, pair.liquidityUSD)
+        const feeApr1m = calculateFeeApr(AprTimeRange.ONE_MONTH, feeApr1m, pair.feesUSD, pair.liquidityUSD)
+
         const feesChange1h = calculatePercentageChange(
           currentFeesUSD,
           oneHourData.get(pair.id)?.feesUSD ?? 0,
@@ -770,35 +751,16 @@ function transformV3(queryResult: { chainId: ChainId; data: V3Data }) {
       const currentLiquidityUSD = Number(pair.totalValueLockedUSD)
       const currentFeesUSD = Number(pair.feesUSD)
 
-      const feeApr1h = calculateFeeApr(
-        AprTimeRange.ONE_HOUR,
-        oneHourData.get(pair.id)?.feesUSD ?? currentFeesUSD,
-        pair.feesUSD,
-        pair.totalValueLockedUSD
-      )
-      const feeApr1d = calculateFeeApr(
-        AprTimeRange.ONE_DAY,
-        oneDayData.get(pair.id)?.feesUSD ?? currentFeesUSD,
-        pair.feesUSD,
-        pair.totalValueLockedUSD
-      )
-      const feeApr1w = calculateFeeApr(
-        AprTimeRange.ONE_WEEK,
-        oneWeekData.get(pair.id)?.feesUSD ?? currentFeesUSD,
-        pair.feesUSD,
-        pair.totalValueLockedUSD
-      )
-      const feeApr1m = calculateFeeApr(
-        AprTimeRange.ONE_MONTH,
-        oneMonthData.get(pair.id)?.feesUSD ?? currentFeesUSD,
-        pair.feesUSD,
-        pair.totalValueLockedUSD
-      )
-
       const fees1h = oneHourData.has(pair.id) ? currentFeesUSD - oneHourData.get(pair.id).feesUSD : currentFeesUSD
       const fees1d = oneDayData.has(pair.id) ? currentFeesUSD - oneDayData.get(pair.id).feesUSD : currentFeesUSD
       const fees1w = oneWeekData.has(pair.id) ? currentFeesUSD - oneWeekData.get(pair.id).feesUSD : currentFeesUSD
       const fees1m = oneMonthData.has(pair.id) ? currentFeesUSD - oneMonthData.get(pair.id).feesUSD : currentFeesUSD
+
+      const feeApr1h = calculateFeeApr(AprTimeRange.ONE_HOUR, fees1h, pair.feesUSD, pair.totalValueLockedUSD)
+      const feeApr1d = calculateFeeApr(AprTimeRange.ONE_DAY, fees1d, pair.feesUSD, pair.totalValueLockedUSD)
+      const feeApr1w = calculateFeeApr(AprTimeRange.ONE_WEEK, fees1w, pair.feesUSD, pair.totalValueLockedUSD)
+      const feeApr1m = calculateFeeApr(AprTimeRange.ONE_MONTH, fees1m, pair.feesUSD, pair.totalValueLockedUSD)
+
       const feesChange1h = calculatePercentageChange(
         currentFeesUSD,
         oneHourData.get(pair.id)?.feesUSD ?? 0,

--- a/jobs/pool/src/pools.ts
+++ b/jobs/pool/src/pools.ts
@@ -493,7 +493,7 @@ function transformLegacyOrTrident(queryResult: { chainId: ChainId; data: V2Data 
         const feeApr1h = calculateFeeApr(AprTimeRange.ONE_HOUR, fees1h, pair.feesUSD, pair.liquidityUSD)
         const feeApr1d = calculateFeeApr(AprTimeRange.ONE_DAY, fees1d, pair.feesUSD, pair.liquidityUSD)
         const feeApr1w = calculateFeeApr(AprTimeRange.ONE_WEEK, fees1w, pair.feesUSD, pair.liquidityUSD)
-        const feeApr1m = calculateFeeApr(AprTimeRange.ONE_MONTH, feeApr1m, pair.feesUSD, pair.liquidityUSD)
+        const feeApr1m = calculateFeeApr(AprTimeRange.ONE_MONTH, fees1m, pair.feesUSD, pair.liquidityUSD)
 
         const feesChange1h = calculatePercentageChange(
           currentFeesUSD,

--- a/jobs/pool/src/pools.ts
+++ b/jobs/pool/src/pools.ts
@@ -481,6 +481,31 @@ function transformLegacyOrTrident(queryResult: { chainId: ChainId; data: V2Data 
           throw new Error('Unknown pool type')
         }
 
+        const feeApr1h = calculateFeeApr(
+          AprTimeRange.ONE_HOUR,
+          oneHourData.get(pair.id)?.feesUSD ?? 0,
+          pair.feesUSD,
+          pair.liquidityUSD
+        )
+        const feeApr1d = calculateFeeApr(
+          AprTimeRange.ONE_DAY,
+          oneDayData.get(pair.id)?.feesUSD ?? 0,
+          pair.feesUSD,
+          pair.liquidityUSD
+        )
+        const feeApr1w = calculateFeeApr(
+          AprTimeRange.ONE_WEEK,
+          oneWeekData.get(pair.id)?.feesUSD ?? 0,
+          pair.feesUSD,
+          pair.liquidityUSD
+        )
+        const feeApr1m = calculateFeeApr(
+          AprTimeRange.ONE_MONTH,
+          oneMonthData.get(pair.id)?.feesUSD ?? 0,
+          pair.feesUSD,
+          pair.liquidityUSD
+        )
+
         const currentVolumeUSD = Number(pair.volumeUSD)
         const currentLiquidityUSD = Number(pair.liquidityUSD)
         const currentFeesUSD = Number(pair.feesUSD)
@@ -489,12 +514,6 @@ function transformLegacyOrTrident(queryResult: { chainId: ChainId; data: V2Data 
         const fees1d = oneDayData.has(pair.id) ? currentFeesUSD - oneDayData.get(pair.id).feesUSD : currentFeesUSD
         const fees1w = oneWeekData.has(pair.id) ? currentFeesUSD - oneWeekData.get(pair.id).feesUSD : currentFeesUSD
         const fees1m = oneMonthData.has(pair.id) ? currentFeesUSD - oneMonthData.get(pair.id).feesUSD : currentFeesUSD
-
-        const feeApr1h = calculateFeeApr(AprTimeRange.ONE_HOUR, fees1h, pair.feesUSD, pair.liquidityUSD)
-        const feeApr1d = calculateFeeApr(AprTimeRange.ONE_DAY, fees1d, pair.feesUSD, pair.liquidityUSD)
-        const feeApr1w = calculateFeeApr(AprTimeRange.ONE_WEEK, fees1w, pair.feesUSD, pair.liquidityUSD)
-        const feeApr1m = calculateFeeApr(AprTimeRange.ONE_MONTH, fees1m, pair.feesUSD, pair.liquidityUSD)
-
         const feesChange1h = calculatePercentageChange(
           currentFeesUSD,
           oneHourData.get(pair.id)?.feesUSD ?? 0,
@@ -747,6 +766,30 @@ function transformV3(queryResult: { chainId: ChainId; data: V3Data }) {
         .concat(pair.token1.symbol.replace(regex, '').slice(0, 15))
       const swapFee = Number(pair.feeTier) / 1_000_000
 
+      const feeApr1h = calculateFeeApr(
+        AprTimeRange.ONE_HOUR,
+        oneHourData.get(pair.id)?.feesUSD ?? 0,
+        pair.feesUSD,
+        pair.totalValueLockedUSD
+      )
+      const feeApr1d = calculateFeeApr(
+        AprTimeRange.ONE_DAY,
+        oneDayData.get(pair.id)?.feesUSD ?? 0,
+        pair.feesUSD,
+        pair.totalValueLockedUSD
+      )
+      const feeApr1w = calculateFeeApr(
+        AprTimeRange.ONE_WEEK,
+        oneWeekData.get(pair.id)?.feesUSD ?? 0,
+        pair.feesUSD,
+        pair.totalValueLockedUSD
+      )
+      const feeApr1m = calculateFeeApr(
+        AprTimeRange.ONE_MONTH,
+        oneMonthData.get(pair.id)?.feesUSD ?? 0,
+        pair.feesUSD,
+        pair.totalValueLockedUSD
+      )
       const currentVolumeUSD = Number(pair.volumeUSD)
       const currentLiquidityUSD = Number(pair.totalValueLockedUSD)
       const currentFeesUSD = Number(pair.feesUSD)
@@ -755,12 +798,6 @@ function transformV3(queryResult: { chainId: ChainId; data: V3Data }) {
       const fees1d = oneDayData.has(pair.id) ? currentFeesUSD - oneDayData.get(pair.id).feesUSD : currentFeesUSD
       const fees1w = oneWeekData.has(pair.id) ? currentFeesUSD - oneWeekData.get(pair.id).feesUSD : currentFeesUSD
       const fees1m = oneMonthData.has(pair.id) ? currentFeesUSD - oneMonthData.get(pair.id).feesUSD : currentFeesUSD
-
-      const feeApr1h = calculateFeeApr(AprTimeRange.ONE_HOUR, fees1h, pair.feesUSD, pair.totalValueLockedUSD)
-      const feeApr1d = calculateFeeApr(AprTimeRange.ONE_DAY, fees1d, pair.feesUSD, pair.totalValueLockedUSD)
-      const feeApr1w = calculateFeeApr(AprTimeRange.ONE_WEEK, fees1w, pair.feesUSD, pair.totalValueLockedUSD)
-      const feeApr1m = calculateFeeApr(AprTimeRange.ONE_MONTH, fees1m, pair.feesUSD, pair.totalValueLockedUSD)
-
       const feesChange1h = calculatePercentageChange(
         currentFeesUSD,
         oneHourData.get(pair.id)?.feesUSD ?? 0,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
Update the `PoolAPRCell` component to use `totalApr1h` instead of `totalApr1d` for displaying the APR. Also, refactor the calculation of fee APRs in the `pools.ts` file.

### Detailed summary:
- Updated `PoolAPRCell` component to use `totalApr1h` instead of `totalApr1d` for displaying the APR.
- Refactored the calculation of fee APRs in the `pools.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->