### PR TITLE
fix: wagmi config in graph-client

### DIFF
--- a/packages/graph-client/lib/wagmi.ts
+++ b/packages/graph-client/lib/wagmi.ts
@@ -1,16 +1,18 @@
-// import { allChains, allProviders } from '@sushiswap/wagmi-config'
+import { allChains, allProviders } from '@sushiswap/wagmi-config'
 import {
   Address,
-  // configureChains,
-  // createConfig,
+  configureChains,
+  createConfig,
   erc20ABI,
   readContract,
 } from '@wagmi/core'
 import { isPromiseFulfilled } from 'sushi/validate'
 
-// const { publicClient } = configureChains(allChains, allProviders)
-
-// createConfig({ publicClient })
+const { publicClient } = configureChains(allChains, allProviders)
+createConfig({
+  autoConnect: true,
+  publicClient,
+})
 
 export async function fetchBalances(
   args: { token: string; user: string; chainId: number }[],


### PR DESCRIPTION
wagmi config in `packages/graph-client` isn't set up, leading to `fetchBalances` calls to fail.

This results in unstaked V2 liquidity to be missing from the pools table.