### PR TITLE
fix: swap api overload turn off

### DIFF
--- a/apis/extractor/src/index.ts
+++ b/apis/extractor/src/index.ts
@@ -281,13 +281,14 @@ function processRequest(
     try {
       const statistics = requestStatistics.requestProcessingStart()
 
+      // Server Overloaded protection - time not came
       // @ts-ignore
-      if (process.getActiveResourcesInfo().length > 150) {
-        requestStatistics.requestRejected(
-          ResponseRejectReason.SERVER_OVERLOADED,
-        )
-        return res.status(529).send('Server Overloaded')
-      }
+      // if (process.getActiveResourcesInfo().length > 150) {
+      //   requestStatistics.requestRejected(
+      //     ResponseRejectReason.SERVER_OVERLOADED,
+      //   )
+      //   return res.status(529).send('Server Overloaded')
+      // }
 
       const parsed = qSchema.safeParse(req.query)
       if (!parsed.success) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Commented out code related to server overload protection.
- Added a comment indicating that the server overload protection is not yet implemented.
- Modified the code to disable the server overload protection check.
- Commented out code related to handling the server overload response.
- Added a comment indicating that the server overload response is not yet implemented.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->