### PR TITLE
fix(apps/evm): only show aptos where applicable

### DIFF
--- a/apps/evm/src/ui/pool/SelectNetworkWidget.tsx
+++ b/apps/evm/src/ui/pool/SelectNetworkWidget.tsx
@@ -29,6 +29,7 @@ export const SelectNetworkWidget: FC<SelectNetworkWidgetProps> = memo(
             networks={networks}
             selected={selectedNetwork}
             onSelect={onSelect}
+            showAptos={true}
           >
             <Button variant="secondary" className="!font-medium">
               <NetworkIcon chainId={selectedNetwork} width={16} height={16} />

--- a/packages/ui/src/components/network-selector.tsx
+++ b/packages/ui/src/components/network-selector.tsx
@@ -43,6 +43,7 @@ export interface NetworkSelectorProps<T extends number = ChainId> {
   networks: readonly T[]
   selected: T
   onSelect: NetworkSelectorOnSelectCallback<T>
+  showAptos?: boolean
   children: ReactNode
 }
 
@@ -54,6 +55,7 @@ const NEW_CHAINS: number[] = [
 const NetworkSelector = <T extends number>({
   onSelect,
   networks = [],
+  showAptos = false,
   children,
 }: Omit<NetworkSelectorProps<T>, 'variant'>) => {
   const [open, setOpen] = useState(false)
@@ -76,21 +78,23 @@ const NetworkSelector = <T extends number>({
           />
           <CommandEmpty>No network found.</CommandEmpty>
           <CommandGroup>
-            <CommandItem className="cursor-pointer">
-              <Link
-                href="https://aptos.sushi.com"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <div className="flex items-center gap-2">
-                  <AptosCircle width={22} height={22} />
-                  Aptos
-                  <div className="text-[10px] italic rounded-full px-[6px] bg-gradient-to-r from-blue to-pink text-white font-bold">
-                    NEW
+            {showAptos && (
+              <CommandItem className="cursor-pointer">
+                <Link
+                  href="https://aptos.sushi.com"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <div className="flex items-center gap-2">
+                    <AptosCircle width={22} height={22} />
+                    Aptos
+                    <div className="text-[10px] italic rounded-full px-[6px] bg-gradient-to-r from-blue to-pink text-white font-bold">
+                      NEW
+                    </div>
                   </div>
-                </div>
-              </Link>
-            </CommandItem>
+                </Link>
+              </CommandItem>
+            )}
             {_networks.map((el) => (
               <CommandItem
                 className="cursor-pointer"

--- a/packages/wagmi/src/components/header-network-selector.tsx
+++ b/packages/wagmi/src/components/header-network-selector.tsx
@@ -15,7 +15,8 @@ export const HeaderNetworkSelector: FC<{
   networks: ChainId[]
   selectedNetwork?: ChainId
   onChange?(chainId: ChainId): void
-}> = ({ networks, selectedNetwork, onChange }) => {
+  showAptos?: boolean
+}> = ({ networks, selectedNetwork, onChange, showAptos = false }) => {
   const isMounted = useIsMounted()
   const { switchNetworkAsync } = useSwitchNetwork()
   const { chain } = useNetwork()
@@ -53,6 +54,7 @@ export const HeaderNetworkSelector: FC<{
       selected={selected}
       onSelect={onSwitchNetwork}
       networks={networks}
+      showAptos={showAptos}
     >
       <Button variant="secondary" testId="network-selector">
         <Suspense fallback={null}>

--- a/packages/wagmi/src/components/wagmi-header-components.tsx
+++ b/packages/wagmi/src/components/wagmi-header-components.tsx
@@ -22,6 +22,7 @@ export const WagmiHeaderComponents: React.FC<WagmiHeaderComponentsProps> = ({
         networks={chainIds}
         selectedNetwork={selectedNetwork}
         onChange={onChange}
+        showAptos={true}
       />
       <UserProfile networks={chainIds} />
     </>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a new feature to show the Aptos network in the network selector component. 

### Detailed summary
- Added a `showAptos` prop to the `HeaderNetworkSelector` and `NetworkSelector` components.
- Updated the `HeaderNetworkSelector` component to conditionally render the Aptos network based on the `showAptos` prop.
- Added a new `CommandItem` for the Aptos network in the `NetworkSelector` component.
- Updated the `SelectNetworkWidget` component to pass the `showAptos` prop to the `HeaderNetworkSelector` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->