### PR TITLE
Feat/add steer types

### DIFF
--- a/apps/evm/src/ui/pool/CreatePositionManual.tsx
+++ b/apps/evm/src/ui/pool/CreatePositionManual.tsx
@@ -18,15 +18,6 @@ import { ConcentratedLiquidityWidget } from 'src/ui/pool/ConcentratedLiquidityWi
 
 import { SelectPricesWidget } from './SelectPricesWidget'
 
-export const SteerStrategies = {
-  [SteerStrategy.ClassicRebalance]: <></>,
-  [SteerStrategy.DeltaNeutralStables]: <></>,
-  [SteerStrategy.ElasticExpansion]: <></>,
-  [SteerStrategy.HighLowChannel]: <></>,
-  [SteerStrategy.MovingVolatilityChannelMedium]: <></>,
-  [SteerStrategy.StaticStable]: <></>,
-} as const satisfies Record<SteerStrategy, unknown>
-
 interface ManualProps {
   address: string
   chainId: SushiSwapV3ChainId

--- a/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerBaseStrategy.tsx
+++ b/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerBaseStrategy.tsx
@@ -32,7 +32,7 @@ import {
 import { SteerStrategyLiquidityDistribution } from '../SteerStrategyLiquidityChart'
 import { SteerStrategyConfig } from '../constants'
 
-export const SteerElasticExpansionStrategy: SteerStrategyComponent = ({
+export const SteerBaseStrategy: SteerStrategyComponent = ({
   vault,
   generic: { priceExtremes, tokenRatios, adjustment, positions },
 }) => {

--- a/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerClassicRebalanceStrategy.tsx
+++ b/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerClassicRebalanceStrategy.tsx
@@ -1,5 +1,0 @@
-import { SteerStrategyComponent } from '.'
-import { SteerElasticExpansionStrategy } from './SteerElasticExpansionStrategy'
-
-export const SteerClassicRebalanceStrategy: SteerStrategyComponent =
-  SteerElasticExpansionStrategy

--- a/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerDeltaNeutralStablesStrategy.tsx
+++ b/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerDeltaNeutralStablesStrategy.tsx
@@ -1,5 +1,0 @@
-import { SteerStrategyComponent } from '.'
-import { SteerElasticExpansionStrategy } from './SteerElasticExpansionStrategy'
-
-export const SteerDeltaNeutralStablesStrategy: SteerStrategyComponent =
-  SteerElasticExpansionStrategy

--- a/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerHighLowChannelStrategy.tsx
+++ b/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerHighLowChannelStrategy.tsx
@@ -1,5 +1,0 @@
-import { SteerStrategyComponent } from '.'
-import { SteerElasticExpansionStrategy } from './SteerElasticExpansionStrategy'
-
-export const SteerHighLowChannelStrategy: SteerStrategyComponent =
-  SteerElasticExpansionStrategy

--- a/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerMovingVolatilityChannelMediumStrategy.tsx
+++ b/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerMovingVolatilityChannelMediumStrategy.tsx
@@ -1,7 +1,0 @@
-'use client'
-
-import { SteerStrategyComponent } from '.'
-import { SteerElasticExpansionStrategy } from './SteerElasticExpansionStrategy'
-
-export const SteerMovingVolatilityChannelMediumStrategy: SteerStrategyComponent =
-  SteerElasticExpansionStrategy

--- a/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerStaticStableStrategy.tsx
+++ b/apps/evm/src/ui/pool/Steer/SteerStrategies/SteerStaticStableStrategy.tsx
@@ -1,7 +1,0 @@
-'use client'
-
-import { SteerStrategyComponent } from '.'
-import { SteerElasticExpansionStrategy } from './SteerElasticExpansionStrategy'
-
-export const SteerStaticStableStrategy: SteerStrategyComponent =
-  SteerElasticExpansionStrategy

--- a/apps/evm/src/ui/pool/Steer/SteerStrategies/index.ts
+++ b/apps/evm/src/ui/pool/Steer/SteerStrategies/index.ts
@@ -2,12 +2,7 @@ import { SteerVault } from '@sushiswap/client'
 import { SteerStrategy } from '@sushiswap/client'
 import { FC } from 'react'
 
-import { SteerClassicRebalanceStrategy } from './SteerClassicRebalanceStrategy'
-import { SteerDeltaNeutralStablesStrategy } from './SteerDeltaNeutralStablesStrategy'
-import { SteerElasticExpansionStrategy } from './SteerElasticExpansionStrategy'
-import { SteerHighLowChannelStrategy } from './SteerHighLowChannelStrategy'
-import { SteerMovingVolatilityChannelMediumStrategy } from './SteerMovingVolatilityChannelMediumStrategy'
-import { SteerStaticStableStrategy } from './SteerStaticStableStrategy'
+import { SteerBaseStrategy } from './SteerBaseStrategy'
 
 export interface SteerStrategyGeneric {
   tokenRatios: {
@@ -38,11 +33,16 @@ export const SteerStrategyComponents: Record<
   SteerStrategy,
   SteerStrategyComponent
 > = {
-  [SteerStrategy.ClassicRebalance]: SteerClassicRebalanceStrategy,
-  [SteerStrategy.DeltaNeutralStables]: SteerDeltaNeutralStablesStrategy,
-  [SteerStrategy.ElasticExpansion]: SteerElasticExpansionStrategy,
-  [SteerStrategy.HighLowChannel]: SteerHighLowChannelStrategy,
-  [SteerStrategy.MovingVolatilityChannelMedium]:
-    SteerMovingVolatilityChannelMediumStrategy,
-  [SteerStrategy.StaticStable]: SteerStaticStableStrategy,
+  [SteerStrategy.ClassicRebalance]: SteerBaseStrategy,
+  [SteerStrategy.DeltaNeutralStables]: SteerBaseStrategy,
+  [SteerStrategy.ElasticExpansion]: SteerBaseStrategy,
+  [SteerStrategy.HighLowChannel]: SteerBaseStrategy,
+  [SteerStrategy.MovingVolatilityChannelMedium]: SteerBaseStrategy,
+  [SteerStrategy.StaticStable]: SteerBaseStrategy,
+  [SteerStrategy.BollingerAlgo]: SteerBaseStrategy,
+  [SteerStrategy.ChannelMultiplier]: SteerBaseStrategy,
+  [SteerStrategy.FixedPercentage]: SteerBaseStrategy,
+  [SteerStrategy.PriceMultiplier]: SteerBaseStrategy,
+  [SteerStrategy.KeltnerAlgo]: SteerBaseStrategy,
+  [SteerStrategy.MovingVolatilityChannel]: SteerBaseStrategy,
 }

--- a/apps/evm/src/ui/pool/Steer/constants.tsx
+++ b/apps/evm/src/ui/pool/Steer/constants.tsx
@@ -36,4 +36,31 @@ export const SteerStrategyConfig: Record<SteerStrategy, SteerStrategyConfig> = {
     description:
       "This strategy is set based on the token's decimal precision and the typical offset and variance from the ideal peg. These positions are static, meaning low gas fees and reduced price volatility.",
   },
+  [SteerStrategy.BollingerAlgo]: {
+    name: 'Bollinger Bands Pool',
+    description: '',
+  },
+  [SteerStrategy.ChannelMultiplier]: {
+    name: 'Channel Multiplier Pool',
+    description:
+      'This strategy uses a multiplier to make channel around the price. The wider the multiplier the wider area of coverage on channel on both side of current price.',
+  },
+  [SteerStrategy.FixedPercentage]: {
+    name: 'Fixed Percentage Pool',
+    description: '',
+  },
+  [SteerStrategy.PriceMultiplier]: {
+    name: 'Price Multiplier Pool',
+    description:
+      'This strategy makes a position based on a multiplier of the current price of the pool. The multiplier makes a position from the price / multiplier to the price * multiplier.',
+  },
+  [SteerStrategy.KeltnerAlgo]: {
+    name: 'Keltner Channel Pool',
+    description: '',
+  },
+  [SteerStrategy.MovingVolatilityChannel]: {
+    name: 'Moving Volatility Pool',
+    description:
+      'This strategy uses recent trading data to form a Keltner Channel that sets the range to place optimal liquidity for a given period of time. The Keltner Channel is a technical indicator that measures volatility using upper and lower bands, and an exponential moving average. These bands adjust based on market volatility and can help identify trends useful for providing liquidity. The Keltner Channel is a useful tool for LPs seeking to make informed decisions based on market volatility.',
+  },
 }

--- a/apps/evm/src/ui/pool/Steer/constants.tsx
+++ b/apps/evm/src/ui/pool/Steer/constants.tsx
@@ -38,7 +38,8 @@ export const SteerStrategyConfig: Record<SteerStrategy, SteerStrategyConfig> = {
   },
   [SteerStrategy.BollingerAlgo]: {
     name: 'Bollinger Bands Pool',
-    description: '',
+    description:
+      'This strategy uses a technique called Bollinger bands to create a flexible pool of funds for liquidity provision. It automatically adjusts to changes in market conditions, such as price swings and fluctuations, to optimize the placement of funds, fees earned, and capital efficiency.',
   },
   [SteerStrategy.ChannelMultiplier]: {
     name: 'Channel Multiplier Pool',
@@ -47,7 +48,8 @@ export const SteerStrategyConfig: Record<SteerStrategy, SteerStrategyConfig> = {
   },
   [SteerStrategy.FixedPercentage]: {
     name: 'Fixed Percentage Pool',
-    description: '',
+    description:
+      'This strategy routinely sets a position of a provided percentage spreading above and below the current price.',
   },
   [SteerStrategy.PriceMultiplier]: {
     name: 'Price Multiplier Pool',
@@ -56,7 +58,8 @@ export const SteerStrategyConfig: Record<SteerStrategy, SteerStrategyConfig> = {
   },
   [SteerStrategy.KeltnerAlgo]: {
     name: 'Keltner Channel Pool',
-    description: '',
+    description:
+      'This strategy uses recent trading data to form a Keltner Channel that sets the range to place optimal liquidity for a given period of time. The Keltner Channel is a technical indicator that measures volatility using upper and lower bands, and an exponential moving average. These bands adjust based on market volatility and can help identify trends useful for providing liquidity.',
   },
   [SteerStrategy.MovingVolatilityChannel]: {
     name: 'Moving Volatility Pool',

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -212,10 +212,16 @@ model Incentive {
 enum SteerStrategy {
   DeltaNeutralStables
   ElasticExpansion
+  MovingVolatilityChannel
   MovingVolatilityChannelMedium
   HighLowChannel
   StaticStable
   ClassicRebalance
+  ChannelMultiplier
+  PriceMultiplier
+  FixedPercentage
+  KeltnerAlgo
+  BollingerAlgo
 }
 
 enum VaultState {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on deleting unused files and adding new strategies to the Steer feature in the EVM app.

### Detailed summary:
- Deleted the following files:
  - `SteerStaticStableStrategy.tsx`
  - `SteerHighLowChannelStrategy.tsx`
  - `SteerClassicRebalanceStrategy.tsx`
  - `SteerDeltaNeutralStablesStrategy.tsx`
  - `SteerMovingVolatilityChannelMediumStrategy.tsx`
  - `schema.prisma`

- Added the following strategies to the Steer feature:
  - `MovingVolatilityChannel`
  - `ChannelMultiplier`
  - `PriceMultiplier`
  - `FixedPercentage`
  - `KeltnerAlgo`
  - `BollingerAlgo`

- Updated the `SteerElasticExpansionStrategy` file to `SteerBaseStrategy`.

- Updated the `SteerStrategies` object in `CreatePositionManual.tsx` to remove the deleted strategies.

- Updated the `SteerStrategyComponents` object in `index.ts` to include the new strategies.

- Added descriptions for the new strategies in `constants.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->