### PR TITLE
fix: filter out trident liquidity provider during e2e tests

### DIFF
--- a/apps/evm/src/lib/swap/useCrossChainTrade/useCrossChainTrade.ts
+++ b/apps/evm/src/lib/swap/useCrossChainTrade/useCrossChainTrade.ts
@@ -30,8 +30,6 @@ import {
 import { UseCrossChainTradeParams, UseCrossChainTradeReturn } from './types'
 import { useStargateBridgeFees } from './useStargateBridgeFees'
 
-import * as Sentry from '@sentry/nextjs'
-
 export const useCrossChainTrade = ({
   network0,
   network1,

--- a/apps/evm/test/global.setup.ts
+++ b/apps/evm/test/global.setup.ts
@@ -11,7 +11,7 @@ export default async function globalSetup(_config: FullConfig) {
     },
   })
 
-  process.on('exit', async () => {
+  process.on('SIGTERM', async () => {
     await shutdown()
   })
 }

--- a/apps/evm/test/playwright.config.ts
+++ b/apps/evm/test/playwright.config.ts
@@ -19,7 +19,7 @@ const baseURL = `http://localhost:${PORT}`
  */
 const config: PlaywrightTestConfig = {
   // quiet: true,
-  // testMatch: 'swap.test.ts',
+  // testMatch: 'pool.test.ts',
   testIgnore: 'cross-chain-swap.test.ts',
   /* Maximum time one test can run for. Defaults to 30s. */
   timeout: 120_000,

--- a/packages/react-query/src/hooks/rewards/useAngleRewards.ts
+++ b/packages/react-query/src/hooks/rewards/useAngleRewards.ts
@@ -5,12 +5,14 @@ import { ZERO } from 'sushi/math'
 import { parseUnits } from 'viem'
 import z from 'zod'
 
+import { isAngleEnabledChainId } from 'sushi/config'
+
 import { usePrices } from '../prices'
+
 import {
   angleRewardsBaseValidator,
   angleRewardsPoolsValidator,
 } from './validator'
-import { isAngleEnabledChainId } from 'sushi/config'
 
 type TransformedRewardsPerToken = Record<
   string,

--- a/packages/router/src/liquidity-providers/LiquidityProvider.ts
+++ b/packages/router/src/liquidity-providers/LiquidityProvider.ts
@@ -36,12 +36,14 @@ export abstract class LiquidityProvider {
   chainId: ChainId
   client: PublicClient
   lastUpdateBlock = 0
+  isTest = false
   readonly ON_DEMAND_POOLS_LIFETIME_IN_SECONDS = 60
   readonly FETCH_AVAILABLE_POOLS_AFTER_SECONDS = 900
 
-  constructor(chainId: ChainId, client: PublicClient) {
+  constructor(chainId: ChainId, client: PublicClient, isTest = false) {
     this.chainId = chainId
     this.client = client
+    this.isTest = isTest
   }
 
   abstract getType(): LiquidityProviders

--- a/packages/router/src/liquidity-providers/Trident.ts
+++ b/packages/router/src/liquidity-providers/Trident.ts
@@ -88,8 +88,9 @@ export class TridentProvider extends LiquidityProvider {
   constructor(
     chainId: Extract<ChainId, BentoBoxChainId & TridentChainId>,
     web3Client: PublicClient,
+    isTest = false,
   ) {
-    super(chainId, web3Client)
+    super(chainId, web3Client, isTest)
     this.chainId = chainId
     if (
       !(chainId in this.bentoBox) ||

--- a/packages/router/src/liquidity-providers/UniswapV2Base.ts
+++ b/packages/router/src/liquidity-providers/UniswapV2Base.ts
@@ -64,8 +64,9 @@ export abstract class UniswapV2BaseProvider extends LiquidityProvider {
     web3Client: PublicClient,
     factory: Record<number, Address>,
     initCodeHash: Record<number, Hex>,
+    isTest = false,
   ) {
-    super(chainId, web3Client)
+    super(chainId, web3Client, isTest)
     this.factory = factory
     this.initCodeHash = initCodeHash
     if (!(chainId in this.factory) || !(chainId in this.initCodeHash)) {

--- a/packages/router/src/liquidity-providers/UniswapV3Base.ts
+++ b/packages/router/src/liquidity-providers/UniswapV3Base.ts
@@ -58,8 +58,9 @@ export abstract class UniswapV3BaseProvider extends LiquidityProvider {
     factory: Record<number, Address>,
     initCodeHash: Record<number, string>,
     tickLens: Record<number, string>,
+    isTest = false,
   ) {
-    super(chainId, web3Client)
+    super(chainId, web3Client, isTest)
     this.factory = factory
     this.initCodeHash = initCodeHash
     this.tickLens = tickLens

--- a/packages/wagmi/src/hooks/pools/actions/getAllPoolsCodeMap.ts
+++ b/packages/wagmi/src/hooks/pools/actions/getAllPoolsCodeMap.ts
@@ -50,7 +50,9 @@ export const getAllPoolsCodeMap = async ({
     LiquidityProviders.LaserSwap, // thundercore
   ]
 
-  const testLiquidityProviders = [...sushiLiquidityProviders]
+  const testLiquidityProviders = [...sushiLiquidityProviders].filter(
+    (p) => p !== LiquidityProviders.Trident,
+  )
 
   const dataFetcher = DataFetcher.onChain(chainId)
   // console.log('dataFetcher startDataFetching')


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on making changes related to test configurations and adding an `isTest` parameter to certain classes.

### Detailed summary:
- Updated `process.on('exit')` to `process.on('SIGTERM')` in `apps/evm/test/global.setup.ts`.
- Removed import of `Sentry` in `apps/evm/src/lib/swap/useCrossChainTrade/useCrossChainTrade.ts`.
- Updated `testMatch` in `apps/evm/test/playwright.config.ts`.
- Added `isTest` parameter to `Trident.ts`, `UniswapV3Base.ts`, `UniswapV2Base.ts`, and `LiquidityProvider.ts` classes.
- Updated `getAllPoolsCodeMap.ts` to filter out `LiquidityProviders.Trident` from `testLiquidityProviders`.
- Updated import order in `useAngleRewards.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->