### PR TITLE
chore: add minHeight to token list in TokenSelector

### DIFF
--- a/packages/wagmi/src/future/components/TokenSelector/TokenSelector.tsx
+++ b/packages/wagmi/src/future/components/TokenSelector/TokenSelector.tsx
@@ -184,7 +184,7 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
           </div>
         ) : null}
 
-        <List.Control className="relative flex flex-1 flex-col flex-grow gap-3 px-1 py-0.5">
+        <List.Control className="relative flex flex-1 flex-col flex-grow gap-3 px-1 py-0.5 min-h-[128px]">
           {isQueryTokenLoading || isLoading ? (
             <div className="py-0.5 h-[64px] -mb-3">
               <div className="flex items-center w-full h-full px-3 rounded-lg">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the `TokenSelector` component in the `TokenSelector.tsx` file.

### Detailed summary:
- The `min-h-[128px]` class has been added to the `List.Control` component, setting its minimum height to 128 pixels.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->