### PR TITLE
fix: RP4 custom error

### DIFF
--- a/protocols/route-processor/contracts/RouteProcessor4.sol
+++ b/protocols/route-processor/contracts/RouteProcessor4.sol
@@ -157,7 +157,7 @@ contract RouteProcessor4 is Ownable {
     require(balanceInFinal + amountIn >= balanceInInitial, 'RouteProcessor: Minimal imput balance violation');
 
     uint256 balanceOutFinal = tokenOut == NATIVE_ADDRESS ? address(to).balance : IERC20(tokenOut).balanceOf(to);
-    if (balanceOutFinal >= balanceOutInitial + amountOutMin)
+    if (balanceOutFinal < balanceOutInitial + amountOutMin)
       revert MinimalOutputBalanceViolation(balanceOutFinal - balanceOutInitial);
 
     amountOut = balanceOutFinal - balanceOutInitial;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on fixing a bug related to the minimal output balance violation in the `RouteProcessor4.sol` contract.

### Detailed summary:
- The `balanceOutFinal` variable is updated to calculate the final balance of the `to` address.
- The condition in the `if` statement is changed to check if the `balanceOutFinal` is less than the sum of `balanceOutInitial` and `amountOutMin`.
- If the condition is met, a `MinimalOutputBalanceViolation` revert is triggered.
- The `amountOut` variable is updated to calculate the difference between `balanceOutFinal` and `balanceOutInitial`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->