### PR TITLE
fix: usdt approvals

### DIFF
--- a/packages/wagmi/src/future/hooks/approvals/hooks/useTokenApproval.ts
+++ b/packages/wagmi/src/future/hooks/approvals/hooks/useTokenApproval.ts
@@ -4,7 +4,7 @@ import { Amount, Type } from '@sushiswap/currency'
 import { createErrorToast, createToast } from '@sushiswap/ui/components/toast'
 import { useCallback, useMemo, useState } from 'react'
 import { maxUint256, UserRejectedRequestError } from 'viem'
-import { Address, erc20ABI, useAccount, useContractWrite, usePrepareContractWrite } from 'wagmi'
+import { Address, useAccount, useContractWrite, usePrepareContractWrite } from 'wagmi'
 import { SendTransactionResult, waitForTransaction } from 'wagmi/actions'
 
 import { useTokenAllowance } from './useTokenAllowance'
@@ -23,21 +23,6 @@ interface UseTokenApprovalParams {
   approveMax?: boolean
   enabled?: boolean
 }
-
-const usdtApproveAbi = [
-  {
-    constant: false,
-    inputs: [
-      { name: '_spender', type: 'address' },
-      { name: '_value', type: 'uint256' },
-    ],
-    name: 'approve',
-    outputs: [{ name: '', type: 'bool' }],
-    payable: false,
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-] as const
 
 export const useTokenApproval = ({
   amount,
@@ -61,7 +46,20 @@ export const useTokenApproval = ({
 
   const { config } = usePrepareContractWrite({
     chainId: amount?.currency.chainId,
-    abi: erc20ABI,
+    abi: [
+      {
+        constant: false,
+        inputs: [
+          { name: 'spender', type: 'address' },
+          { name: 'amount', type: 'uint256' },
+        ],
+        name: 'approve',
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+    ] as const,
     address: amount?.currency?.wrapped?.address as Address,
     functionName: 'approve',
     args: [spender as Address, approveMax ? maxUint256 : amount ? amount.quotient : 0n],


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary:
- The `erc20ABI` import has been removed.
- The `usdtApproveAbi` constant has been removed.
- The `abi` parameter in the `usePrepareContractWrite` function has been updated to a new array.
- The `name` and `outputs` properties in the new `abi` array have been modified.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->