### PR TITLE
fix(config/graph): update v2 bttc subgraph name

### DIFF
--- a/config/graph/src/index.ts
+++ b/config/graph/src/index.ts
@@ -286,7 +286,7 @@ export const SUSHISWAP_SUBGRAPH_NAME: Record<number, string> = {
   [ChainId.SCROLL]: 'sushiswap-scroll/v0.0.1',
   [ChainId.KAVA]: 'sushi-v2/sushiswap-kava',
   [ChainId.METIS]: 'sushi-v2/sushiswap-metis',
-  [ChainId.BTTC]: 'sushi-v2/bttc',
+  [ChainId.BTTC]: 'sushi-v2/sushiswap-bttc',
 } as const
 
 export const SUSHISWAP_V3_SUBGRAPH_NAME: Record<number, string> = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The focus of this PR is to update the subgraph name for the `BTTC` chain in the Sushiswap v2 configuration file.
- The subgraph name is changed from `sushi-v2/bttc` to `sushi-v2/sushiswap-bttc`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->