### PR TITLE
Release/extractor

### DIFF
--- a/.changeset/lovely-foxes-deliver.md
+++ b/.changeset/lovely-foxes-deliver.md
@@ -1,0 +1,10 @@
+---
+"@sushiswap/sushixswap-sdk": major
+"@sushiswap/bentobox-sdk": major
+"@sushiswap/token-lists": major
+"@sushiswap/furo-sdk": major
+"@sushiswap/dexie": major
+"@sushiswap/extractor": patch
+---
+
+remove private flags to related depedencies

--- a/packages/bentobox-sdk/package.json
+++ b/packages/bentobox-sdk/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@sushiswap/bentobox-sdk",
-  "version": "0.0.1",
-  "private": true,
+  "version": "0.0.0",
   "description": "BentoBox SDK",
   "keywords": [
     "bentobox",

--- a/packages/dexie/package.json
+++ b/packages/dexie/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@sushiswap/dexie",
   "version": "0.0.8",
-  "private": true,
   "description": "Sushi Dexie",
   "keywords": [
     "sushi",

--- a/packages/furo-sdk/package.json
+++ b/packages/furo-sdk/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@sushiswap/furo-sdk",
   "version": "0.0.1",
-  "private": true,
   "description": "Furo SDK",
   "keywords": [
     "furo",

--- a/packages/sushixswap-sdk/package.json
+++ b/packages/sushixswap-sdk/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@sushiswap/sushixswap-sdk",
   "version": "0.0.1",
-  "private": true,
   "description": "SushiXSwap SDK",
   "keywords": [
     "sushixswap",

--- a/packages/token-lists/package.json
+++ b/packages/token-lists/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@sushiswap/token-lists",
   "version": "0.0.8",
-  "private": true,
   "description": "Sushi Token Lists",
   "keywords": [
     "sushi",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the "private" flags from several dependencies. 

### Detailed summary:
- Updated the version of "@sushiswap/dexie" to "0.0.8"
- Updated the version of "@sushiswap/furo-sdk" to "0.0.1"
- Updated the version of "@sushiswap/token-lists" to "0.0.8"
- Updated the version of "@sushiswap/sushixswap-sdk" to "0.0.1"
- Updated the version of "@sushiswap/bentobox-sdk" to "0.0.0"
- Updated the changeset file to remove the "private" flags for the related dependencies

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->