### PR TITLE
chore(packages/router): support for xswap liquidity source

### DIFF
--- a/packages/router/src/Router.ts
+++ b/packages/router/src/Router.ts
@@ -234,7 +234,7 @@ export class Router {
 
     return {
       tokenIn,
-      amountIn: source === RouterLiquiditySource.Sender ? route.amountInBI : 0n,
+      amountIn: route.amountInBI,
       tokenOut,
       amountOutMin,
       to,

--- a/packages/router/src/TinesToRouteProcessor2.ts
+++ b/packages/router/src/TinesToRouteProcessor2.ts
@@ -26,7 +26,7 @@ export function getTokenType(token: RToken): TokenType {
 
 export enum RouterLiquiditySource {
   Sender = 'Sender', // msg.sender
-  Self = 'Self', // already aboard
+  XSwap = 'XSwap',
 }
 
 export class TinesToRouteProcessor2 {
@@ -70,7 +70,7 @@ export class TinesToRouteProcessor2 {
         else res += this.processBentoCode(token, route, toAddress)
       } else {
         if (token.address === '') res += this.processNativeCode(token, route, toAddress)
-        else res += this.processERC20Code(source === RouterLiquiditySource.Self, token, route, toAddress)
+        else res += this.processERC20Code(source === RouterLiquiditySource.XSwap, token, route, toAddress)
       }
     })
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- In `Router.ts`, the `amountIn` property is updated to use the `route.amountInBI` value instead of `0n` when the `source` is `RouterLiquiditySource.Sender`.
- In `TinesToRouteProcessor2.ts`, the `RouterLiquiditySource` enum is updated to replace the value `Self` with `XSwap` and the `processERC20Code` method is updated to use `RouterLiquiditySource.XSwap` instead of `RouterLiquiditySource.Self`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->