### PR TITLE
chore: override arbitrum nova explorer

### DIFF
--- a/packages/sushi/src/chain/index.ts
+++ b/packages/sushi/src/chain/index.ts
@@ -106,6 +106,15 @@ export class Chain implements Chain {
       this.explorers?.sort((explorer) =>
         explorer.name === 'Scrollscan' ? -1 : 1,
       )
+    } else if (data.name === 'Arbitrum Nova') {
+      this.explorers = [
+        {
+          name: 'Arbitrum Nova Explorer',
+          url: 'https://nova.arbiscan.io',
+          standard: 'EIP3091',
+        },
+        ...(this.explorers ?? []),
+      ]
     }
   }
   getTxUrl(txHash: string): string {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding support for the "Arbitrum Nova" explorer in the SushiSwap chain.

### Detailed summary:
- Added support for the "Arbitrum Nova" explorer in the SushiSwap chain.
- Added a new object with the explorer details including name, URL, and standard.
- Appended the new explorer object to the existing list of explorers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->