### PR TITLE
fix(apis/balances): result

### DIFF
--- a/apis/balances/api/v0/[chainId]/[address].ts
+++ b/apis/balances/api/v0/[chainId]/[address].ts
@@ -51,11 +51,14 @@ const handler = async (request: VercelRequest, response: VercelResponse) => {
     ),
   })
 
-  const zipped = zip(tokens, balances)
+  const zipped = zip(
+    tokens,
+    balances.map((balance) => balance?.result || 0n)
+  )
   return response.status(200).json({
     '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee': balance.value.toString(),
     ...Object.fromEntries(
-      zipped.filter(([, balance]) => balance?.result !== 0n).map(([token, balance]) => [token, balance?.toString()])
+      zipped.filter(([, balance]) => balance !== 0n).map(([token, balance]) => [token, balance?.toString()])
     ),
   })
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The focus of this PR is to update the `zipped` variable in the `balances` API endpoint.
- Notable changes include:
  - Mapping the `balances` array to extract the `result` property or default to 0n.
  - Filtering the `zipped` array based on the `balance` value instead of `balance?.result`.
  - Converting the `balance` value to a string before assigning it to the response object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->