### PR TITLE
fix: other token lists loading if some fail

### DIFF
--- a/packages/react-query/src/hooks/rewards/useAngleRewards.ts
+++ b/packages/react-query/src/hooks/rewards/useAngleRewards.ts
@@ -230,6 +230,8 @@ export const useAngleRewards = ({
     select: (data) => angleRewardsSelect({ chainId, data, prices }),
     staleTime: 15000, // 15 seconds
     cacheTime: 60000, // 1min
-    enabled: Boolean(enabled && prices && chainId && isAngleEnabledChainId(chainId)),
+    enabled: Boolean(
+      enabled && prices && chainId && isAngleEnabledChainId(chainId),
+    ),
   })
 }

--- a/packages/sushi/src/token-list/constants.ts
+++ b/packages/sushi/src/token-list/constants.ts
@@ -32,7 +32,8 @@ const SET_LIST =
 
 export const OPTIMISM_LIST =
   'https://static.optimism.io/optimism.tokenlist.json'
-export const ARBITRUM_LIST = 'https://bridge.arbitrum.io/token-list-42161.json'
+export const ARBITRUM_LIST =
+  'https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json'
 export const CELO_LIST =
   'https://celo-org.github.io/celo-token-list/celo.tokenlist.json'
 export const PLASMA_BNB_LIST =


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on making changes to the `useAngleRewards` hook and the `useOtherTokenListsQuery` hook.

### Detailed summary:
- In `useAngleRewards` hook, the `enabled` condition is wrapped in parentheses for readability.
- The `ARBITRUM_LIST` constant in `constants.ts` is updated with a new URL.
- The `useOtherTokenListsQuery` hook now uses the `isPromiseFulfilled` function from the `sushi` module.
- The `useOtherTokenListsQuery` hook now uses `Promise.allSettled` instead of `Promise.all` for fetching token lists.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->