### PR TITLE
fix: tokens api address bug

### DIFF
--- a/apis/tokens/lib/api/v1.ts
+++ b/apis/tokens/lib/api/v1.ts
@@ -9,7 +9,7 @@ import { redis } from '../redis.js'
 
 const REDIS_KEY_PREFIX = 'token-list-v2-'
 
-export async function fetchTokensFromLists(chainId?: number) {
+export async function fetchTokensFromLists(chainId: number) {
   const redisResult = await Promise.all(
     DEFAULT_LIST_OF_LISTS.map(async (url) => {
       const value = await redis.get<TokenList | null>(
@@ -28,32 +28,36 @@ export async function fetchTokensFromLists(chainId?: number) {
   return merge(tokenLists, chainId)
 }
 
-function merge(tokenLists: Map<string, TokenList>, chainId?: number) {
+function merge(tokenLists: Map<string, TokenList>, chainId: number) {
   const tokens = new Map<string, TokenInfo>()
 
   // Set sushi default tokens first, they will take precedence
-  tokenLists.get(SUSHI_DEFAULT_TOKEN_LIST)?.tokens.forEach((token) => {
-    if (chainId === undefined || token.chainId === chainId) {
-      tokens.set(token.address.toLowerCase(), {
-        ...(token as TokenInfo),
-        address: getAddress(token.address), // Token addresses are sometimes lowercase from token lists
-      })
-    }
-  })
-
-  tokenLists.forEach((tokenList, url) => {
-    if (url === SUSHI_DEFAULT_TOKEN_LIST) return // skip because we already ran this
-    tokenList.tokens.forEach((token) => {
-      if (
-        (chainId === undefined || token.chainId === chainId) &&
-        !tokens.has(token.address.toLowerCase())
-      ) {
+  tokenLists
+    .get(SUSHI_DEFAULT_TOKEN_LIST)
+    ?.tokens.filter((token) => token.chainId === chainId)
+    .forEach((token) => {
+      try {
         tokens.set(token.address.toLowerCase(), {
           ...(token as TokenInfo),
           address: getAddress(token.address), // Token addresses are sometimes lowercase from token lists
         })
-      }
+      } catch (_e) {}
     })
+
+  tokenLists.forEach((tokenList, url) => {
+    if (url === SUSHI_DEFAULT_TOKEN_LIST) return // skip because we already ran this
+    tokenList?.tokens
+      .filter((token) => token.chainId === chainId)
+      .forEach((token) => {
+        if (!tokens.has(token.address.toLowerCase())) {
+          try {
+            tokens.set(token.address.toLowerCase(), {
+              ...(token as TokenInfo),
+              address: getAddress(token.address), // Token addresses are sometimes lowercase from token lists
+            })
+          } catch (_e) {}
+        }
+      })
   })
   return Array.from(tokens.values())
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the `fetchTokensFromLists` function in `apis/tokens/lib/api/v1.ts`. 

### Detailed summary:
- Changed the parameter `chainId` from optional to required.
- Refactored the code to filter tokens based on the `chainId` parameter.
- Fixed an issue where token addresses were not converted to lowercase.
- Improved error handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->