### PR TITLE
Update token-addresses.ts

### DIFF
--- a/config/router/src/additional-bases.ts
+++ b/config/router/src/additional-bases.ts
@@ -88,6 +88,17 @@ export const ADDITIONAL_BASES: {
       SNX[ChainId.POLYGON],
       CRV[ChainId.POLYGON],
       YFI[ChainId.POLYGON],
+      GNS[ChainId.POLYGON],
+      SAND[ChainId.POLYGON],
+      STG[ChainId.POLYGON],
+      UNI[ChainId.POLYGON],
+      SUSHI[ChainId.POLYGON],
+      RNDR[ChainId.POLYGON],
+      TEL[ChainId.POLYGON],
+      GRT[ChainId.POLYGON],
+      BAL[ChainId.POLYGON],
+      QUICK[ChainId.POLYGON],
+      OCEAN[ChainId.POLYGON],
       // ENJ[ChainId.POLYGON], // could not find on polygon
     ],
   },
@@ -133,5 +144,15 @@ export const ADDITIONAL_BASES: {
   [ChainId.OPTIMISM]: {
     [FRAX_ADDRESS[ChainId.OPTIMISM]]: [FXS[ChainId.OPTIMISM]],
     [FXS_ADDRESS[ChainId.OPTIMISM]]: [FRAX[ChainId.OPTIMISM]],
+    ['0x9E8862e39496BD336565Dd15cE2C0B90bc7dc121']: [
+      // FIVE
+      WNATIVE[ChainId.OPTIMISM],
+      WETH9[ChainId.OPTIMISM],
+      SNX[ChainId.OPTIMISM],
+      WBTC[ChainId.OPTIMISM],
+      LINK[ChainId.OPTIMISM],
+      SUSHI[ChainId.OPTIMISM],
+      XSUSHI[ChainId.OPTIMISM],
+    ],
   },
 }

--- a/packages/currency/src/constants/token-addresses.ts
+++ b/packages/currency/src/constants/token-addresses.ts
@@ -40,6 +40,38 @@ export const MANA_ADDRESS = {
   [ChainId.POLYGON]: '0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4',
 } as const
 
+export const GNS_ADDRESS = {
+  [ChainId.POLYGON]: '0xE5417Af564e4bFDA1c483642db72007871397896',
+} as const
+
+export const SAND_ADDRESS = {
+  [ChainId.POLYGON]: '0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683',
+} as const
+
+export const STG_ADDRESS = {
+  [ChainId.POLYGON]: '0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590',
+} as const
+
+export const RNDR_ADDRESS = {
+  [ChainId.POLYGON]: '0x61299774020dA444Af134c82fa83E3810b309991',
+} as const
+
+export const TEL_ADDRESS = {
+  [ChainId.POLYGON]: '0x61299774020dA444Af134c82fa83E3810b309991',
+} as const
+
+export const GRT_ADDRESS = {
+  [ChainId.POLYGON]: '0x5fe2B58c013d7601147DcdD68C143A77499f5531',
+} as const
+
+export const BAL_ADDRESS = {
+  [ChainId.POLYGON]: '0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3',
+} as const
+
+export const OCEAN_ADDRESS = {
+  [ChainId.POLYGON]: '0x282d8efCe846A88B159800bd4130ad77443Fa1A1',
+} as const
+
 export const MKR_ADDRESS = {
   [ChainId.ETHEREUM]: '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2',
   [ChainId.POLYGON]: '0x6f7C932e7684666C9fd1d44527765433e01fF61d',


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR adds additional base tokens for the Polygon and Optimism chains in the router configuration.

### Detailed summary:
- Added GNS, SAND, STG, UNI, SUSHI, RNDR, TEL, GRT, BAL, QUICK, and OCEAN as additional base tokens for the Polygon chain in the router configuration.
- Added FIVE, WNATIVE, WETH9, SNX, WBTC, LINK, SUSHI, and XSUSHI as additional base tokens for the Optimism chain in the router configuration.
- Added token addresses for GNS, SAND, STG, RNDR, TEL, GRT, BAL, and OCEAN on the Polygon chain in the token addresses constants file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->