### PR TITLE
fix: simple swap dialog network fee

### DIFF
--- a/apps/evm/ui/swap/simple/simple-swap-trade-review-dialog.tsx
+++ b/apps/evm/ui/swap/simple/simple-swap-trade-review-dialog.tsx
@@ -395,10 +395,10 @@ export const SimpleSwapTradeReviewDialog: FC<{ children(error: Error | null): Re
                       </List.KeyValue>
                     )}
                     <List.KeyValue title="Network fee">
-                      {isFetching ? (
+                      {isFetching || !trade?.gasSpent || trade.gasSpent === '0' ? (
                         <SkeletonText align="right" fontSize="sm" className="w-1/3" />
                       ) : (
-                        `~$${trade?.gasSpent ?? '0.00'}`
+                        `${trade.gasSpent} ${Native.onChain(chainId).symbol}`
                       )}
                     </List.KeyValue>
                     {isSwap && (


### PR DESCRIPTION
Simple swap review dialog currently displays the native network fee as dollar value.

<img width="502" alt="Screenshot 2023-09-05 at 2 24 05 PM" src="https://github.com/sushiswap/sushiswap/assets/82962873/3e1b939b-306c-4294-83ad-5125fc9a7786">
<img width="469" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/9ce6cc0b-3f59-4b5e-b651-ec909dd194a2">


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Updated the `simple-swap-trade-review-dialog.tsx` file in the `apps/evm/ui/swap/simple` directory.
- Changed the rendering of the "Network fee" section.
- Added a condition to display a skeleton text when `isFetching` is true or when `trade.gasSpent` is undefined or '0'.
- Updated the display format of the `trade.gasSpent` variable to include the symbol of the native currency for the given `chainId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->