### PR TITLE
fix: case where request is made for position on unsupported angle chains

### DIFF
--- a/apps/evm/src/app/pool/incentivize/page.tsx
+++ b/apps/evm/src/app/pool/incentivize/page.tsx
@@ -53,7 +53,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { Chain } from 'sushi/chain'
 import { Token, Type, tryParseAmount } from 'sushi/currency'
 
-import { ANGLE_ENABLED_NETWORKS } from '../../../config'
+import { ANGLE_ENABLED_NETWORKS } from 'sushi/config'
 import { ConcentratedLiquidityProvider } from '../../../ui/pool/ConcentratedLiquidityProvider'
 import {
   ConcentratedLiquidityURLStateProvider,

--- a/apps/evm/src/config.ts
+++ b/apps/evm/src/config.ts
@@ -4,19 +4,6 @@ import { SushiSwapV3ChainIds } from '@sushiswap/v3-sdk'
 import { ChainId, TESTNET_CHAIN_IDS } from 'sushi/chain'
 import { Currency } from 'sushi/currency'
 
-export const ANGLE_ENABLED_NETWORKS = [
-  ChainId.ETHEREUM,
-  ChainId.POLYGON,
-  ChainId.ARBITRUM,
-  ChainId.OPTIMISM,
-  ChainId.BASE,
-]
-export type AngleEnabledChainId = typeof ANGLE_ENABLED_NETWORKS[number]
-export const isAngleEnabledChainId = (
-  chainId: number,
-): chainId is AngleEnabledChainId =>
-  ANGLE_ENABLED_NETWORKS.includes(chainId as AngleEnabledChainId)
-
 export const SWAP_API_ENABLED_NETWORKS = [
   ChainId.ARBITRUM,
   ChainId.ARBITRUM_NOVA,

--- a/apps/evm/src/ui/pool/PoolRewardDistributionsCard.tsx
+++ b/apps/evm/src/ui/pool/PoolRewardDistributionsCard.tsx
@@ -20,7 +20,7 @@ import { ChainId } from 'sushi/chain'
 import { Native } from 'sushi/currency'
 import { getAddress } from 'viem'
 
-import { isAngleEnabledChainId } from '../../config'
+import { isAngleEnabledChainId } from 'sushi/config'
 import { DistributionDataTable } from './DistributionDataTable'
 
 interface PoolRewardDistributionsCardParams {

--- a/apps/evm/src/ui/pool/PoolsTable.tsx
+++ b/apps/evm/src/ui/pool/PoolsTable.tsx
@@ -42,7 +42,7 @@ import { Native } from 'sushi/currency'
 import { useSWRConfig } from 'swr'
 
 import { usePoolCount, usePoolsInfinite } from '@sushiswap/client/hooks'
-import { isAngleEnabledChainId } from '../../config'
+import { isAngleEnabledChainId } from 'sushi/config'
 import { usePoolFilters } from './PoolsFiltersProvider'
 import {
   APR_COLUMN_POOL,

--- a/apps/evm/src/ui/pool/PositionView.tsx
+++ b/apps/evm/src/ui/pool/PositionView.tsx
@@ -47,8 +47,8 @@ import { Chain } from 'sushi/chain'
 import { Amount } from 'sushi/currency'
 import { formatUSD } from 'sushi/format'
 
+import { isAngleEnabledChainId } from 'sushi/config'
 import { getAddress } from 'viem'
-import { isAngleEnabledChainId } from '../../config'
 import { Bound } from '../../lib/constants'
 import {
   formatTickPrice,

--- a/apps/evm/src/ui/pool/RewardsSection.tsx
+++ b/apps/evm/src/ui/pool/RewardsSection.tsx
@@ -15,7 +15,7 @@ import { Carousel } from '@sushiswap/ui/components/carousel'
 import { useAccount } from '@sushiswap/wagmi'
 import { ColumnDef, PaginationState } from '@tanstack/react-table'
 import React, { FC, useCallback, useMemo, useState } from 'react'
-import { ANGLE_ENABLED_NETWORKS } from 'src/config'
+import { ANGLE_ENABLED_NETWORKS } from 'sushi/config'
 
 import { usePoolFilters } from './PoolsFiltersProvider'
 import { RewardSlide, RewardSlideSkeleton } from './RewardSlide'

--- a/apps/evm/src/ui/pool/SmartPoolsTable.tsx
+++ b/apps/evm/src/ui/pool/SmartPoolsTable.tsx
@@ -51,7 +51,7 @@ import { Native, Token, unwrapToken } from 'sushi/currency'
 import { formatNumber, formatPercent, formatUSD } from 'sushi/format'
 
 import { useSteerVaults } from '@sushiswap/client/hooks'
-import { isAngleEnabledChainId } from '../../config'
+import { isAngleEnabledChainId } from 'sushi/config'
 import { APRHoverCard } from './APRHoverCard'
 import { ProtocolBadge } from './PoolNameCell'
 import { usePoolFilters } from './PoolsFiltersProvider'

--- a/packages/react-query/src/hooks/rewards/useAngleRewards.ts
+++ b/packages/react-query/src/hooks/rewards/useAngleRewards.ts
@@ -230,6 +230,8 @@ export const useAngleRewards = ({
     select: (data) => angleRewardsSelect({ chainId, data, prices }),
     staleTime: 15000, // 15 seconds
     cacheTime: 60000, // 1min
-    enabled: Boolean(enabled && prices && chainId && isAngleEnabledChainId(chainId)),
+    enabled: Boolean(
+      enabled && prices && chainId && isAngleEnabledChainId(chainId),
+    ),
   })
 }

--- a/packages/react-query/src/hooks/rewards/useAngleRewards.ts
+++ b/packages/react-query/src/hooks/rewards/useAngleRewards.ts
@@ -10,6 +10,7 @@ import {
   angleRewardsBaseValidator,
   angleRewardsPoolsValidator,
 } from './validator'
+import { isAngleEnabledChainId } from 'sushi/config'
 
 type TransformedRewardsPerToken = Record<
   string,
@@ -229,6 +230,6 @@ export const useAngleRewards = ({
     select: (data) => angleRewardsSelect({ chainId, data, prices }),
     staleTime: 15000, // 15 seconds
     cacheTime: 60000, // 1min
-    enabled: Boolean(enabled && prices && chainId),
+    enabled: Boolean(enabled && prices && chainId && isAngleEnabledChainId(chainId)),
   })
 }

--- a/packages/sushi/src/config/angle.ts
+++ b/packages/sushi/src/config/angle.ts
@@ -1,0 +1,18 @@
+import { ChainId } from '../chain'
+
+export const ANGLE_ENABLED_NETWORKS = [
+  ChainId.ARBITRUM,
+  ChainId.ETHEREUM,
+  ChainId.OPTIMISM,
+  ChainId.POLYGON,
+  // ChainId.POLYGON_ZKEVM,
+  ChainId.BASE,
+  // ChainId.THUNDERCORE,
+  // ChainId.CORE,
+  // ChainId.GNOSIS
+]
+export type AngleEnabledChainId = typeof ANGLE_ENABLED_NETWORKS[number]
+export const isAngleEnabledChainId = (
+  chainId: number,
+): chainId is AngleEnabledChainId =>
+  ANGLE_ENABLED_NETWORKS.includes(chainId as AngleEnabledChainId)

--- a/packages/sushi/src/config/index.ts
+++ b/packages/sushi/src/config/index.ts
@@ -1,3 +1,4 @@
+export * from './angle'
 export * from './bentobox'
 export * from './extractor'
 export * from './route-processor'


### PR DESCRIPTION
…pport

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The import statements for `isAngleEnabledChainId` have been updated in multiple files to use the new location in the `sushi/config` file instead of the previous location in the `../../config` file.
- The `ANGLE_ENABLED_NETWORKS` constant and the `isAngleEnabledChainId` function have been moved from the `config.ts` file to a new `angle.ts` file in the `sushi/src/config` directory.
- The `isAngleEnabledChainId` function has been updated to include additional chain IDs in the `ANGLE_ENABLED_NETWORKS` array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->