### PR TITLE
fix: enable useRewarder in PoolPositionRewardsProvider

### DIFF
--- a/apps/evm/src/ui/pool/PoolPositionRewardsProvider.tsx
+++ b/apps/evm/src/ui/pool/PoolPositionRewardsProvider.tsx
@@ -102,6 +102,7 @@ export const _PoolPositionRewardsProvider: FC<
     rewarderAddresses,
     types,
     chef: chefType,
+    enabled: Boolean(account),
   })
 
   const { harvest } = useMasterChef({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enabling the `harvest` function in the `PoolPositionRewardsProvider.tsx` file. 

### Detailed summary
- Added `enabled` property with a boolean value based on the `account` value
- Enabled the `harvest` function in the `useMasterChef` hook

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->