### PR TITLE
fix: cross-chain token pricing

### DIFF
--- a/apps/evm/ui/swap/cross-chain/cross-chain-swap-header.tsx
+++ b/apps/evm/ui/swap/cross-chain/cross-chain-swap-header.tsx
@@ -23,7 +23,7 @@ export const CrossChainSwapHeader = () => {
   }, [token0, token1])
 
   const [token0FiatPrice] = useTokenAmountDollarValues({ chainId: chainId0, amounts: amounts[0] })
-  const [token1FiatPrice] = useTokenAmountDollarValues({ chainId: chainId1, amounts: amounts[0] })
+  const [token1FiatPrice] = useTokenAmountDollarValues({ chainId: chainId1, amounts: amounts[1] })
 
   const { data: prices0 } = usePrices({ chainId: chainId0 })
   const { data: prices1 } = usePrices({ chainId: chainId1 })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- The focus of this PR is to update the `token1FiatPrice` variable in the `cross-chain-swap-header.tsx` file.
- Previously, the `token1FiatPrice` was calculated using `amounts[0]` for `chainId1`.
- Now, the `token1FiatPrice` is calculated using `amounts[1]` for `chainId1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->