### PR TITLE
chore(config/wagmi): add additional arbitrum nova rpc

### DIFF
--- a/config/wagmi/src/chains.ts
+++ b/config/wagmi/src/chains.ts
@@ -381,10 +381,10 @@ export const otherChains: Chain[] = [
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     rpcUrls: {
       default: {
-        http: ['https://nova.arbitrum.io/rpc'],
+        http: ['https://nova.arbitrum.io/rpc', 'https://arbitrum-nova.drpc.org'],
       },
       public: {
-        http: ['https://nova.arbitrum.io/rpc'],
+        http: ['https://nova.arbitrum.io/rpc', 'https://arbitrum-nova.drpc.org'],
       },
     },
     blockExplorers: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the RPC URLs for the `default` and `public` configurations in `chains.ts`. 

### Detailed summary
- Added `'https://arbitrum-nova.drpc.org'` to the `http` array for both `default` and `public` configurations in `rpcUrls`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->