### PR TITLE
feat: xswap e2e test

### DIFF
--- a/.github/workflows/apps-evm-e2e.yml
+++ b/.github/workflows/apps-evm-e2e.yml
@@ -37,9 +37,10 @@ jobs:
     strategy:
       matrix:
         chain-id: [137]
+        dst-chain-id: [42161]
         node-version: [18]
         pnpm-version: [8.9.2]
-        block-number: [47479278]
+        block-number: [42259027]
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -81,6 +82,7 @@ jobs:
           ANVIL_PORT: 8545
           NEXT_PUBLIC_ALCHEMY_ID: ${{ secrets.NEXT_PUBLIC_ALCHEMY_ID }}
           NEXT_PUBLIC_CHAIN_ID: ${{ matrix.chain-id }}
+          NEXT_PUBLIC_DST_CHAIN_ID: ${{ matrix.dst-chain-id }}
           # NEXT_PUBLIC_DRPC_ID: ${{ secrets.NEXT_PUBLIC_DRPC_ID }}
           NEXT_PUBLIC_APP_ENV: 'test'
         working-directory: .

--- a/apps/evm/test/pages/cross-chain-swap.test.ts
+++ b/apps/evm/test/pages/cross-chain-swap.test.ts
@@ -1,0 +1,239 @@
+
+
+import { Page, expect, test } from '@playwright/test'
+import { ChainId, chainName } from 'sushi/chain'
+import { Native, Type } from 'sushi/currency'
+import { zeroAddress } from 'viem'
+
+import { SupportedChainId } from '../../config'
+
+type InputType = 'INPUT' | 'OUTPUT'
+
+if (typeof process.env.NEXT_PUBLIC_CHAIN_ID !== 'string') {
+  throw new Error('NEXT_PUBLIC_CHAIN_ID not set')
+}
+
+if (typeof process.env.NEXT_PUBLIC_DST_CHAIN_ID !== 'string') {
+  throw new Error('NEXT_PUBLIC_DST_CHAIN_ID not set')
+}
+
+const srcChainId = parseInt(process.env.NEXT_PUBLIC_CHAIN_ID) as SupportedChainId
+const dstChainId = parseInt(process.env.NEXT_PUBLIC_DST_CHAIN_ID) as SupportedChainId
+
+const url = 'http://localhost:3000/swap/cross-chain'
+
+test.beforeEach(async ({ page, }) => {
+  page.on('pageerror', (error) => {
+    console.error(error)
+  })
+
+  await page.goto(url)
+  await switchNetwork(page, srcChainId)
+})
+
+test('Bridge Native to Native', async ({ page, }) => {
+  test.slow()
+  await xswap(page, Native.onChain(srcChainId), Native.onChain(dstChainId), '100')
+})
+
+test('Bridge Native to USDC', async ({ page, }) => {
+  test.slow()
+  await xswap(page, Native.onChain(srcChainId), Native.onChain(dstChainId), '100')
+})
+
+async function xswap(
+  page: Page,
+  inputCurrency: Type,
+  outputCurrency: Type,
+  amount: string,
+) {
+  await handleToken(page, inputCurrency, 'INPUT')
+  await handleToken(page, outputCurrency, 'OUTPUT')
+  await inputAmount(page, amount)
+
+  const swapFromBalance = page.locator('[testdata-id=swap-from-balance-button]')
+  await expect(swapFromBalance).toBeVisible()
+  await expect(swapFromBalance).toBeEnabled()
+  const swapFromBalanceBefore = await swapFromBalance.textContent()
+
+  const swapToBalance = page.locator('[testdata-id=swap-to-balance-button]')
+  await expect(swapToBalance).toBeVisible()
+
+  await approve(page, inputCurrency)
+
+  const swapButton = page.locator('[testdata-id=swap-button]')
+  await expect(swapButton).toBeVisible()
+
+  const priceImpactCheckbox = page.locator(
+    '[testdata-id=price-impact-checkbox]',
+  )
+  while (!(await swapButton.isEnabled())) {
+    if (
+      (await priceImpactCheckbox.isVisible()) &&
+      !(await priceImpactCheckbox.isChecked())
+    ) {
+      await priceImpactCheckbox.check()
+    }
+  }
+
+  await swapButton.click()
+
+  const confirmSwap = page.locator('[testdata-id=confirm-swap-button]')
+  await expect(confirmSwap).toBeVisible()
+  await expect(confirmSwap).toBeEnabled()
+  await confirmSwap.click()
+
+  // If this text is duplicated elsewhere it could false positive
+  const expectedSwappingText = new RegExp(
+    `(Swapping .* ${inputCurrency.symbol}.* to bridge token .* ${outputCurrency.symbol}.*.)`,
+  )
+  expect(page.getByText(expectedSwappingText)).toBeVisible()
+
+  // If this text is duplicated elsewhere it could false positive
+  const expectedSwapText = new RegExp(
+    `(Swap .* ${inputCurrency.symbol}.* to bridge token .* ${outputCurrency.symbol}.*.)`,
+  )
+  expect(page.getByText(expectedSwapText)).toBeVisible()
+
+  // Bridge pending
+  await expect(page.getByText("Bridging to destination chain")).toBeVisible()
+
+  await mockLayerZeroApi(page)
+
+  const expectedSwapSuccessText = new RegExp(
+    `(You sold .* ${inputCurrency.symbol}.* for .* ${outputCurrency.symbol}.*.)|(Sent .* ${outputCurrency.symbol}.* to .*.)`,
+  )
+  await expect(page.getByText(expectedSwapSuccessText)).toBeVisible()
+
+  const close = page.locator('[testdata-id=swap-dialog-close-button]', {
+    hasText: 'Make another swap',
+  },)
+  await expect(close).toBeVisible()
+  await expect(close).toBeEnabled()
+  await close.click()
+
+  // Compare against cached balances to ensure there is at least a change...
+  await expect(swapFromBalance).not.toHaveText(swapFromBalanceBefore as string)
+}
+
+async function approve(page: Page, currency: Type) {
+  if (!currency.isNative) {
+    const approveButton = page.locator('[testdata-id=approve-erc20-button]', {
+      hasText: `Approve ${currency.symbol}`,
+    })
+    await expect(approveButton).toBeVisible()
+    await expect(approveButton).toBeEnabled()
+    await approveButton.click()
+
+    const expectedApprovingText = `Approving ${currency.symbol}`
+    expect(page.getByText(expectedApprovingText)).toBeVisible()
+
+    const expectedApproveText = `Successfully approved ${currency.symbol}`
+    expect(page.getByText(expectedApproveText)).toBeVisible()
+  }
+}
+
+async function handleNetwork(page: Page, chainId: ChainId, type: InputType) {
+  const selectorInfix = `${type === 'INPUT' ? 'from' : 'to'}`
+
+  // Open network list
+  const networkSelector = page.locator(
+    `[testdata-id=network-selector-${selectorInfix}-button]`,
+  )
+  await expect(networkSelector).toBeVisible()
+  await expect(networkSelector).toBeEnabled()
+  await networkSelector.click()
+
+  const networkSearch = page.locator(
+    `[testdata-id=network-selector-input]`,
+  )
+  await expect(networkSearch).toBeVisible()
+  await expect(networkSearch).toBeEnabled()
+  await networkSearch.fill(chainName[chainId])
+
+  const networkToSelect = page.locator(
+    `[testdata-id=network-selector-${chainId}]`,
+  )
+  await expect(networkToSelect).toBeVisible()
+
+  await networkToSelect.click()
+  await expect(networkSelector).toContainText(chainName[chainId])
+}
+
+async function handleToken(page: Page, currency: Type, type: InputType) {
+  await handleNetwork(page, currency.chainId, type)
+
+  const selectorInfix = `${type === 'INPUT' ? 'from' : 'to'}`
+
+  // Open token list
+  const tokenSelector = page.locator(
+    `[testdata-id=swap-${selectorInfix}-button]`,
+  )
+  await expect(tokenSelector).toBeVisible()
+  await expect(tokenSelector).toBeEnabled()
+  await tokenSelector.click()
+
+  const tokenSearch = page.locator(
+    `[testdata-id=swap-${selectorInfix}-token-selector-address-input]`,
+  )
+  await expect(tokenSearch).toBeVisible()
+  await expect(tokenSearch).toBeEnabled()
+  await tokenSearch.fill(currency.symbol as string)
+
+  const tokenToSelect = page.locator(
+    `[testdata-id=swap-${selectorInfix}-token-selector-row-${currency.isNative ? zeroAddress : currency.address.toLowerCase()
+    }]`,
+  )
+  await expect(tokenToSelect).toBeVisible()
+
+  await tokenToSelect.click()
+  await expect(tokenSelector).toContainText(currency.symbol as string)
+}
+
+async function inputAmount(page: Page, amount: string) {
+  const input0 = page.locator('[testdata-id=swap-from-input]')
+  // Inputs are not rendered until the trade is found
+  await expect(input0).toBeVisible()
+  await expect(input0).toBeEnabled()
+  await input0.fill(amount)
+}
+
+async function switchNetwork(page: Page, chainId: number) {
+  const networkSelector = page.locator('[testdata-id=network-selector-button]')
+  await expect(networkSelector).toBeVisible()
+  await expect(networkSelector).toBeEnabled()
+  await networkSelector.click()
+
+  const networkToSelect = page.locator(
+    `[testdata-id=network-selector-${chainId}]`,
+  )
+  await expect(networkToSelect).toBeVisible()
+  await expect(networkToSelect).toBeEnabled()
+  await networkToSelect.click()
+
+  const fromToken = page.locator('[testdata-id=swap-from-button]')
+  await expect(fromToken).toHaveText(Native.onChain(chainId).symbol)
+}
+
+async function mockLayerZeroApi(
+  page: Page,
+) {
+
+  const mockLayerZeroResp = {
+    messages: [{
+      srcUaAddress: zeroAddress,
+      dstUaAddress: zeroAddress,
+      srcChainId: 1,
+      dstChainId: 1,
+      srcUaNonce: 0,
+      status: "DELIVERED",
+    }]
+  }
+
+  await page.route('https://api-mainnet.layerzero-scan.com/tx/*', async (route) => {
+    await route.fulfill({
+      json: mockLayerZeroResp
+    })
+  }
+  )
+}

