### PR TITLE
fix: xswap link on landing page

### DIFF
--- a/apps/evm/src/app/(landing)/components/Story/Section2/Move.tsx
+++ b/apps/evm/src/app/(landing)/components/Story/Section2/Move.tsx
@@ -20,7 +20,7 @@ export const Move: FC = () => {
                 you’re on, with no extra fees.
               </h5>
               <div className="flex gap-6">
-                <LinkInternal href="/xswap">
+                <LinkInternal href="/swap/cross-chain">
                   <Button asChild variant="secondary">
                     Visit xSwap
                   </Button>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- The `href` attribute of the `LinkInternal` component in `Move.tsx` has been changed from "/xswap" to "/swap/cross-chain".
- The text content of the `Button` component has been changed from "Visit xSwap" to "Visit xSwap".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->