### PR TITLE
fix: v3 liquidity chart not filling canvas

### DIFF
--- a/apps/evm/src/ui/pool/LiquidityChartRangeInput/Area.tsx
+++ b/apps/evm/src/ui/pool/LiquidityChartRangeInput/Area.tsx
@@ -34,9 +34,16 @@ export const Area: FC<AreaProps> = ({
             .x((d: unknown) => xScale(xValue(d as ChartEntry)))
             .y1((d: unknown) => yScale(yValue(d as ChartEntry)))
             .y0(yScale(0))(
-            series.filter((d) => {
+            series.filter((d, i) => {
               const value = xScale(xValue(d))
-              return value > 0 && value <= window.innerWidth
+              if (value > 0 && value <= window.innerWidth) return true
+
+              if (i < series.length - 1) {
+                const value = xScale(xValue(series[i + 1]))
+                if (value > 0 && value <= window.innerWidth) return true
+              }
+
+              return false
             }) as Iterable<[number, number]>,
           ) ?? undefined
         }

--- a/packages/ui/src/components/icons/network/circle/AptosCircle.tsx
+++ b/packages/ui/src/components/icons/network/circle/AptosCircle.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
-import { IconComponent } from '../../../../types'
 import classNames from 'classnames'
+import { IconComponent } from '../../../../types'
 
 export const AptosCircle: IconComponent = (props) => (
   <svg

--- a/packages/ui/src/components/network-selector.tsx
+++ b/packages/ui/src/components/network-selector.tsx
@@ -80,7 +80,7 @@ const NetworkSelector = <T extends number>({
                 target="_blank"
               >
                 <div className="flex items-center gap-2">
-                  <AptosCircle  width={22} height={22} />
+                  <AptosCircle width={22} height={22} />
                   Aptos
                   <div className="text-[10px] italic rounded-full px-[6px] bg-gradient-to-r from-blue to-pink text-white font-bold">
                     NEW


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on making changes to three files: `AptosCircle.tsx`, `network-selector.tsx`, and `Area.tsx`.

### Detailed summary:
- In `AptosCircle.tsx`, the `classNames` import is removed.
- In `network-selector.tsx`, the `AptosCircle` component is used with updated props.
- In `Area.tsx`, the `series.filter` function is modified to include additional conditions for filtering.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->