### PR TITLE
fix: scientific notation in usePrices

### DIFF
--- a/apps/evm/src/ui/pool/ConcentratedLiquidityProvider.tsx
+++ b/apps/evm/src/ui/pool/ConcentratedLiquidityProvider.tsx
@@ -34,6 +34,7 @@ import {
   Type,
   tryParseAmount,
 } from 'sushi/currency'
+import { withoutScientificNotation } from 'sushi/format'
 import { Rounding } from 'sushi/math'
 
 type FullRange = true
@@ -876,36 +877,5 @@ export function useRangeHopCallbacks(
     getIncrementUpper,
     getSetFullRange: setFullRange,
     resetMintState,
-  }
-}
-
-/**
- * Convert scientific notation into decimal form, e.g. "-12.34e-5" => "-0.0001234",
- * @param value Number in scientific notation
- * @return Number in decimal form only
- */
-export function withoutScientificNotation(value: string): string | undefined {
-  if (!value.includes('e')) return value
-
-  if (!value.match(/^-?\d*\.?\d+(e[+-]?\d+)?$/)) return undefined
-
-  const [sign, absValue] = value.startsWith('-')
-    ? ['-', value.slice(1)]
-    : ['', value]
-  const [m, n] = absValue.split('e')
-  const [integer, fraction] = m.split('.')
-
-  const mantissa = (integer + (fraction ?? '')).replace(/^0+/, '')
-  const exponent = parseInt(n ?? 0) - (fraction ?? '').length
-
-  if (exponent >= 0) {
-    return sign + mantissa + '0'.repeat(exponent)
-  } else {
-    const i = mantissa.length + exponent
-    if (i > 0) {
-      return `${sign + mantissa.slice(0, i)}.${mantissa.slice(i) || 0}`
-    } else {
-      return `${sign}0.${'0'.repeat(-i)}${mantissa}`
-    }
   }
 }

--- a/packages/react-query/src/hooks/prices/usePrices.ts
+++ b/packages/react-query/src/hooks/prices/usePrices.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import { withoutScientificNotation } from 'sushi/format'
 import { Fraction } from 'sushi/math'
 import { getAddress, isAddress, parseUnits } from 'viem'
 
@@ -16,10 +17,11 @@ export const usePrices = ({ chainId }: UsePrices) => {
         // `http://localhost:3001/v2/${chainId}`,
       ).then((response) => response.json())
       return Object.entries(data).reduce<Record<string, Fraction>>(
-        (acc, [address, price]) => {
-          if (isAddress(address)) {
+        (acc, [address, _price]) => {
+          const price = withoutScientificNotation(_price.toFixed(18))
+          if (isAddress(address) && typeof price !== 'undefined') {
             acc[getAddress(address)] = new Fraction(
-              parseUnits(price.toFixed(18), 18).toString(),
+              parseUnits(price, 18).toString(),
               parseUnits('1', 18).toString(),
             )
           }

--- a/packages/sushi/src/format/number.ts
+++ b/packages/sushi/src/format/number.ts
@@ -7,3 +7,34 @@ export const formatNumber = (value: any) => {
 
   return numeral(value).format('(0.00a)')
 }
+
+/**
+ * Convert scientific notation into decimal form, e.g. "-12.34e-5" => "-0.0001234",
+ * @param value Number in scientific notation
+ * @return Number in decimal form only
+ */
+export function withoutScientificNotation(value: string): string | undefined {
+  if (!value.includes('e')) return value
+
+  if (!value.match(/^-?\d*\.?\d+(e[+-]?\d+)?$/)) return undefined
+
+  const [sign, absValue] = value.startsWith('-')
+    ? ['-', value.slice(1)]
+    : ['', value]
+  const [m, n] = absValue.split('e') as [string, string]
+  const [integer, fraction] = m.split('.')
+
+  const mantissa = (integer + (fraction ?? '')).replace(/^0+/, '')
+  const exponent = parseInt(n ?? 0) - (fraction ?? '').length
+
+  if (exponent >= 0) {
+    return sign + mantissa + '0'.repeat(exponent)
+  } else {
+    const i = mantissa.length + exponent
+    if (i > 0) {
+      return `${sign + mantissa.slice(0, i)}.${mantissa.slice(i) || 0}`
+    } else {
+      return `${sign}0.${'0'.repeat(-i)}${mantissa}`
+    }
+  }
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the handling of scientific notation in the code.

### Detailed summary:
- Added a new function `withoutScientificNotation` to convert numbers in scientific notation to decimal form.
- Modified the `usePrices` hook to use `withoutScientificNotation` for converting prices.
- Imported `withoutScientificNotation` in `ConcentratedLiquidityProvider` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->