### PR TITLE
fix(apps/steer): crash on no apr data

### DIFF
--- a/apps/evm/src/ui/pool/Steer/SteerAPRChart/_SteerAPRChart.tsx
+++ b/apps/evm/src/ui/pool/Steer/SteerAPRChart/_SteerAPRChart.tsx
@@ -95,7 +95,7 @@ export function _SteerAPRChart({ timeseries, loading }: _SteerAPRChartProps) {
   )
 
   const [leftDate, rightDate] = useMemo(() => {
-    if (!timeseries) return ['', '']
+    if (!timeseries || timeseries.length === 0) return ['', '']
 
     const leftDate = new Date(timeseries[0].startTime * 1000)
     const rightDate = new Date(
@@ -144,7 +144,18 @@ export function _SteerAPRChart({ timeseries, loading }: _SteerAPRChartProps) {
       <div className="w-full h-full">
         <ReactVirtualizedAutoSizer>
           {({ height, width }) => (
-            <ReactECharts option={chartConfig} style={{ height, width }} />
+            <>
+              {timeseries?.length ? (
+                <ReactECharts option={chartConfig} style={{ height, width }} />
+              ) : (
+                <div
+                  style={{ width, height }}
+                  className="flex justify-center items-center text-slate-300 text-sm"
+                >
+                  No data found.
+                </div>
+              )}
+            </>
           )}
         </ReactVirtualizedAutoSizer>
       </div>

--- a/packages/steer-sdk/src/functions/getSteerVaultAprTimeseries.ts
+++ b/packages/steer-sdk/src/functions/getSteerVaultAprTimeseries.ts
@@ -7,13 +7,11 @@ interface GetSteerVaultsAprs {
 }
 
 interface AprTimeseries {
-  data: [
-    {
-      startTime: number
-      endTime: number
-      feeApr: number
-    },
-  ]
+  data: {
+    startTime: number
+    endTime: number
+    feeApr: number
+  }[]
   message: string
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on handling cases where the `timeseries` data is empty or undefined in the SteerAPRChart component.

### Detailed summary:
- Updated the `AprTimeseries` interface in `getSteerVaultAprTimeseries.ts` to use an array of objects instead of an array of arrays.
- Modified the `_SteerAPRChart` component in `_SteerAPRChart.tsx` to display "No data found." when the `timeseries` data is empty or undefined.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->