### PR TITLE
fix(apps/evm): furo passthrough

### DIFF
--- a/apps/evm/next.config.js
+++ b/apps/evm/next.config.js
@@ -4,7 +4,7 @@ const { withAxiom } = require('next-axiom')
 
 const ACADEMY_URL = process.env.ACADEMY_URL || 'https://academy.sushi.com'
 const BLOG_URL = process.env.BLOG_URL || 'https://blog.sushi.com'
-const FURO_URL = process.env.ACADEMY_URL || 'https://furo.sushi.com'
+const FURO_URL = process.env.FURO_URL || 'https://furo.sushi.com'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `next.config.js` file in the `evm` app. 

### Detailed summary
- Updated the `FURO_URL` constant to use the `FURO_URL` environment variable instead of `ACADEMY_URL`.
- Default value for `ACADEMY_URL` is now 'https://academy.sushi.com'.
- Default value for `BLOG_URL` is now 'https://blog.sushi.com'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->