### PR TITLE
fix(apps/pool): janky remove liq behaviour

### DIFF
--- a/apps/evm/src/ui/pool/RemoveSectionLegacy.tsx
+++ b/apps/evm/src/ui/pool/RemoveSectionLegacy.tsx
@@ -300,7 +300,7 @@ export const RemoveSectionLegacy: FC<RemoveSectionLegacyProps> =
       ...config,
       onSettled,
       onSuccess: () => {
-        setPercentage('')
+        setPercentage('0')
       },
     })
 

--- a/apps/evm/src/ui/pool/RemoveSectionTrident.tsx
+++ b/apps/evm/src/ui/pool/RemoveSectionTrident.tsx
@@ -303,7 +303,7 @@ export const RemoveSectionTrident: FC<RemoveSectionTridentProps> =
       ...config,
       onSettled,
       onSuccess: () => {
-        setPercentage('')
+        setPercentage('0')
         setSignature(undefined)
       },
     })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the `onSuccess` callback function in two files (`RemoveSectionLegacy.tsx` and `RemoveSectionTrident.tsx`) to set the `percentage` state to '0' and also reset the `signature` state in `RemoveSectionTrident.tsx`.

### Detailed summary:
- Updated `onSuccess` callback function in `RemoveSectionLegacy.tsx` to set the `percentage` state to '0'.
- Updated `onSuccess` callback function in `RemoveSectionTrident.tsx` to set the `percentage` state to '0' and reset the `signature` state.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->