--- a/apps/evm/test/pages/cross-chain-swap.test.ts
+++ b/apps/evm/test/pages/cross-chain-swap.test.ts
@@ -1,5 +1,3 @@
-
-
 import { Page, expect, test } from '@playwright/test'
 import { ChainId, chainName } from 'sushi/chain'
 import { Native, Type } from 'sushi/currency'
@@ -17,12 +15,16 @@ if (typeof process.env.NEXT_PUBLIC_DST_CHAIN_ID !== 'string') {
   throw new Error('NEXT_PUBLIC_DST_CHAIN_ID not set')
 }
 
-const srcChainId = parseInt(process.env.NEXT_PUBLIC_CHAIN_ID) as SupportedChainId
-const dstChainId = parseInt(process.env.NEXT_PUBLIC_DST_CHAIN_ID) as SupportedChainId
+const srcChainId = parseInt(
+  process.env.NEXT_PUBLIC_CHAIN_ID,
+) as SupportedChainId
+const dstChainId = parseInt(
+  process.env.NEXT_PUBLIC_DST_CHAIN_ID,
+) as SupportedChainId
 
 const url = 'http://localhost:3000/swap/cross-chain'
 
-test.beforeEach(async ({ page, }) => {
+test.beforeEach(async ({ page }) => {
   page.on('pageerror', (error) => {
     console.error(error)
   })
@@ -31,14 +33,24 @@ test.beforeEach(async ({ page, }) => {
   await switchNetwork(page, srcChainId)
 })
 
-test('Bridge Native to Native', async ({ page, }) => {
+test('Bridge Native to Native', async ({ page }) => {
   test.slow()
-  await xswap(page, Native.onChain(srcChainId), Native.onChain(dstChainId), '100')
+  await xswap(
+    page,
+    Native.onChain(srcChainId),
+    Native.onChain(dstChainId),
+    '100',
+  )
 })
 
-test('Bridge Native to USDC', async ({ page, }) => {
+test('Bridge Native to USDC', async ({ page }) => {
   test.slow()
-  await xswap(page, Native.onChain(srcChainId), Native.onChain(dstChainId), '100')
+  await xswap(
+    page,
+    Native.onChain(srcChainId),
+    Native.onChain(dstChainId),
+    '100',
+  )
 })
 
 async function xswap(
@@ -96,7 +108,7 @@ async function xswap(
   expect(page.getByText(expectedSwapText)).toBeVisible()
 
   // Bridge pending
-  await expect(page.getByText("Bridging to destination chain")).toBeVisible()
+  await expect(page.getByText('Bridging to destination chain')).toBeVisible()
 
   await mockLayerZeroApi(page)
 
@@ -107,7 +119,7 @@ async function xswap(
 
   const close = page.locator('[testdata-id=swap-dialog-close-button]', {
     hasText: 'Make another swap',
-  },)
+  })
   await expect(close).toBeVisible()
   await expect(close).toBeEnabled()
   await close.click()
@@ -144,9 +156,7 @@ async function handleNetwork(page: Page, chainId: ChainId, type: InputType) {
   await expect(networkSelector).toBeEnabled()
   await networkSelector.click()
 
-  const networkSearch = page.locator(
-    `[testdata-id=network-selector-input]`,
-  )
+  const networkSearch = page.locator(`[testdata-id=network-selector-input]`)
   await expect(networkSearch).toBeVisible()
   await expect(networkSearch).toBeEnabled()
   await networkSearch.fill(chainName[chainId])
@@ -181,7 +191,8 @@ async function handleToken(page: Page, currency: Type, type: InputType) {
   await tokenSearch.fill(currency.symbol as string)
 
   const tokenToSelect = page.locator(
-    `[testdata-id=swap-${selectorInfix}-token-selector-row-${currency.isNative ? zeroAddress : currency.address.toLowerCase()
+    `[testdata-id=swap-${selectorInfix}-token-selector-row-${
+      currency.isNative ? zeroAddress : currency.address.toLowerCase()
     }]`,
   )
   await expect(tokenToSelect).toBeVisible()
@@ -215,25 +226,26 @@ async function switchNetwork(page: Page, chainId: number) {
   await expect(fromToken).toHaveText(Native.onChain(chainId).symbol)
 }
 
-async function mockLayerZeroApi(
-  page: Page,
-) {
-
+async function mockLayerZeroApi(page: Page) {
   const mockLayerZeroResp = {
-    messages: [{
-      srcUaAddress: zeroAddress,
-      dstUaAddress: zeroAddress,
-      srcChainId: 1,
-      dstChainId: 1,
-      srcUaNonce: 0,
-      status: "DELIVERED",
-    }]
+    messages: [
+      {
+        srcUaAddress: zeroAddress,
+        dstUaAddress: zeroAddress,
+        srcChainId: 1,
+        dstChainId: 1,
+        srcUaNonce: 0,
+        status: 'DELIVERED',
+      },
+    ],
   }
 
-  await page.route('https://api-mainnet.layerzero-scan.com/tx/*', async (route) => {
-    await route.fulfill({
-      json: mockLayerZeroResp
-    })
-  }
+  await page.route(
+    'https://api-mainnet.layerzero-scan.com/tx/*',
+    async (route) => {
+      await route.fulfill({
+        json: mockLayerZeroResp,
+      })
+    },
   )
 }

--- a/apps/evm/ui/swap/cross-chain/cross-chain-swap-token0-input.tsx
+++ b/apps/evm/ui/swap/cross-chain/cross-chain-swap-token0-input.tsx
@@ -36,7 +36,7 @@ export const CrossChainSwapToken0Input = () => {
               close()
             }}
           >
-            <Button variant="secondary" size="xs">
+            <Button variant="secondary" size="xs" testId="network-selector-from">
               <NetworkIcon chainId={chainId0} width={16} height={16} />
               {Chain.from(chainId0)?.name}
               <SelectIcon />

--- a/apps/evm/ui/swap/cross-chain/cross-chain-swap-token0-input.tsx
+++ b/apps/evm/ui/swap/cross-chain/cross-chain-swap-token0-input.tsx
@@ -36,7 +36,11 @@ export const CrossChainSwapToken0Input = () => {
               close()
             }}
           >
-            <Button variant="secondary" size="xs" testId="network-selector-from">
+            <Button
+              variant="secondary"
+              size="xs"
+              testId="network-selector-from"
+            >
               <NetworkIcon chainId={chainId0} width={16} height={16} />
               {Chain.from(chainId0)?.name}
               <SelectIcon />

--- a/apps/evm/ui/swap/cross-chain/cross-chain-swap-token1-input.tsx
+++ b/apps/evm/ui/swap/cross-chain/cross-chain-swap-token1-input.tsx
@@ -46,7 +46,7 @@ export const CrossChainSwapToken1Input = () => {
                 close()
               }}
             >
-              <Button variant="secondary" size="xs">
+              <Button variant="secondary" size="xs" testId="network-selector-to">
                 <NetworkIcon chainId={chainId1} width={16} height={16} />
                 {Chain.from(chainId1)?.name}
                 <SelectIcon />

--- a/apps/evm/ui/swap/cross-chain/cross-chain-swap-token1-input.tsx
+++ b/apps/evm/ui/swap/cross-chain/cross-chain-swap-token1-input.tsx
@@ -46,7 +46,11 @@ export const CrossChainSwapToken1Input = () => {
                 close()
               }}
             >
-              <Button variant="secondary" size="xs" testId="network-selector-to">
+              <Button
+                variant="secondary"
+                size="xs"
+                testId="network-selector-to"
+              >
                 <NetworkIcon chainId={chainId1} width={16} height={16} />
                 {Chain.from(chainId1)?.name}
                 <SelectIcon />

--- a/apps/evm/ui/swap/cross-chain/cross-chain-swap-trade-button.tsx
+++ b/apps/evm/ui/swap/cross-chain/cross-chain-swap-trade-button.tsx
@@ -67,6 +67,7 @@ export const CrossChainSwapTradeButton: FC = () => {
                         }
                         fullWidth
                         size="xl"
+                        testId="swap"
                       >
                         {!checked && warningSeverity(trade?.priceImpact) >= 3
                           ? 'Price impact too high'

--- a/apps/evm/ui/swap/cross-chain/cross-chain-swap-trade-review-dialog.tsx
+++ b/apps/evm/ui/swap/cross-chain/cross-chain-swap-trade-review-dialog.tsx
@@ -496,7 +496,7 @@ export const CrossChainSwapTradeReviewDialog: FC<{ children: ReactNode }> = ({
                       ? 'red'
                       : 'blue'
                   }
-                  testId='confirm-swap'
+                  testId="confirm-swap"
                 >
                   {isError ? (
                     'Shoot! Something went wrong :('
@@ -539,7 +539,7 @@ export const CrossChainSwapTradeReviewDialog: FC<{ children: ReactNode }> = ({
           </div>
           <DialogFooter>
             <DialogClose asChild>
-              <Button size="xl" fullWidth id='swap-dialog-close'>
+              <Button size="xl" fullWidth id="swap-dialog-close">
                 {failedState(stepStates)
                   ? 'Try again'
                   : finishedState(stepStates)

--- a/apps/evm/ui/swap/cross-chain/cross-chain-swap-trade-review-dialog.tsx
+++ b/apps/evm/ui/swap/cross-chain/cross-chain-swap-trade-review-dialog.tsx
@@ -77,7 +77,6 @@ import {
 export const CrossChainSwapTradeReviewDialog: FC<{ children: ReactNode }> = ({
   children,
 }) => {
-  const [review, setReview] = useState(false)
   const [slippageTolerance] = useSlippageTolerance()
   const { address } = useAccount()
   const { chain } = useNetwork()
@@ -239,8 +238,6 @@ export const CrossChainSwapTradeReviewDialog: FC<{ children: ReactNode }> = ({
   })
 
   const onComplete = useCallback(() => {
-    setReview(false)
-
     // Reset after half a second because of dialog close animation
     setTimeout(() => {
       setStepStates({
@@ -253,42 +250,36 @@ export const CrossChainSwapTradeReviewDialog: FC<{ children: ReactNode }> = ({
 
   const onClick = useCallback(
     (confirm: () => void) => {
-      if (pendingState(stepStates)) {
-        setReview(true)
-      } else if (review) {
-        setStepStates({
-          source: StepState.Sign,
-          bridge: StepState.NotStarted,
-          dest: StepState.NotStarted,
-        })
+      setStepStates({
+        source: StepState.Sign,
+        bridge: StepState.NotStarted,
+        dest: StepState.NotStarted,
+      })
 
-        const promise = writeAsync?.()
-        if (promise) {
-          promise
-            .then(() => {
-              confirm()
+      const promise = writeAsync?.()
+      if (promise) {
+        promise
+          .then(() => {
+            confirm()
+            setStepStates({
+              source: StepState.Pending,
+              bridge: StepState.NotStarted,
+              dest: StepState.NotStarted,
+            })
+          })
+          .catch((e: unknown) => {
+            if (e instanceof UserRejectedRequestError) onComplete()
+            else {
               setStepStates({
-                source: StepState.Pending,
+                source: StepState.Failed,
                 bridge: StepState.NotStarted,
                 dest: StepState.NotStarted,
               })
-            })
-            .catch((e: unknown) => {
-              if (e instanceof UserRejectedRequestError) onComplete()
-              else {
-                setStepStates({
-                  source: StepState.Failed,
-                  bridge: StepState.NotStarted,
-                  dest: StepState.NotStarted,
-                })
-              }
-            })
-        }
-      } else {
-        setReview(true)
+            }
+          })
       }
     },
-    [onComplete, review, stepStates, writeAsync],
+    [onComplete, stepStates, writeAsync],
   )
 
   const { data: lzData } = useLayerZeroScanLink({
@@ -505,6 +496,7 @@ export const CrossChainSwapTradeReviewDialog: FC<{ children: ReactNode }> = ({
                       ? 'red'
                       : 'blue'
                   }
+                  testId='confirm-swap'
                 >
                   {isError ? (
                     'Shoot! Something went wrong :('
@@ -547,7 +539,7 @@ export const CrossChainSwapTradeReviewDialog: FC<{ children: ReactNode }> = ({
           </div>
           <DialogFooter>
             <DialogClose asChild>
-              <Button size="xl" fullWidth>
+              <Button size="xl" fullWidth id='swap-dialog-close'>
                 {failedState(stepStates)
                   ? 'Try again'
                   : finishedState(stepStates)

--- a/packages/ui/src/components/network-selector.tsx
+++ b/packages/ui/src/components/network-selector.tsx
@@ -62,7 +62,7 @@ const NetworkSelector = <T extends number>({
       <PopoverPrimitive.Trigger asChild>{children}</PopoverPrimitive.Trigger>
       <PopoverContent className="!w-60 !p-0 !overflow-x-hidden !overflow-y-scroll scroll">
         <Command>
-          <CommandInput placeholder="Search network" />
+          <CommandInput testdata-id="network-selector-input" placeholder="Search network" />
           <CommandEmpty>No network found.</CommandEmpty>
           <CommandGroup>
             {_networks.map((el) => (

--- a/packages/ui/src/components/network-selector.tsx
+++ b/packages/ui/src/components/network-selector.tsx
@@ -62,7 +62,10 @@ const NetworkSelector = <T extends number>({
       <PopoverPrimitive.Trigger asChild>{children}</PopoverPrimitive.Trigger>
       <PopoverContent className="!w-60 !p-0 !overflow-x-hidden !overflow-y-scroll scroll">
         <Command>
-          <CommandInput testdata-id="network-selector-input" placeholder="Search network" />
+          <CommandInput
+            testdata-id="network-selector-input"
+            placeholder="Search network"
+          />
           <CommandEmpty>No network found.</CommandEmpty>
           <CommandGroup>
             {_networks.map((el) => (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `testId` prop to `cross-chain-swap-trade-button.tsx`, `cross-chain-swap-token1-input.tsx`, `cross-chain-swap-token0-input.tsx`, `network-selector.tsx`, `cross-chain-swap-trade-review-dialog.tsx`, and `cross-chain-swap.test.ts`.
- Updated `apps-evm-e2e.yml` to include `dst-chain-id` and `block-number` in the matrix.
- Removed `useState` hook and related logic in `cross-chain-swap-trade-review-dialog.tsx`.
- Updated `cross-chain-swap-trade-review-dialog.tsx` to handle `UserRejectedRequestError` and set step states accordingly.
- Added `test` file for `cross-chain-swap.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->