### PR TITLE
fix(add/removesections): icons

### DIFF
--- a/apps/evm/ui/pool/AddSection/AddSectionStakeWidget.tsx
+++ b/apps/evm/ui/pool/AddSection/AddSectionStakeWidget.tsx
@@ -8,7 +8,6 @@ import { Button } from '@sushiswap/ui/components/button'
 import { Currency } from '@sushiswap/ui/components/currency'
 import { IconButton } from '@sushiswap/ui/components/iconbutton'
 import { Input } from '@sushiswap/ui/components/input'
-import { SelectIcon } from '@sushiswap/ui/components/select'
 import { Widget, WidgetContent, WidgetHeader } from '@sushiswap/ui/components/widget'
 import { useTotalSupply } from '@sushiswap/wagmi'
 import { useTokenAmountDollarValues, useUnderlyingTokenBalanceFromPool } from 'lib/hooks'
@@ -71,9 +70,7 @@ export const AddSectionStakeWidget: FC<AddSectionStakeWidgetProps> = ({
                       icon={ChevronDownIcon}
                       name="Select"
                       testdata-id="stake-liquidity-header-button"
-                    >
-                      <SelectIcon />
-                    </IconButton>
+                    />
                   </div>
                 </Disclosure.Button>
                 <Transition

--- a/apps/evm/ui/pool/AddSection/AddSectionWidget.tsx
+++ b/apps/evm/ui/pool/AddSection/AddSectionWidget.tsx
@@ -5,7 +5,6 @@ import { ChainId } from '@sushiswap/chain'
 import { Type } from '@sushiswap/currency'
 import { useIsMounted } from '@sushiswap/hooks'
 import { IconButton } from '@sushiswap/ui/components/iconbutton'
-import { SelectIcon } from '@sushiswap/ui/components/select'
 import { SettingsModule, SettingsOverlay } from '@sushiswap/ui/components/settings'
 import { Widget, WidgetContent, WidgetHeader } from '@sushiswap/ui/components/widget'
 import { Web3Input } from '@sushiswap/wagmi/future/components/Web3Input'
@@ -70,9 +69,7 @@ export const AddSectionWidget: FC<AddSectionWidgetProps> = ({
                       )}
                     </SettingsOverlay>
                     <Disclosure.Button as={Fragment}>
-                      <IconButton size="sm" icon={ChevronDownIcon} name="Select">
-                        <SelectIcon />
-                      </IconButton>
+                      <IconButton size="sm" icon={ChevronDownIcon} name="Select" />
                     </Disclosure.Button>
                   </div>
                 </WidgetHeader>

--- a/apps/evm/ui/pool/RemoveSection/RemoveSectionUnstakeWidget.tsx
+++ b/apps/evm/ui/pool/RemoveSection/RemoveSectionUnstakeWidget.tsx
@@ -9,7 +9,6 @@ import { Button } from '@sushiswap/ui/components/button'
 import { Currency } from '@sushiswap/ui/components/currency'
 import { IconButton } from '@sushiswap/ui/components/iconbutton'
 import { Input } from '@sushiswap/ui/components/input'
-import { SelectIcon } from '@sushiswap/ui/components/select'
 import { Widget, WidgetContent, WidgetHeader } from '@sushiswap/ui/components/widget'
 import { useTotalSupply } from '@sushiswap/wagmi'
 import { useTokenAmountDollarValues, useUnderlyingTokenBalanceFromPool } from 'lib/hooks'
@@ -87,9 +86,7 @@ export const RemoveSectionUnstakeWidget: FC<RemoveSectionUnstakeWidget> = ({
                       icon={ChevronDownIcon}
                       name="Select"
                       testdata-id="unstake-liquidity-header-button"
-                    >
-                      <SelectIcon />
-                    </IconButton>
+                    />
                   </div>
                 </Disclosure.Button>
                 <Transition

--- a/apps/evm/ui/pool/RemoveSection/RemoveSectionWidget.tsx
+++ b/apps/evm/ui/pool/RemoveSection/RemoveSectionWidget.tsx
@@ -10,7 +10,6 @@ import { Button } from '@sushiswap/ui/components/button'
 import { Currency as UICurrency } from '@sushiswap/ui/components/currency'
 import { IconButton } from '@sushiswap/ui/components/iconbutton'
 import { Input } from '@sushiswap/ui/components/input'
-import { SelectIcon } from '@sushiswap/ui/components/select'
 import { SettingsModule, SettingsOverlay } from '@sushiswap/ui/components/settings'
 import { Widget, WidgetContent, WidgetHeader } from '@sushiswap/ui/components/widget'
 import { useAccount } from '@sushiswap/wagmi'
@@ -93,9 +92,7 @@ export const RemoveSectionWidget: FC<RemoveSectionWidgetProps> = ({
                         )}
                       </SettingsOverlay>
                       <Disclosure.Button as={Fragment}>
-                        <IconButton size="sm" icon={ChevronDownIcon} name="Select">
-                          <SelectIcon />
-                        </IconButton>
+                        <IconButton size="sm" icon={ChevronDownIcon} name="Select" />
                       </Disclosure.Button>
                     </div>
                   </WidgetHeader>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on removing the unused `SelectIcon` component from multiple files in the `evm/ui/pool` directory.

### Detailed summary
- Removed `SelectIcon` import and usage from `AddSectionStakeWidget.tsx`
- Removed `SelectIcon` import and usage from `RemoveSectionUnstakeWidget.tsx`
- Removed `SelectIcon` import and usage from `RemoveSectionWidget.tsx`
- Removed `SelectIcon` import and usage from `AddSectionWidget.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->