### PR TITLE
fix(apps/swap): reset approval tag on account change

### DIFF
--- a/packages/wagmi/src/systems/Checker/Success.tsx
+++ b/packages/wagmi/src/systems/Checker/Success.tsx
@@ -2,6 +2,7 @@
 
 import React, { FC, ReactNode, useEffect } from 'react'
 
+import { watchAccount, watchNetwork } from '@wagmi/core'
 import { useApprovedActions } from './Provider'
 
 interface SuccessProps {
@@ -16,6 +17,20 @@ const Success: FC<SuccessProps> = ({ children, tag }) => {
     setApproved(true)
     return () => {
       setApproved(false)
+    }
+  }, [setApproved])
+
+  useEffect(() => {
+    const unwatchAccountListener = watchAccount(() => {
+      setApproved(true)
+    })
+    const unwatchChainListener = watchNetwork(() => {
+      setApproved(true)
+    })
+
+    return () => {
+      unwatchAccountListener()
+      unwatchChainListener()
     }
   }, [setApproved])
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added imports for `watchAccount` and `watchNetwork` from `@wagmi/core`
- Added `useEffect` hook to watch for changes in account and network
- When either account or network changes, `setApproved` is called with `true`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->