### PR TITLE
fix(apps/pool): api caching

### DIFF
--- a/apps/evm/src/app/pool/api/graphPool/[id]/route.ts
+++ b/apps/evm/src/app/pool/api/graphPool/[id]/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from 'next/server'
 import { getGraphPool } from 'src/lib/api'
 import { z } from 'zod'
 
+export const revalidate = 15
+
 const schema = z.object({
   id: z.string(),
 })
-
-// export const revalidate = 60 // revalidate every minute
 
 // uses thegraph, not the pools api
 export async function GET(

--- a/apps/evm/src/app/pool/api/graphPools/route.ts
+++ b/apps/evm/src/app/pool/api/graphPools/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from 'next/server'
 import { getGraphPools } from 'src/lib/api'
 import { z } from 'zod'
 
+export const revalidate = 60
+
 const schema = z.object({
   ids: z.string().transform((ids) => ids.split(',')),
 })
-
-// export const revalidate = 60 // revalidate every minute
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)

--- a/apps/evm/src/app/pool/api/pools/[chainId]/[address]/route.ts
+++ b/apps/evm/src/app/pool/api/pools/[chainId]/[address]/route.ts
@@ -2,6 +2,8 @@ import { PoolApiSchema, getPoolFromDB } from '@sushiswap/client/api'
 import { NextResponse } from 'next/server.js'
 import { CORS } from '../../../cors'
 
+export const revalidate = 15
+
 export async function GET(
   _request: Request,
   { params }: { params: { chainId: string; address: string } },

--- a/apps/evm/src/app/pool/api/pools/count/route.ts
+++ b/apps/evm/src/app/pool/api/pools/count/route.ts
@@ -2,6 +2,8 @@ import { PoolCountApiSchema, getPoolCountFromDB } from '@sushiswap/client/api'
 import { NextResponse } from 'next/server.js'
 import { CORS } from '../../cors'
 
+export const revalidate = 15
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const result = PoolCountApiSchema.safeParse(Object.fromEntries(searchParams))

--- a/apps/evm/src/app/pool/api/pools/route.ts
+++ b/apps/evm/src/app/pool/api/pools/route.ts
@@ -2,6 +2,8 @@ import { PoolsApiSchema, getPoolsFromDB } from '@sushiswap/client/api'
 import { NextResponse } from 'next/server.js'
 import { CORS } from '../cors'
 
+export const revalidate = 15
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const result = PoolsApiSchema.safeParse(Object.fromEntries(searchParams))

--- a/apps/evm/src/app/pool/api/steer-vault/[chainId]/[address]/route.ts
+++ b/apps/evm/src/app/pool/api/steer-vault/[chainId]/[address]/route.ts
@@ -2,6 +2,8 @@ import { SteerVaultApiSchema, getSteerVaultFromDB } from '@sushiswap/client/api'
 import { NextResponse } from 'next/server.js'
 import { CORS } from '../../../cors'
 
+export const revalidate = 15
+
 export async function GET(
   _request: Request,
   { params }: { params: { chainId: string; address: string } },

--- a/apps/evm/src/app/pool/api/steer-vault/count/route.ts
+++ b/apps/evm/src/app/pool/api/steer-vault/count/route.ts
@@ -5,6 +5,8 @@ import {
 import { NextResponse } from 'next/server.js'
 import { CORS } from '../../cors'
 
+export const revalidate = 15
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const result = SteerVaultCountApiSchema.safeParse(

--- a/apps/evm/src/app/pool/api/steer-vault/route.ts
+++ b/apps/evm/src/app/pool/api/steer-vault/route.ts
@@ -5,6 +5,8 @@ import {
 import { NextResponse } from 'next/server.js'
 import { CORS } from '../cors'
 
+export const revalidate = 15
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const result = SteerVaultsApiSchema.safeParse(

--- a/apps/evm/src/app/pool/api/user/route.ts
+++ b/apps/evm/src/app/pool/api/user/route.ts
@@ -3,6 +3,8 @@ import { getUser } from 'src/lib/api'
 import { ChainId } from 'sushi/chain'
 import { z } from 'zod'
 
+export const revalidate = 15
+
 const schema = z.object({
   id: z.string(),
   chainIds: z


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a `revalidate` constant to several route files in the `pool/api` directory.

### Detailed summary:
- Added `revalidate` constant with a value of 15 to the following files:
  - `apps/evm/src/app/pool/api/user/route.ts`
  - `apps/evm/src/app/pool/api/pools/[chainId]/[address]/route.ts`
  - `apps/evm/src/app/pool/api/steer-vault/[chainId]/[address]/route.ts`
  - `apps/evm/src/app/pool/api/steer-vault/route.ts`
  - `apps/evm/src/app/pool/api/steer-vault/count/route.ts`
  - `apps/evm/src/app/pool/api/pools/route.ts`
- Added `revalidate` constant with a value of 60 to the following file:
  - `apps/evm/src/app/pool/api/graphPools/route.ts`
- Removed `revalidate` constant from the following file:
  - `apps/evm/src/app/pool/api/graphPool/[id]/route.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->