### PR TITLE
fix(tines): testutils

### DIFF
--- a/packages/tines/test/utils.ts
+++ b/packages/tines/test/utils.ts
@@ -191,8 +191,8 @@ function getCPPool(rnd: () => number, t0: TToken, t1: TToken) {
     t0,
     t1,
     fee,
-    getBigInt(reserve0 * (10 ** t0.decimals - 6)),
-    getBigInt(reserve1 * (10 ** t1.decimals - 6))
+    getBigInt(reserve0 * (10 ** (t0.decimals - 6))),
+    getBigInt(reserve1 * (10 ** (t1.decimals - 6)))
   )
 }
 
@@ -231,8 +231,8 @@ function getStableSwapPool(rnd: () => number, t0: TToken, t1: TToken) {
     t0,
     t1,
     fee,
-    getBigInt(reserve0 * (10 ** t0.decimals - 6)),
-    getBigInt(reserve1 * (10 ** t1.decimals - 6)),
+    getBigInt(reserve0 * (10 ** (t0.decimals - 6))),
+    getBigInt(reserve1 * (10 ** (t1.decimals - 6))),
     t0.decimals,
     t1.decimals,
     total0,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on fixing a bug in the `utils.ts` file related to the calculation of reserve values in a stable swap pool.

### Detailed summary:
- Updated the calculation of reserve values in the `getStableSwapPool` function in `utils.ts`.
- Replaced `reserve0 * (10 ** t0.decimals - 6)` with `reserve0 * (10 ** (t0.decimals - 6))`.
- Replaced `reserve1 * (10 ** t1.decimals - 6)` with `reserve1 * (10 ** (t1.decimals - 6))`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->