### PR TITLE
fix: useTicks contractReads

### DIFF
--- a/apps/evm/src/lib/hooks/useTicks.ts
+++ b/apps/evm/src/lib/hooks/useTicks.ts
@@ -89,7 +89,11 @@ export function useTicks({
 
   const contractReads = useMemo(() => {
     const reads = []
-    if (minIndex && maxIndex && poolAddress) {
+    if (
+      typeof minIndex === 'number' &&
+      typeof maxIndex === 'number' &&
+      typeof poolAddress === 'string'
+    ) {
       for (let i = minIndex; i <= maxIndex; i++) {
         reads.push({
           ...getV3TickLensContractConfig(chainId),


### PR DESCRIPTION
resolves LiquidityChartRangeInput not displaying when creating a new position

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added type checks for `minIndex`, `maxIndex`, and `poolAddress` in the `contractReads` function in `useTicks.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->