### PR TITLE
fix(DataFetcher): create2address

### DIFF
--- a/packages/router/src/liquidity-providers/UniswapV2Base.ts
+++ b/packages/router/src/liquidity-providers/UniswapV2Base.ts
@@ -1,3 +1,4 @@
+import { getCreate2Address } from '@ethersproject/address'
 import { getReservesAbi } from '@sushiswap/abi'
 import { ChainId } from '@sushiswap/chain'
 import { Token } from '@sushiswap/currency'
@@ -5,7 +6,7 @@ import { PrismaClient } from '@sushiswap/database'
 import { ADDITIONAL_BASES, BASES_TO_CHECK_TRADES_AGAINST } from '@sushiswap/router-config'
 import { ConstantProductRPool, RToken } from '@sushiswap/tines'
 import { add, getUnixTime } from 'date-fns'
-import { Address, encodePacked, getCreate2Address, Hex, keccak256, PublicClient } from 'viem'
+import { Address, encodePacked, Hex, keccak256, PublicClient } from 'viem'
 
 import { getCurrencyCombinations } from '../getCurrencyCombinations'
 import { discoverNewPools, filterOnDemandPools, filterTopPools, getAllPools, mapToken, PoolResponse2 } from '../lib/api'
@@ -402,11 +403,11 @@ export abstract class UniswapV2BaseProvider extends LiquidityProvider {
   }
 
   _getPoolAddress(t1: Token, t2: Token): Address {
-    return getCreate2Address({
-      from: this.factory[this.chainId as keyof typeof this.factory],
-      salt: keccak256(encodePacked(['address', 'address'], [t1.address as Address, t2.address as Address])),
-      bytecode: this.initCodeHash[this.chainId as keyof typeof this.initCodeHash],
-    })
+    return getCreate2Address(
+      this.factory[this.chainId as keyof typeof this.factory],
+      keccak256(encodePacked(['address', 'address'], [t1.address as Address, t2.address as Address])),
+      this.initCodeHash[this.chainId as keyof typeof this.initCodeHash]
+    ) as Address
   }
 
   // TODO: Decide if this is worth keeping as fallback in case fetching top pools fails? only used on initial load.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `UniswapV2Base.ts` file in the `router` package. 

### Detailed summary
- Updated import statements for `getReservesAbi`, `ChainId`, and `Token` from the `@sushiswap` packages.
- Updated import statements for `PrismaClient` from the `@sushiswap/database` package.
- Updated import statements for `ConstantProductRPool` and `RToken` from the `@sushiswap/tines` package.
- Updated import statements for various functions and types from the `viem` package.
- Updated import statements for various functions and types from the `../getCurrencyCombinations` and `../lib/api` files.
- Updated the `_getPoolAddress` function to return the result as `Address`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->