### PR TITLE
fix(apps/swap): button not disabled when there was a min output violation error

### DIFF
--- a/apps/evm/lib/hooks/index.ts
+++ b/apps/evm/lib/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './api'
 export * from './useIsTickAtLimit'
+export * from './usePersistedSlippageError'
 export * from './usePriceInverter'
 export * from './useTicks'
 export * from './useTokenAmountDollarValues'

--- a/apps/evm/lib/hooks/usePersistedSlippageError.ts
+++ b/apps/evm/lib/hooks/usePersistedSlippageError.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+export const usePersistedSlippageError = ({ isSuccess, error }: { isSuccess: boolean; error: Error | null }) => {
+  const [show, setShow] = useState(false)
+  const [persistedError, setPersistedError] = useState<Error | null>(error)
+
+  // Need to perform some funky business because wagmi isn't keeping the previous error while its refetching
+  useEffect(() => {
+    if (error && error.message.includes('Minimal ouput balance violation')) {
+      setShow(true)
+      setPersistedError(error)
+    }
+
+    if (isSuccess) setPersistedError(null)
+  }, [error, isSuccess])
+
+  const isSlippageError = Boolean(persistedError)
+
+  return { isSlippageError, show, setShow }
+}

--- a/apps/evm/ui/swap/simple/simple-swap-error-message.tsx
+++ b/apps/evm/ui/swap/simple/simple-swap-error-message.tsx
@@ -16,7 +16,9 @@ import {
   TextField,
 } from '@sushiswap/ui'
 import { Collapsible } from '@sushiswap/ui/components/animation/Collapsible'
