### PR TITLE
fix(jobs/pool): apr fallback

### DIFF
--- a/jobs/pool/src/pools.ts
+++ b/jobs/pool/src/pools.ts
@@ -901,7 +901,7 @@ function transformV3(queryResult: { chainId: ChainId; data: V3Data }) {
         ...(oneDayData.get(pair.id)?.feesUSD && { feeApr1d }),
         ...(oneWeekData.get(pair.id)?.feesUSD && { feeApr1w }),
         ...(oneMonthData.get(pair.id)?.feesUSD && { feeApr1m }),
-        ...(oneHourData.get(pair.id)?.feesUSD && { totalApr1h: feeApr1h }),
+        ...(oneDayData.get(pair.id)?.feesUSD && { feeApr1d } || oneHourData.get(pair.id)?.feesUSD && { feeApr1d: feeApr1h }),
         ...(oneDayData.get(pair.id)?.feesUSD && { totalApr1d: feeApr1d }),
         ...(oneWeekData.get(pair.id)?.feesUSD && { totalApr1w: feeApr1w }),
         ...(oneMonthData.get(pair.id)?.feesUSD && { totalApr1m: feeApr1m }),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

This PR focuses on updating the logic for calculating feeApr1d in the `pools.ts` file. The changes include:
- Replacing `totalApr1h` with `feeApr1d` if `oneHourData` is undefined
- Adding `feeApr1d` if `oneDayData` is defined
- Updating `totalApr1d` to use `feeApr1d`
- Updating `totalApr1w` and `totalApr1m` to use `feeApr1w` and `feeApr1m` respectively

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->