### PR TITLE
fix(apps/analytics): disable kava

### DIFF
--- a/apps/evm/src/config.ts
+++ b/apps/evm/src/config.ts
@@ -81,6 +81,17 @@ export const SUPPORTED_CHAIN_IDS = Array.from(
     !DISABLED_CHAIN_IDS.includes(c as typeof DISABLED_CHAIN_IDS[number]),
 )
 
+const DISABLED_ANALYTICS_CHAIN_IDS = [ChainId.BOBA_AVAX, ChainId.KAVA]
+
+export const ANALYTICS_CHAIN_IDS = [
+  ...SUPPORTED_CHAIN_IDS.filter(
+    (el) =>
+      !DISABLED_ANALYTICS_CHAIN_IDS.includes(
+        el as typeof DISABLED_ANALYTICS_CHAIN_IDS[number],
+      ),
+  ),
+]
+
 export type SupportedChainId = typeof SUPPORTED_CHAIN_IDS[number]
 export const isSupportedChainId = (
   chainId: number,

--- a/apps/evm/src/config.ts
+++ b/apps/evm/src/config.ts
@@ -81,7 +81,11 @@ export const SUPPORTED_CHAIN_IDS = Array.from(
     !DISABLED_CHAIN_IDS.includes(c as typeof DISABLED_CHAIN_IDS[number]),
 )
 
-const DISABLED_ANALYTICS_CHAIN_IDS = [ChainId.BOBA_AVAX, ChainId.KAVA, ChainId.MOONRIVER]
+const DISABLED_ANALYTICS_CHAIN_IDS = [
+  ChainId.BOBA_AVAX,
+  ChainId.KAVA,
+  ChainId.MOONRIVER,
+]
 
 export const ANALYTICS_CHAIN_IDS = [
   ...SUPPORTED_CHAIN_IDS.filter(

--- a/apps/evm/src/config.ts
+++ b/apps/evm/src/config.ts
@@ -81,7 +81,7 @@ export const SUPPORTED_CHAIN_IDS = Array.from(
     !DISABLED_CHAIN_IDS.includes(c as typeof DISABLED_CHAIN_IDS[number]),
 )
 
-const DISABLED_ANALYTICS_CHAIN_IDS = [ChainId.BOBA_AVAX, ChainId.KAVA]
+const DISABLED_ANALYTICS_CHAIN_IDS = [ChainId.BOBA_AVAX, ChainId.KAVA, ChainId.MOONRIVER]
 
 export const ANALYTICS_CHAIN_IDS = [
   ...SUPPORTED_CHAIN_IDS.filter(

--- a/apps/evm/src/ui/analytics/global-stats-charts.tsx
+++ b/apps/evm/src/ui/analytics/global-stats-charts.tsx
@@ -21,18 +21,18 @@ import {
   Separator,
 } from '@sushiswap/ui'
 import { Chain, ChainId } from 'sushi/chain'
-import { SUPPORTED_CHAIN_IDS } from '../../config'
+import { ANALYTICS_CHAIN_IDS } from '../../config'
 import { TVLChart } from './tvl-chart'
 import { VolumeChart } from './volume-chart'
 
 const isAllThenNone = (chainIds: number[]) =>
-  SUPPORTED_CHAIN_IDS.length === chainIds.length ? [] : chainIds
+  ANALYTICS_CHAIN_IDS.length === chainIds.length ? [] : chainIds
 
 const fetcher = ({ url, chainIds }: { url: string; chainIds: ChainId[] }) => {
   const _url = new URL(url, window.location.origin)
   _url.searchParams.set(
     'networks',
-    stringify(chainIds.length > 0 ? chainIds : SUPPORTED_CHAIN_IDS),
+    stringify(chainIds.length > 0 ? chainIds : ANALYTICS_CHAIN_IDS),
   )
 
   return fetch(_url.href)
@@ -43,7 +43,7 @@ const fetcher = ({ url, chainIds }: { url: string; chainIds: ChainId[] }) => {
 export const GlobalStatsCharts: FC = () => {
   const [open, setOpen] = useState(false)
   const [localValue, setValues] = useState<number[]>(
-    isAllThenNone(SUPPORTED_CHAIN_IDS),
+    isAllThenNone(ANALYTICS_CHAIN_IDS),
   )
   const { data } = useSWR(
     { url: '/analytics/api/charts', chainIds: localValue },
@@ -92,7 +92,7 @@ export const GlobalStatsCharts: FC = () => {
                             {localValue.length} selected
                           </Chip>
                         ) : (
-                          SUPPORTED_CHAIN_IDS.filter((option) =>
+                          ANALYTICS_CHAIN_IDS.filter((option) =>
                             localValue.includes(option),
                           ).map((option) => (
                             <Chip variant="secondary" key={option}>
@@ -111,7 +111,7 @@ export const GlobalStatsCharts: FC = () => {
               >
                 <Command className="flex items-center gap-1">
                   <CommandGroup>
-                    {SUPPORTED_CHAIN_IDS.map((chainId) => (
+                    {ANALYTICS_CHAIN_IDS.map((chainId) => (
                       <CommandItem
                         key={chainId}
                         value={`${chainId}`}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the analytics chain IDs used in the EVM app. 

### Detailed summary
- Added `DISABLED_ANALYTICS_CHAIN_IDS` constant
- Updated `ANALYTICS_CHAIN_IDS` to exclude disabled chain IDs
- Updated import of `SUPPORTED_CHAIN_IDS` to `ANALYTICS_CHAIN_IDS` in `global-stats-charts.tsx`
- Updated `isAllThenNone` function to use `ANALYTICS_CHAIN_IDS`
- Updated `fetcher` function to use `ANALYTICS_CHAIN_IDS`
- Updated usage of `SUPPORTED_CHAIN_IDS` to `ANALYTICS_CHAIN_IDS` in `GlobalStatsCharts` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->