### PR TITLE
fix(apps/pool): truncate/make pool header text smaller

### DIFF
--- a/apps/evm/ui/pool/PoolHeader.tsx
+++ b/apps/evm/ui/pool/PoolHeader.tsx
@@ -59,7 +59,7 @@ export const PoolHeader: FC<PoolHeader> = ({ backUrl, address, pool, apy, priceR
           <LinkInternal href={backUrl} className="text-blue hover:underline text-sm">
             ← Pools
           </LinkInternal>
-          <div className="relative flex items-center gap-3">
+          <div className="relative flex items-center gap-3 max-w-[100vh]">
             <Currency.IconList iconWidth={36} iconHeight={36}>
               <Currency.Icon currency={token0} />
               <Currency.Icon currency={token1} />
@@ -69,7 +69,8 @@ export const PoolHeader: FC<PoolHeader> = ({ backUrl, address, pool, apy, priceR
               variant="link"
               className={typographyVariants({
                 variant: 'h1',
-                className: '!text-4xl !font-bold text-gray-900 dark:text-slate-50',
+                className:
+                  'sm:!text2-xl sm:!text-4xl !font-bold text-gray-900 dark:text-slate-50 truncate overflow-x-auto',
               })}
             >
               <LinkExternal href={Chain.from(pool.chainId).getTokenUrl(address)}>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Updated the `PoolHeader` component in `PoolHeader.tsx`.
- Added `max-w-[100vh]` class to the container div.
- Adjusted the typography classes for the heading.
- Added `truncate` and `overflow-x-auto` classes to the heading for responsive behavior.
- Updated the `href` attribute of the external link.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->