### PR TITLE
fix(apis/pool): twapEnabled check for unindexed trident pools

### DIFF
--- a/apis/pools/lib/getUnindexedPool.ts
+++ b/apis/pools/lib/getUnindexedPool.ts
@@ -49,22 +49,25 @@ async function getV2Pool({ chainId, address }: GetPoolArgs): Promise<Pool> {
 async function getTridentPool({ chainId, address, protocol }: GetPoolArgs): Promise<Pool> {
   if (!protocol) throw new Error('Protocol is required for Trident pools.')
   // These methods should be identical for all pool types
-  const [token0, token1, totalSupply, swapFee] = await readContracts({
+  const [token0, token1, totalSupply, swapFee, reserves] = await readContracts({
     allowFailure: false,
     contracts: [
       { address: address as Address, abi: tridentConstantPoolAbi, functionName: 'token0', chainId },
       { address: address as Address, abi: tridentConstantPoolAbi, functionName: 'token1', chainId },
       { address: address as Address, abi: tridentConstantPoolAbi, functionName: 'totalSupply', chainId },
       { address: address as Address, abi: tridentConstantPoolAbi, functionName: 'swapFee', chainId },
+      { address: address as Address, abi: tridentConstantPoolAbi, functionName: 'getReserves', chainId },
     ],
   })
+
+  const twapEnabled = reserves[2] > BigInt(0)
 
   return {
     tokens: [token0, token1],
     totalSupply: totalSupply.toString(),
     // 30 => 0.003%
     swapFee: Number(swapFee) / 10000,
-    twapEnabled: true,
+    twapEnabled,
     protocol,
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
Add the ability to retrieve reserves from Trident pools and determine if TWAP (Time-Weighted Average Price) is enabled.

### Detailed summary:
- Added `getReserves` function to the `readContracts` method.
- Added `reserves` variable to store the retrieved reserves.
- Added `twapEnabled` variable to check if TWAP is enabled based on the value of `reserves[2]`.
- Updated the return object to include `twapEnabled` instead of a hardcoded value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->