-import { FC, useEffect, useState } from 'react'
+import { FC } from 'react'
+
+import { usePersistedSlippageError } from '../../../lib/hooks'
 
 export const SimpleSwapErrorMessage: FC<{ isSuccess: boolean; error: Error | null; isLoading: boolean }> = ({
   isSuccess,
@@ -24,20 +26,7 @@ export const SimpleSwapErrorMessage: FC<{ isSuccess: boolean; error: Error | nul
   isLoading,
 }) => {
   const [slippageTolerance, setSlippageTolerance] = useSlippageTolerance()
-  const [show, setShow] = useState(false)
-  const [persistedError, setPersistedError] = useState<Error | null>(error)
-
-  // Need to perform some funky business because wagmi isn't keeping the previous error while its refetching
-  useEffect(() => {
-    if (error && error.message.includes('Minimal ouput balance violation')) {
-      setShow(true)
-      setPersistedError(error)
-    }
-
-    if (isSuccess) setPersistedError(null)
-  }, [error, isSuccess])
-
-  const isSlippageError = Boolean(persistedError)
+  const { isSlippageError, setShow, show } = usePersistedSlippageError({ isSuccess, error })
 
   return (
     <HoverCard openDelay={0} closeDelay={0}>

--- a/apps/evm/ui/swap/simple/simple-swap-trade-button.tsx
+++ b/apps/evm/ui/swap/simple/simple-swap-trade-button.tsx
@@ -19,15 +19,28 @@ import { APPROVE_TAG_SWAP } from 'lib/constants'
 import { warningSeverity } from 'lib/swap/warningSeverity'
 import React, { FC, useEffect, useState } from 'react'
 
+import { usePersistedSlippageError } from '../../../lib/hooks'
 import { useDerivedStateSimpleSwap, useSimpleSwapTrade } from './derivedstate-simple-swap-provider'
 import { SimpleSwapTradeReviewDialog } from './simple-swap-trade-review-dialog'
 
 export const SimpleSwapTradeButton: FC = () => {
+  return (
+    <>
+      <SimpleSwapTradeReviewDialog>
+        {({ error, isSuccess }) => <_SimpleSwapTradeButton error={error} isSuccess={isSuccess} />}
+      </SimpleSwapTradeReviewDialog>
+    </>
+  )
+}
+
+export const _SimpleSwapTradeButton: FC<{ error: Error | null; isSuccess: boolean }> = ({ error, isSuccess }) => {
+  const { isSlippageError } = usePersistedSlippageError({ isSuccess, error })
   const { data: trade } = useSimpleSwapTrade()
+  const [checked, setChecked] = useState(false)
+
   const {
     state: { swapAmount, swapAmountString, chainId, token0, token1 },
   } = useDerivedStateSimpleSwap()
-  const [checked, setChecked] = useState(false)
 
   const isWrap = token0?.isNative && token1?.wrapped.address === Native.onChain(chainId).wrapped.address
   const isUnwrap = token1?.isNative && token0?.wrapped.address === Native.onChain(chainId).wrapped.address
@@ -41,61 +54,58 @@ export const SimpleSwapTradeButton: FC = () => {
 
   return (
     <>
-      <SimpleSwapTradeReviewDialog>
-        {(error) => (
-          <div>
-            <Checker.Connect>
-              <Checker.Network chainId={chainId}>
-                <Checker.Amounts chainId={chainId} amounts={[swapAmount]}>
-                  <Checker.ApproveERC20
-                    id="approve-erc20"
-                    amount={swapAmount}
-                    contract={
-                      isRouteProcessor3_2ChainId(chainId)
-                        ? ROUTE_PROCESSOR_3_2_ADDRESS[chainId]
-                        : isRouteProcessor3_1ChainId(chainId)
-                        ? ROUTE_PROCESSOR_3_1_ADDRESS[chainId]
-                        : isRouteProcessor3ChainId(chainId)
-                        ? ROUTE_PROCESSOR_3_ADDRESS[chainId]
-                        : isRouteProcessorChainId(chainId)
-                        ? ROUTE_PROCESSOR_ADDRESS[chainId]
-                        : undefined
-                    }
-                  >
-                    <Checker.Success tag={APPROVE_TAG_SWAP}>
-                      <DialogTrigger asChild>
-                        <Button
-                          size="xl"
-                          disabled={Boolean(
-                            error ||
-                              !trade?.amountOut?.greaterThan(ZERO) ||
-                              trade?.route?.status === 'NoWay' ||
-                              +swapAmountString === 0 ||
-                              (!checked && warningSeverity(trade?.priceImpact) > 3)
-                          )}
-                          color={warningSeverity(trade?.priceImpact) >= 3 ? 'red' : 'blue'}
-                          fullWidth
-                          testId="swap"
-                        >
-                          {!checked && warningSeverity(trade?.priceImpact) >= 3
-                            ? 'Price impact too high'
-                            : trade?.route?.status === 'NoWay'
-                            ? 'No trade found'
-                            : isWrap
-                            ? 'Wrap'
-                            : isUnwrap
-                            ? 'Unwrap'
-                            : 'Swap'}
-                        </Button>
-                      </DialogTrigger>
-                    </Checker.Success>
-                  </Checker.ApproveERC20>
-                </Checker.Amounts>
-              </Checker.Network>
-            </Checker.Connect>
-          </div>
-        )}
-      </SimpleSwapTradeReviewDialog>
+      <div>
+        <Checker.Connect>
+          <Checker.Network chainId={chainId}>
+            <Checker.Amounts chainId={chainId} amounts={[swapAmount]}>
+              <Checker.ApproveERC20
+                id="approve-erc20"
+                amount={swapAmount}
+                contract={
+                  isRouteProcessor3_2ChainId(chainId)
+                    ? ROUTE_PROCESSOR_3_2_ADDRESS[chainId]
+                    : isRouteProcessor3_1ChainId(chainId)
+                    ? ROUTE_PROCESSOR_3_1_ADDRESS[chainId]
+                    : isRouteProcessor3ChainId(chainId)
+                    ? ROUTE_PROCESSOR_3_ADDRESS[chainId]
+                    : isRouteProcessorChainId(chainId)
+                    ? ROUTE_PROCESSOR_ADDRESS[chainId]
+                    : undefined
+                }
+              >
+                <Checker.Success tag={APPROVE_TAG_SWAP}>
+                  <DialogTrigger asChild>
+                    <Button
+                      size="xl"
+                      disabled={Boolean(
+                        isSlippageError ||
+                          error ||
+                          !trade?.amountOut?.greaterThan(ZERO) ||
+                          trade?.route?.status === 'NoWay' ||
+                          +swapAmountString === 0 ||
+                          (!checked && warningSeverity(trade?.priceImpact) > 3)
+                      )}
+                      color={warningSeverity(trade?.priceImpact) >= 3 ? 'red' : 'blue'}
+                      fullWidth
+                      testId="swap"
+                    >
+                      {!checked && warningSeverity(trade?.priceImpact) >= 3
+                        ? 'Price impact too high'
+                        : trade?.route?.status === 'NoWay'
+                        ? 'No trade found'
+                        : isWrap
+                        ? 'Wrap'
+                        : isUnwrap
+                        ? 'Unwrap'
+                        : 'Swap'}
+                    </Button>
+                  </DialogTrigger>
+                </Checker.Success>
+              </Checker.ApproveERC20>
+            </Checker.Amounts>
+          </Checker.Network>
+        </Checker.Connect>
+      </div>
       {warningSeverity(trade?.priceImpact) > 3 && (
         <div className="flex items-start px-4 py-3 mt-4 rounded-xl bg-red/20">
           <input

--- a/apps/evm/ui/swap/simple/simple-swap-trade-review-dialog.tsx
+++ b/apps/evm/ui/swap/simple/simple-swap-trade-review-dialog.tsx
@@ -54,7 +54,9 @@ import { TradeRoutePathView } from '../trade-route-path-view'
 import { useDerivedStateSimpleSwap, useSimpleSwapTrade } from './derivedstate-simple-swap-provider'
 import { SimpleSwapErrorMessage } from './simple-swap-error-message'
 
-export const SimpleSwapTradeReviewDialog: FC<{ children(error: Error | null): ReactNode }> = ({ children }) => {
+export const SimpleSwapTradeReviewDialog: FC<{
+  children({ error, isSuccess }: { error: Error | null; isSuccess: boolean }): ReactNode
+}> = ({ children }) => {
   const {
     state: { token0, token1, chainId, swapAmount, recipient },
     mutate: { setSwapAmount },
@@ -337,7 +339,7 @@ export const SimpleSwapTradeReviewDialog: FC<{ children(error: Error | null): Re
           <>
             <div className="flex flex-col">
               <SimpleSwapErrorMessage error={error} isSuccess={isPrepareSuccess} isLoading={isPrepareFetching} />
-              <div className="mt-4">{children(error)}</div>
+              <div className="mt-4">{children({ error, isSuccess: isPrepareSuccess })}</div>
             </div>
             <DialogContent>
               <DialogHeader>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The PR adds a new hook `usePersistedSlippageError` to handle persisted slippage errors.
- The `SimpleSwapTradeReviewDialog` component now accepts an object with `error` and `isSuccess` properties as its children.
- The `SimpleSwapErrorMessage` component uses the `usePersistedSlippageError` hook to handle slippage errors.
- The `SimpleSwapTradeButton` component uses the `usePersistedSlippageError` hook to handle slippage errors and includes additional logic for enabling/disabling the swap button based on the error and other conditions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->