### PR TITLE
fix: price range percent change on v3 position

### DIFF
--- a/apps/evm/src/ui/pool/PositionView.tsx
+++ b/apps/evm/src/ui/pool/PositionView.tsx
@@ -501,13 +501,13 @@ const Component: FC<{ id: string }> = ({ id }) => {
                                     {priceLower
                                       ?.subtract(
                                         invert
-                                          ? pool.token1Price
-                                          : pool.token0Price,
+                                          ? pool.token0Price
+                                          : pool.token1Price,
                                       )
                                       .divide(
                                         invert
-                                          ? pool.token1Price
-                                          : pool.token0Price,
+                                          ? pool.token0Price
+                                          : pool.token1Price,
                                       )
                                       .multiply(100)
                                       .toSignificant(2)}
@@ -522,13 +522,13 @@ const Component: FC<{ id: string }> = ({ id }) => {
                                       {priceLower
                                         ?.subtract(
                                           invert
-                                            ? pool.token1Price
-                                            : pool.token0Price,
+                                            ? pool.token0Price
+                                            : pool.token1Price,
                                         )
                                         .divide(
                                           invert
-                                            ? pool.token1Price
-                                            : pool.token0Price,
+                                            ? pool.token0Price
+                                            : pool.token1Price,
                                         )
                                         .multiply(100)
                                         .toSignificant(2)}
@@ -579,13 +579,13 @@ const Component: FC<{ id: string }> = ({ id }) => {
                                     {priceUpper
                                       ?.subtract(
                                         invert
-                                          ? pool.token1Price
-                                          : pool.token0Price,
+                                          ? pool.token0Price
+                                          : pool.token1Price,
                                       )
                                       .divide(
                                         invert
-                                          ? pool.token1Price
-                                          : pool.token0Price,
+                                          ? pool.token0Price
+                                          : pool.token1Price,
                                       )
                                       .multiply(100)
                                       .toSignificant(2)}
@@ -600,13 +600,13 @@ const Component: FC<{ id: string }> = ({ id }) => {
                                       {priceUpper
                                         ?.subtract(
                                           invert
-                                            ? pool.token1Price
-                                            : pool.token0Price,
+                                            ? pool.token0Price
+                                            : pool.token1Price,
                                         )
                                         .divide(
                                           invert
-                                            ? pool.token1Price
-                                            : pool.token0Price,
+                                            ? pool.token0Price
+                                            : pool.token1Price,
                                         )
                                         .multiply(100)
                                         .toSignificant(2)}


### PR DESCRIPTION
<img width="400" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/d65be0c9-5242-4de0-a4c1-10aa472011df">
<img width="400" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/3817fef0-3d4b-4555-95bf-83aee54fcd03">


Before:
<img width="390" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/b50623f8-5340-4501-9bd4-07ec1d143902">
<img width="390" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/1f92e881-4a0b-4ef1-914e-e4e2db8ca983">

After:
<img width="540" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/6b2ea6ef-b2c2-44b4-8867-d15863260fed">
<img width="533" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/40ca5181-4a16-4df6-be6d-422a355b53d7">


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on swapping the values of `pool.token0Price` and `pool.token1Price` in the `PositionView.tsx` file.

### Detailed summary:
- Swapped the values of `pool.token0Price` and `pool.token1Price` in the `subtract` and `divide` calculations.
- Updated the calculation of `priceLower` and `priceUpper` accordingly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->