### PR TITLE
fix: only show Aptos on network selector in header

### DIFF
--- a/packages/ui/src/components/network-selector.tsx
+++ b/packages/ui/src/components/network-selector.tsx
@@ -40,6 +40,7 @@ const PREFERRED_CHAINID_ORDER: ChainId[] = [
 ]
 
 export interface NetworkSelectorProps<T extends number = ChainId> {
+  showAptos?: boolean
   networks: readonly T[]
   selected: T
   onSelect: NetworkSelectorOnSelectCallback<T>
@@ -52,6 +53,7 @@ const NEW_CHAINS: number[] = [
 ] satisfies ChainId[]
 
 const NetworkSelector = <T extends number>({
+  showAptos = false,
   onSelect,
   networks = [],
   children,
@@ -76,21 +78,23 @@ const NetworkSelector = <T extends number>({
           />
           <CommandEmpty>No network found.</CommandEmpty>
           <CommandGroup>
-            <CommandItem className="cursor-pointer">
+            {showAptos ? (
               <Link
                 href="https://aptos.sushi.com"
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                <div className="flex items-center gap-2">
-                  <AptosCircle width={22} height={22} />
-                  Aptos
-                  <div className="text-[10px] italic rounded-full px-[6px] bg-gradient-to-r from-blue to-pink text-white font-bold">
-                    NEW
+                <CommandItem className="cursor-pointer">
+                  <div className="flex items-center gap-2">
+                    <AptosCircle width={22} height={22} />
+                    Aptos
+                    <div className="text-[10px] italic rounded-full px-[6px] bg-gradient-to-r from-blue to-pink text-white font-bold">
+                      NEW
+                    </div>
                   </div>
-                </div>
+                </CommandItem>
               </Link>
-            </CommandItem>
+            ) : null}
             {_networks.map((el) => (
               <CommandItem
                 className="cursor-pointer"

--- a/packages/wagmi/src/components/header-network-selector.tsx
+++ b/packages/wagmi/src/components/header-network-selector.tsx
@@ -50,6 +50,7 @@ export const HeaderNetworkSelector: FC<{
 
   return (
     <NetworkSelector
+      showAptos
       selected={selected}
       onSelect={onSwitchNetwork}
       networks={networks}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new prop `showAptos` to the `NetworkSelector` component in order to conditionally display the "Aptos" network option. It also adds a link to the Aptos website when `showAptos` is true.

### Detailed summary
- Added `showAptos` prop to `NetworkSelectorProps`
- Conditionally render "Aptos" network option based on `showAptos` prop
- Added link to Aptos website when `showAptos` is true

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->