### PR TITLE
fix(apps/pool): remove price dependency for positions

### DIFF
--- a/packages/wagmi/src/future/hooks/positions/hooks/useConcentratedLiquidityPositions.ts
+++ b/packages/wagmi/src/future/hooks/positions/hooks/useConcentratedLiquidityPositions.ts
@@ -31,7 +31,7 @@ export const useConcentratedLiquidityPositions = ({
   enabled = true,
 }: UseConcentratedLiquidityPositionsParams) => {
   const { data: customTokens, hasToken } = useCustomTokens()
-  const { data: prices } = useAllPrices()
+  const { data: prices, isError: isPriceError } = useAllPrices()
 
   return useQuery({
     queryKey: ['useConcentratedLiquidityPositions', { chainIds, account, prices }],
@@ -41,7 +41,7 @@ export const useConcentratedLiquidityPositions = ({
         chainIds,
       })
 
-      if (data && prices) {
+      if (data && (prices || isPriceError)) {
         const pools = await Promise.allSettled(
           data.map(async (el) => {
             const [token0Data, token1Data] = await Promise.all([


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `isError` property to the `prices` object in the `useAllPrices` hook.
- Modified the condition in the `useConcentratedLiquidityPositions` hook to include the `isPriceError` property in addition to `prices` to proceed with further logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->