### PR TITLE
fix(apps/evm): use allSettled instead of all for fetching cliq positions

### DIFF
--- a/apps/evm/ui/pool/PoolsSection/Tables/PositionsTable/ConcentratedPositionsTable.tsx
+++ b/apps/evm/ui/pool/PoolsSection/Tables/PositionsTable/ConcentratedPositionsTable.tsx
@@ -25,11 +25,7 @@ export const ConcentratedPositionsTable: FC<{
   const [columnVisibility, setColumnVisibility] = useState({})
   const [sorting, setSorting] = useState<SortingState>([{ id: 'positionSize', desc: true }])
 
-  const {
-    data: positions,
-    isLoading,
-    isInitialLoading,
-  } = useConcentratedLiquidityPositions({
+  const { data: positions, isInitialLoading } = useConcentratedLiquidityPositions({
     account: address,
     chainIds: SUSHISWAP_V3_SUPPORTED_CHAIN_IDS as Writeable<typeof SUSHISWAP_V3_SUPPORTED_CHAIN_IDS>,
   })
@@ -99,7 +95,7 @@ export const ConcentratedPositionsTable: FC<{
     <div className="mb-[120px]">
       <GenericTable<ConcentratedLiquidityPosition>
         table={table}
-        loading={Boolean(isLoading && address)}
+        loading={isInitialLoading}
         placeholder="No positions found"
         pageSize={_positions?.length ? _positions.length : 1}
         linkFormatter={rowLink}

--- a/packages/wagmi/src/future/hooks/pools/actions/getConcentratedLiquidityPool.ts
+++ b/packages/wagmi/src/future/hooks/pools/actions/getConcentratedLiquidityPool.ts
@@ -92,17 +92,17 @@ export const getConcentratedLiquidityPools = async ({
     const [token0, token1, fee] = tokens
 
     if (!slot0s[index]) return null
-    const slot0 = slot0s[index]
+    const slot0 = slot0s[index].result
 
     if (!liquidities[index]) return null
     const liquidity = liquidities[index].result
 
     if (!tokens || !slot0 || typeof liquidity === 'undefined') return null
 
-    const sqrtPriceX96 = slot0.result?.[0]
+    const sqrtPriceX96 = slot0[0]
     if (!sqrtPriceX96 || sqrtPriceX96 === 0n) return null
 
-    const tick = slot0.result?.[1]
+    const tick = slot0[1]
     if (typeof tick === 'undefined') return null
 
     return new SushiSwapV3Pool(token0, token1, fee, sqrtPriceX96, liquidity, tick)

--- a/packages/wagmi/src/future/hooks/positions/hooks/useConcentratedLiquidityPositions.ts
+++ b/packages/wagmi/src/future/hooks/positions/hooks/useConcentratedLiquidityPositions.ts
@@ -8,6 +8,16 @@ import { Address } from 'wagmi'
 import { getConcentratedLiquidityPool } from '../../pools'
 import { getTokenWithCacheQueryFn, getTokenWithQueryCacheHydrate } from '../../tokens'
 import { getConcentratedLiquidityPositions } from '../actions'
+import { ConcentratedLiquidityPosition } from '../types'
+
+interface UseConcentratedLiquidityPositionsData extends ConcentratedLiquidityPosition {
+  pool: SushiSwapV3Pool
+  position: {
+    position: Position
+    positionUSD: number
+    unclaimedUSD: number
+  }
+}
 
 interface UseConcentratedLiquidityPositionsParams {
   account: Address | undefined
@@ -32,7 +42,7 @@ export const useConcentratedLiquidityPositions = ({
       })
 
       if (data && prices) {
-        const pools = await Promise.all(
+        const pools = await Promise.allSettled(
           data.map(async (el) => {
             const [token0Data, token1Data] = await Promise.all([
               getTokenWithCacheQueryFn({ chainId: el.chainId, hasToken, customTokens, address: el.token0 }),
@@ -84,10 +94,16 @@ export const useConcentratedLiquidityPositions = ({
           })
         )
 
-        return data.map((el, i) => ({
-          ...el,
-          ...pools[i],
-        }))
+        return pools.reduce<UseConcentratedLiquidityPositionsData[]>((acc, el, i) => {
+          if (el.status === 'fulfilled') {
+            acc.push({
+              ...data[i],
+              ...el.value,
+            })
+          }
+
+          return acc
+        }, [])
       }
 
       return []


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the handling of concentrated liquidity positions in the Wagmi and EVM UI packages.

### Detailed summary:
- In `getConcentratedLiquidityPool.ts`:
  - The `slot0` variable is updated to `slot0s[index].result`.
  - The `liquidity` variable is updated to `liquidities[index].result`.
  - The `sqrtPriceX96` variable is updated to `slot0[0]`.
  - The `tick` variable is updated to `slot0[1]`.
  - The `new SushiSwapV3Pool` instance is returned with updated arguments.
- In `ConcentratedPositionsTable.tsx`:
  - The `isLoading` prop is removed from the `GenericTable` component.
  - The `loading` prop is updated to `isInitialLoading`.
- In `useConcentratedLiquidityPositions.ts`:
  - The `ConcentratedLiquidityPosition` type is imported.
  - The `UseConcentratedLiquidityPositionsData` interface is added.
  - The `useConcentratedLiquidityPositions` function is updated to return an array of `UseConcentratedLiquidityPositionsData`.
  - The `pools` variable is updated to use `Promise.allSettled` instead of `Promise.all`.
  - The function now returns an array of `UseConcentratedLiquidityPositionsData`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->