### PR TITLE
feat(apps/pool): add full range option at pool creation

### DIFF
--- a/apps/evm/ui/pool/SelectPricesWidget.tsx
+++ b/apps/evm/ui/pool/SelectPricesWidget.tsx
@@ -184,16 +184,15 @@ export const SelectPricesWidget: FC<SelectPricesWidget> = ({
                 )}
               </div>
               <div className="flex flex-1 justify-between">
-                {!noLiquidity && (
-                  <Toggle
-                    variant="outline"
-                    size="sm"
-                    pressed={isFullRange}
-                    onClick={() => (isFullRange ? resetMintState() : getSetFullRange())}
-                  >
-                    Full Range
-                  </Toggle>
-                )}
+                <Toggle
+                  variant="outline"
+                  size="sm"
+                  disabled={!feeAmount}
+                  pressed={isFullRange}
+                  onClick={() => (isFullRange ? resetMintState() : getSetFullRange())}
+                >
+                  Full Range
+                </Toggle>
                 {switchTokens ? (
                   <div className="flex justify-end gap-1">
                     <Toggle variant="outline" onPressedChange={switchTokens} pressed={isSorted} size="sm">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The `Full Range` toggle button in the `SelectPricesWidget` component is now disabled when there is no fee amount.
- The `Toggle` component is updated with the `disabled` prop and its value is set based on the `feeAmount` variable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->