### PR TITLE
fix: RP3.2 transfer->call roll back

### DIFF
--- a/protocols/route-processor/contracts/RouteProcessor3_2.sol
+++ b/protocols/route-processor/contracts/RouteProcessor3_2.sol
@@ -277,9 +277,7 @@ contract RouteProcessor3_2 is Ownable {
         if (from != address(this)) IERC20(tokenIn).safeTransferFrom(from, address(this), amountIn);
         IWETH(tokenIn).withdraw(amountIn);
       }
-      //payable(to).transfer(address(this).balance);
-      (bool success,)= payable(to).call{value: address(this).balance}("");
-      require(success, "RouteProcessor: Native token transfer failed");
+      payable(to).transfer(address(this).balance);
     }
   }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on simplifying the native token transfer in the `RouteProcessor3_2` contract.

### Detailed summary
- Replaced the `call` method with the `transfer` method for native token transfer.
- Removed the `withdraw` method call for the `IWETH` interface.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->