### PR TITLE
fix(pkgs/wagmi): don't load balances when no wallet is connected

### DIFF
--- a/packages/wagmi/src/components/token-selector/TokenSelector.tsx
+++ b/packages/wagmi/src/components/token-selector/TokenSelector.tsx
@@ -83,7 +83,7 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
   const { data: pricesMap } = usePrices({ chainId })
   const {
     data: balancesMap,
-    isLoading: isBalanceLoading,
+    isInitialLoading: isBalanceLoading,
     refetch,
   } = useBalances({ chainId, account: address, enabled: open })
 
@@ -161,8 +161,8 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
 
   // Refetch whenever TokenSelector opens
   useEffect(() => {
-    if (open) refetch()
-  }, [open, refetch])
+    if (open && !!address) refetch()
+  }, [open, address, refetch])
 
   const isLoading =
     isTokensLoading || isOtherTokensLoading || isQueryTokenLoading


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Changed the variable name `isLoading` to `isInitialLoading` in the `TokenSelector` component.
- Modified the `useEffect` hook to only refetch data if `open` is true and `address` is not empty.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->