### PR TITLE
feat: Extractor Arbitrum - getFilterChanges

### DIFF
--- a/packages/extractor/examples/config.ts
+++ b/packages/extractor/examples/config.ts
@@ -19,7 +19,7 @@ import {
 import { config } from '@sushiswap/viem-config'
 import { Address, createPublicClient } from 'viem'
 
-import { LogFilterType } from '../src/LogFilter'
+import { LogFilterType } from '../src/LogFilter2'
 
 export const SUPPORTED_CHAIN_IDS = [
   ChainId.ARBITRUM,
@@ -120,7 +120,7 @@ export const EXTRACTOR_CONFIG = {
     tickHelperContract: V3_TICK_LENS[ChainId.ARBITRUM],
     cacheDir: './cache',
     logDepth: 300,
-    logType: LogFilterType.SelfFilter,
+    logType: LogFilterType.Native,
     logging: true,
     RP3Address: ROUTE_PROCESSOR_3_ADDRESS[ChainId.ARBITRUM],
   },

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -48,7 +48,7 @@
     "@sentry/node": "7.63.0",
     "abitype": "0.8.2",
     "ethers": "5.7.2",
-    "viem": "1.5.4"
+    "viem": "1.6.0"
   },
   "devDependencies": {
     "@sushiswap/eslint-config": "workspace:*",

--- a/packages/extractor/src/index.ts
+++ b/packages/extractor/src/index.ts
@@ -1,5 +1,5 @@
 export * from './Extractor'
-export * from './LogFilter'
+export * from './LogFilter2'
 export * from './MulticallAggregator'
 export * from './TokenManager'
 export * from './UniV2Extractor'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1776,7 +1776,7 @@ importers:
       ethers: 5.7.2
       express: 4.18.2
       typescript: 5.1.6
-      viem: 1.5.4
+      viem: 1.6.0
       zod: 3.21.4
     dependencies:
       '@sentry/node': 7.63.0
@@ -1792,7 +1792,7 @@ importers:
       '@uniswap/v3-core': 1.0.1
       abitype: 0.8.2_zno6rcmvi3mruj4xg7lanqhjom
       ethers: 5.7.2
-      viem: 1.5.4_zno6rcmvi3mruj4xg7lanqhjom
+      viem: 1.6.0_zno6rcmvi3mruj4xg7lanqhjom
     devDependencies:
       '@sushiswap/eslint-config': link:../../config/eslint
       '@sushiswap/jest-config': link:../../config/jest
@@ -11996,11 +11996,20 @@ packages:
     dependencies:
       '@noble/hashes': 1.3.0
 
+  /@noble/curves/1.1.0:
+    resolution: {integrity: sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==}
+    dependencies:
+      '@noble/hashes': 1.3.1
+
   /@noble/hashes/1.2.0:
     resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
 
   /@noble/hashes/1.3.0:
     resolution: {integrity: sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==}
+
+  /@noble/hashes/1.3.1:
+    resolution: {integrity: sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==}
+    engines: {node: '>= 16'}
 
   /@noble/secp256k1/1.7.1:
     resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
@@ -14340,7 +14349,7 @@ packages:
     resolution: {integrity: sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==}
     dependencies:
       '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.1
       '@scure/base': 1.1.1
 
   /@scure/bip39/1.1.1:
@@ -14352,7 +14361,7 @@ packages:
   /@scure/bip39/1.2.0:
     resolution: {integrity: sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==}
     dependencies:
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.1
       '@scure/base': 1.1.1
 
   /@sentry-internal/tracing/7.63.0:
@@ -14861,8 +14870,8 @@ packages:
     resolution: {integrity: sha512-aJtF/nTs+9St+KtTK/wgVJ+SinfjYzn+3w1ygYIPw8ST6LH+qHBn8XkodgDTwlv/xzNkaVz1kkUDOZ8BPXyZWA==}
     dependencies:
       '@babel/runtime': 7.21.5
-      '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
+      '@noble/curves': 1.1.0
+      '@noble/hashes': 1.3.1
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.3.0
       bigint-buffer: 1.1.5
@@ -40225,6 +40234,31 @@ packages:
     dependencies:
       '@adraffy/ens-normalize': 1.9.0
       '@noble/curves': 1.0.0
+      '@noble/hashes': 1.3.0
+      '@scure/bip32': 1.3.0
+      '@scure/bip39': 1.2.0
+      '@types/ws': 8.5.4
+      '@wagmi/chains': 1.6.0_typescript@5.1.6
+      abitype: 0.9.3_zno6rcmvi3mruj4xg7lanqhjom
+      isomorphic-ws: 5.0.0_ws@8.12.0
+      typescript: 5.1.6
+      ws: 8.12.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /viem/1.6.0_zno6rcmvi3mruj4xg7lanqhjom:
+    resolution: {integrity: sha512-ae9Twkd0q2Qlj4yYpWjb4DzYAhKY0ibEpRH8FJaTywZXNpTjFidSdBaT0CVn1BaH7O7cnX4/O47zvDUMGJD1AA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.9.0
+      '@noble/curves': 1.1.0
       '@noble/hashes': 1.3.0
       '@scure/bip32': 1.3.0
       '@scure/bip39': 1.2.0


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `viem` package to version 1.6.0 and makes changes to the `LogFilter` module.

### Detailed summary
- Updated `viem` package to version 1.6.0
- Renamed `LogFilter` module to `LogFilter2`
- Updated import statements to reflect the changes in `LogFilter2`
- Added a new enum value `Native` to `LogFilterType`
- Updated the `Filter` interface to `FilterMy`
- Updated the `LogFilter2` class to support the new `Native` log filter type
- Updated dependencies in `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->