### PR TITLE
Feature/extractor prefetch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,27 +1,27 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "LOCAL: Minikube",
-            "profile": "local",
-            "type": "cloudcode.kubernetes",
-            "request": "launch",
-            "skaffoldConfig": "${workspaceFolder}/apis/extractor/skaffold.yaml",
-            "watch": false,
-            "cleanUp": true,
-            "portForward": true,
-            "imageRegistry": "gcr.io/extractor-410208"
-        },
-        {
-            "name": "STAGING: GKE",
-            "profile": "staging",
-            "type": "cloudcode.kubernetes",
-            "request": "launch",
-            "skaffoldConfig": "${workspaceFolder}/apis/extractor/skaffold.yaml",
-            "watch": false,
-            "cleanUp": false,
-            "portForward": true,
-            "imageRegistry": "gcr.io/extractor-410208"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "LOCAL: Minikube",
+      "profile": "local",
+      "type": "cloudcode.kubernetes",
+      "request": "launch",
+      "skaffoldConfig": "${workspaceFolder}/apis/extractor/skaffold.yaml",
+      "watch": false,
+      "cleanUp": true,
+      "portForward": true,
+      "imageRegistry": "gcr.io/extractor-410208"
+    },
+    {
+      "name": "STAGING: GKE",
+      "profile": "staging",
+      "type": "cloudcode.kubernetes",
+      "request": "launch",
+      "skaffoldConfig": "${workspaceFolder}/apis/extractor/skaffold.yaml",
+      "watch": false,
+      "cleanUp": false,
+      "portForward": true,
+      "imageRegistry": "gcr.io/extractor-410208"
+    }
+  ]
 }

--- a/apis/extractor/src/config.ts
+++ b/apis/extractor/src/config.ts
@@ -28,6 +28,7 @@ import { config } from '@sushiswap/viem-config'
 import { ChainId } from 'sushi/chain'
 import { type Address, createPublicClient } from 'viem'
 
+const RPC_MAX_CALLS_IN_ONE_BATCH = 1000
 function sushiswapV2Factory(chainId: SushiSwapV2ChainId) {
   return {
     address: SUSHISWAP_V2_FACTORY_ADDRESS[chainId],
@@ -93,6 +94,7 @@ export const EXTRACTOR_CONFIG = {
     logDepth: 300,
     logType: LogFilterType.Native,
     logging: true,
+    maxCallsInOneBatch: RPC_MAX_CALLS_IN_ONE_BATCH,
   },
   [ChainId.ARBITRUM_NOVA]: {
     client: createPublicClient(config[ChainId.ARBITRUM_NOVA]),
@@ -212,6 +214,7 @@ export const EXTRACTOR_CONFIG = {
     cacheDir: './cache',
     logDepth: 1000,
     logging: true,
+    maxCallsInOneBatch: RPC_MAX_CALLS_IN_ONE_BATCH,
   },
   [ChainId.CELO]: {
     client: createPublicClient(config[ChainId.CELO]),
@@ -263,6 +266,7 @@ export const EXTRACTOR_CONFIG = {
     cacheDir: './cache',
     logDepth: 50,
     logging: true,
+    maxCallsInOneBatch: RPC_MAX_CALLS_IN_ONE_BATCH,
   },
   [ChainId.FANTOM]: {
     client: createPublicClient(config[ChainId.FANTOM]),
@@ -332,6 +336,7 @@ export const EXTRACTOR_CONFIG = {
     logDepth: 50,
     logging: true,
     account: '0x4200000000000000000000000000000000000006', // just a whale because optimism eth_call needs gas (
+    maxCallsInOneBatch: RPC_MAX_CALLS_IN_ONE_BATCH,
   },
   [ChainId.POLYGON]: {
     client: createPublicClient(config[ChainId.POLYGON]),
@@ -381,6 +386,7 @@ export const EXTRACTOR_CONFIG = {
     cacheDir: './cache',
     logDepth: 100,
     logging: true,
+    maxCallsInOneBatch: RPC_MAX_CALLS_IN_ONE_BATCH,
   },
   [ChainId.POLYGON_ZKEVM]: {
     client: createPublicClient(config[ChainId.POLYGON_ZKEVM]),

--- a/apis/extractor/src/handlers/swap/schema.ts
+++ b/apis/extractor/src/handlers/swap/schema.ts
@@ -19,17 +19,16 @@ export const zChainId = z.coerce
   .lte(2 ** 256)
   .default(ChainId.ETHEREUM)
 
-export const poolCodesForTokenSchema = z
-  .object({
-    chainId: zChainId
-      .refine((chainId) => isExtractorSupportedChainId(chainId), {
-        message: 'ChainId not supported.',
-      })
-      .transform((chainId) => chainId as ExtractorSupportedChainId),
-    address: z.coerce.string().refine(isAddress, {
-      message: 'Address is not checksummed.',
-    }),
-  })
+export const poolCodesForTokenSchema = z.object({
+  chainId: zChainId
+    .refine((chainId) => isExtractorSupportedChainId(chainId), {
+      message: 'ChainId not supported.',
+    })
+    .transform((chainId) => chainId as ExtractorSupportedChainId),
+  address: z.coerce.string().refine(isAddress, {
+    message: 'Address is not checksummed.',
+  }),
+})
 
 export const querySchema3 = z.object({
   chainId: zChainId

--- a/packages/extractor/src/AlgebraExtractor.ts
+++ b/packages/extractor/src/AlgebraExtractor.ts
@@ -406,18 +406,13 @@ export class AlgebraExtractor {
     if (pool) return pool
     if (this.emptyAddressSet.has(addr)) return
     const promise = this.multiCallAggregator
-      .callValue(
-        factory.address,
-        AlgebraFactory.abi as Abi,
-        'poolByPair',
-        [t0.address, t1.address],
-      )
+      .callValue(factory.address, AlgebraFactory.abi as Abi, 'poolByPair', [
+        t0.address,
+        t1.address,
+      ])
       .then(
         (checkedAddress) => {
-          if (
-            checkedAddress ===
-            '0x0000000000000000000000000000000000000000'
-          ) {
+          if (checkedAddress === '0x0000000000000000000000000000000000000000') {
             this.emptyAddressSet.add(addr)
             return
           }

--- a/packages/extractor/src/AlgebraExtractor.ts
+++ b/packages/extractor/src/AlgebraExtractor.ts
@@ -354,41 +354,9 @@ export class AlgebraExtractor {
       for (let j = i + 1; j < tokensUnique.length; ++j) {
         const t1 = tokensUnique[j]
         this.factoriesFull.forEach((factory) => {
-          const addr = this.computeAlgebraAddress(factory, t0, t1)
-          const addrL = addr.toLowerCase() as Address
-          const pool = this.poolMap.get(addrL)
-          if (pool) {
-            prefetched.push(pool)
-            return
-          }
-          if (this.emptyAddressSet.has(addr)) return
-          const promise = this.multiCallAggregator
-            .callValue(
-              factory.address,
-              AlgebraFactory.abi as Abi,
-              'poolByPair',
-              [t0.address, t1.address],
-            )
-            .then(
-              (checkedAddress) => {
-                if (
-                  checkedAddress ===
-                  '0x0000000000000000000000000000000000000000'
-                ) {
-                  this.emptyAddressSet.add(addr)
-                  return
-                }
-                const watcher = this.addPoolWatching(
-                  { address: addr, token0: t0, token1: t1, factory },
-                  'request',
-                  true,
-                  startTime,
-                )
-                return watcher
-              },
-              () => undefined,
-            )
-          fetching.push(promise)
+          const res = this.getWatchersForTokenPair(factory, t0, t1, startTime)
+          if (res instanceof Promise) fetching.push(res)
+          else if (res !== undefined) prefetched.push(res)
         })
       }
     }
@@ -396,6 +364,74 @@ export class AlgebraExtractor {
       prefetched,
       fetching,
     }
+  }
+
+  getWatchersBetweenTokenSets(
+    tokensUnique1: Token[],
+    tokensUnique2: Token[],
+  ): {
+    prefetched: AlgebraPoolWatcher[]
+    fetching: Promise<AlgebraPoolWatcher | undefined>[]
+  } {
+    const startTime = performance.now()
+    const prefetched: AlgebraPoolWatcher[] = []
+    const fetching: Promise<AlgebraPoolWatcher | undefined>[] = []
+    for (let i = 0; i < tokensUnique1.length; ++i) {
+      const t0 = tokensUnique1[i]
+      this.tokenManager.findToken(t0.address as Address) // to let save it in the cache
+      for (let j = 0; j < tokensUnique2.length; ++j) {
+        const t1 = tokensUnique2[j]
+        this.factoriesFull.forEach((factory) => {
+          const res = this.getWatchersForTokenPair(factory, t0, t1, startTime)
+          if (res instanceof Promise) fetching.push(res)
+          else if (res !== undefined) prefetched.push(res)
+        })
+      }
+    }
+    return {
+      prefetched,
+      fetching,
+    }
+  }
+
+  getWatchersForTokenPair(
+    factory: FactoryAlgebraFull,
+    t0: Token,
+    t1: Token,
+    startTime: number,
+  ): undefined | AlgebraPoolWatcher | Promise<AlgebraPoolWatcher | undefined> {
+    const addr = this.computeAlgebraAddress(factory, t0, t1)
+    const addrL = addr.toLowerCase() as Address
+    const pool = this.poolMap.get(addrL)
+    if (pool) return pool
+    if (this.emptyAddressSet.has(addr)) return
+    const promise = this.multiCallAggregator
+      .callValue(
+        factory.address,
+        AlgebraFactory.abi as Abi,
+        'poolByPair',
+        [t0.address, t1.address],
+      )
+      .then(
+        (checkedAddress) => {
+          if (
+            checkedAddress ===
+            '0x0000000000000000000000000000000000000000'
+          ) {
+            this.emptyAddressSet.add(addr)
+            return
+          }
+          const watcher = this.addPoolWatching(
+            { address: addr, token0: t0, token1: t1, factory },
+            'request',
+            true,
+            startTime,
+          )
+          return watcher
+        },
+        () => undefined,
+      )
+    return promise
   }
 
   async addPoolByAddress(address: Address) {

--- a/packages/extractor/src/Extractor.ts
+++ b/packages/extractor/src/Extractor.ts
@@ -118,8 +118,9 @@ export class Extractor {
     setWarningMessageHandler(args.warningMessageHandler)
   }
 
-  /// @param tokensPrefetch Prefetch all pools between these tokens
-  async start(tokensPrefetch: Token[] = []) {
+  /// @param tokensBaseSet Prefetch all pools between these tokens
+  /// @param tokensAdditionalSet Prefetch all pools between tokensBaseSet and tokensAdditionalSet
+  async start(tokensBaseSet: Token[] = [], tokensAdditionalSet: Token[] = []) {
     this.logFilter.start()
     await Promise.all(
       [
@@ -128,7 +129,7 @@ export class Extractor {
         this.extractorAlg?.start(),
       ].filter((e) => e !== undefined),
     )
-    this.getPoolCodesForTokens(tokensPrefetch)
+    await this.prefetch(tokensBaseSet, tokensAdditionalSet)
     if (this.cacheDir !== '')
       this.printTokensPoolsQuantity(
         this.cacheDir,
@@ -241,6 +242,44 @@ export class Extractor {
         : []
       ++this.requestFinishedNum
       return pools2.concat(pools3).concat(poolsAlg)
+    } catch (e) {
+      ++this.requestFinishedNum
+      ++this.requestFailedNum
+      throw e
+    }
+  }
+
+  // downloads pools for all pairs from tokensBaseSet and between tokensBaseSet and tokensAdditionalSet
+  async prefetch(tokensBaseSet: Token[], tokensAdditionalSet: Token[]): Promise<void> {
+    ++this.requestStartedNum
+    try {
+      const baseMap = new Map<string, Token>()
+      tokensBaseSet.forEach((t) => baseMap.set(t.address, t))
+      const baseUnique = Array.from(baseMap.values())
+
+      const addMap = new Map<string, Token>()
+      tokensAdditionalSet.forEach((t) => {
+        if (baseMap.get(t.address) === undefined)
+         addMap.set(t.address, t)
+      })
+      const addUnique = Array.from(addMap.values())
+
+      let fetching: Promise<unknown>[] = []
+
+      if (this.extractorV2 ) {
+        fetching = fetching.concat(this.extractorV2.getPoolsForTokens(baseUnique).fetching)
+        fetching = fetching.concat(this.extractorV2.getPoolsBetweenTokenSets(baseUnique, addUnique).fetching)
+      }
+      if (this.extractorV3 ) {
+        fetching = fetching.concat(this.extractorV3.getWatchersForTokens(baseUnique).fetching)
+        fetching = fetching.concat(this.extractorV3.getWatchersBetweenTokenSets(baseUnique, addUnique).fetching)
+      }
+      if (this.extractorAlg) {
+        fetching = fetching.concat(this.extractorAlg.getWatchersForTokens(baseUnique).fetching)
+        fetching = fetching.concat(this.extractorAlg.getWatchersBetweenTokenSets(baseUnique, addUnique).fetching)
+      }
+      await Promise.allSettled(fetching)
+      ++this.requestFinishedNum
     } catch (e) {
       ++this.requestFinishedNum
       ++this.requestFailedNum

--- a/packages/extractor/src/Extractor.ts
+++ b/packages/extractor/src/Extractor.ts
@@ -250,7 +250,10 @@ export class Extractor {
   }
 
   // downloads pools for all pairs from tokensBaseSet and between tokensBaseSet and tokensAdditionalSet
-  async prefetch(tokensBaseSet: Token[], tokensAdditionalSet: Token[]): Promise<void> {
+  async prefetch(
+    tokensBaseSet: Token[],
+    tokensAdditionalSet: Token[],
+  ): Promise<void> {
     ++this.requestStartedNum
     try {
       const baseMap = new Map<string, Token>()
@@ -259,24 +262,38 @@ export class Extractor {
 
       const addMap = new Map<string, Token>()
       tokensAdditionalSet.forEach((t) => {
-        if (baseMap.get(t.address) === undefined)
-         addMap.set(t.address, t)
+        if (baseMap.get(t.address) === undefined) addMap.set(t.address, t)
       })
       const addUnique = Array.from(addMap.values())
 
       let fetching: Promise<unknown>[] = []
 
-      if (this.extractorV2 ) {
-        fetching = fetching.concat(this.extractorV2.getPoolsForTokens(baseUnique).fetching)
-        fetching = fetching.concat(this.extractorV2.getPoolsBetweenTokenSets(baseUnique, addUnique).fetching)
+      if (this.extractorV2) {
+        fetching = fetching.concat(
+          this.extractorV2.getPoolsForTokens(baseUnique).fetching,
+        )
+        fetching = fetching.concat(
+          this.extractorV2.getPoolsBetweenTokenSets(baseUnique, addUnique)
+            .fetching,
+        )
       }
-      if (this.extractorV3 ) {
-        fetching = fetching.concat(this.extractorV3.getWatchersForTokens(baseUnique).fetching)
-        fetching = fetching.concat(this.extractorV3.getWatchersBetweenTokenSets(baseUnique, addUnique).fetching)
+      if (this.extractorV3) {
+        fetching = fetching.concat(
+          this.extractorV3.getWatchersForTokens(baseUnique).fetching,
+        )
+        fetching = fetching.concat(
+          this.extractorV3.getWatchersBetweenTokenSets(baseUnique, addUnique)
+            .fetching,
+        )
       }
       if (this.extractorAlg) {
-        fetching = fetching.concat(this.extractorAlg.getWatchersForTokens(baseUnique).fetching)
-        fetching = fetching.concat(this.extractorAlg.getWatchersBetweenTokenSets(baseUnique, addUnique).fetching)
+        fetching = fetching.concat(
+          this.extractorAlg.getWatchersForTokens(baseUnique).fetching,
+        )
+        fetching = fetching.concat(
+          this.extractorAlg.getWatchersBetweenTokenSets(baseUnique, addUnique)
+            .fetching,
+        )
       }
       await Promise.allSettled(fetching)
       ++this.requestFinishedNum

--- a/packages/extractor/src/UniV2Extractor.ts
+++ b/packages/extractor/src/UniV2Extractor.ts
@@ -280,53 +280,9 @@ export class UniV2Extractor {
       for (let j = i + 1; j < tokensUnique.length; ++j) {
         const t1 = tokensUnique[j]
         this.factories.forEach((factory) => {
-          const addr = this.computeV2Address(factory, t0, t1)
-          const addrL = addr.toLowerCase()
-          const poolState = this.poolMap.get(addrL)
-          if (poolState) {
-            if (
-              poolState.status === PoolStatus.ValidPool ||
-              poolState.status === PoolStatus.UpdatingPool
-            )
-              prefetched.push(poolState.poolCode)
-            return
-          }
-          const startTime = performance.now()
-          this.taskCounter.inc()
-          const promise = this.multiCallAggregator
-            .callValue(addr, getReservesAbi, 'getReserves')
-            .then(
-              (reserves) => {
-                this.taskCounter.dec()
-                const poolState2 = this.poolMap.get(addrL)
-                if (poolState2) {
-                  // pool was created
-                  if (
-                    poolState2.status === PoolStatus.ValidPool ||
-                    poolState2.status === PoolStatus.UpdatingPool
-                  )
-                    return poolState2.poolCode
-                }
-                const [reserve0, reserve1] = reserves as [bigint, bigint]
-                return this.addPoolWatching({
-                  address: addr,
-                  token0: t0,
-                  token1: t1,
-                  reserve0,
-                  reserve1,
-                  factory,
-                  source: 'request',
-                  addToCache: true,
-                  startTime,
-                })
-              },
-              () => {
-                this.poolMap.set(addrL, { status: PoolStatus.NoPool })
-                this.taskCounter.dec()
-                return undefined
-              },
-            )
-          fetching.push(promise)
+          const res = this.getPoolForTokenPair(factory, t0, t1)
+          if (res instanceof Promise) fetching.push(res)
+          else prefetched.push(res)
         })
       }
     }
@@ -334,6 +290,86 @@ export class UniV2Extractor {
       prefetched,
       fetching,
     }
+  }
+
+  getPoolsBetweenTokenSets(
+    tokensUnique1: Token[],
+    tokensUnique2: Token[],
+  ): {
+    prefetched: ConstantProductPoolCode[]
+    fetching: Promise<ConstantProductPoolCode | undefined>[]
+  } {
+    const prefetched: ConstantProductPoolCode[] = []
+    const fetching: Promise<ConstantProductPoolCode | undefined>[] = []
+    for (let i = 0; i < tokensUnique1.length; ++i) {
+      const t0 = tokensUnique1[i]
+      this.tokenManager.findToken(t0.address as Address) // to let save it in the cache
+      for (let j = 0; j < tokensUnique2.length; ++j) {
+        const t1 = tokensUnique2[j]
+        this.factories.forEach((factory) => {
+          const res = this.getPoolForTokenPair(factory, t0, t1)
+          if (res instanceof Promise) fetching.push(res)
+          else prefetched.push(res)
+        })
+      }
+    }
+    return {
+      prefetched,
+      fetching,
+    }
+  }
+
+  getPoolForTokenPair(
+    factory: FactoryV2,
+    t0: Token,
+    t1: Token,
+  ): ConstantProductPoolCode | Promise<ConstantProductPoolCode | undefined> {
+    const addr = this.computeV2Address(factory, t0, t1)
+    const addrL = addr.toLowerCase()
+    const poolState = this.poolMap.get(addrL)
+    if (poolState) {
+      if (
+        poolState.status === PoolStatus.ValidPool ||
+        poolState.status === PoolStatus.UpdatingPool
+      )
+        return poolState.poolCode
+    }
+    const startTime = performance.now()
+    this.taskCounter.inc()
+    const promise = this.multiCallAggregator
+      .callValue(addr, getReservesAbi, 'getReserves')
+      .then(
+        (reserves) => {
+          this.taskCounter.dec()
+          const poolState2 = this.poolMap.get(addrL)
+          if (poolState2) {
+            // pool was created
+            if (
+              poolState2.status === PoolStatus.ValidPool ||
+              poolState2.status === PoolStatus.UpdatingPool
+            )
+              return poolState2.poolCode
+          }
+          const [reserve0, reserve1] = reserves as [bigint, bigint]
+          return this.addPoolWatching({
+            address: addr,
+            token0: t0,
+            token1: t1,
+            reserve0,
+            reserve1,
+            factory,
+            source: 'request',
+            addToCache: true,
+            startTime,
+          })
+        },
+        () => {
+          this.poolMap.set(addrL, { status: PoolStatus.NoPool })
+          this.taskCounter.dec()
+          return undefined
+        },
+      )
+    return promise
   }
 
   // Is not used now

--- a/packages/extractor/src/UniV3Extractor.ts
+++ b/packages/extractor/src/UniV3Extractor.ts
@@ -313,7 +313,13 @@ export class UniV3Extractor {
           const feeSpacingMap = factory.feeSpacingMap ?? uniswapFeeSpaceMap
           const fees = Object.keys(feeSpacingMap).map((f) => Number(f))
           fees.forEach((fee) => {
-            const res = this.getWatchersForTokenPair(factory, fee, t0, t1, startTime)
+            const res = this.getWatchersForTokenPair(
+              factory,
+              fee,
+              t0,
+              t1,
+              startTime,
+            )
             if (res instanceof Promise) fetching.push(res)
             else if (res !== undefined) prefetched.push(res)
           })
@@ -345,9 +351,15 @@ export class UniV3Extractor {
           const feeSpacingMap = factory.feeSpacingMap ?? uniswapFeeSpaceMap
           const fees = Object.keys(feeSpacingMap).map((f) => Number(f))
           fees.forEach((fee) => {
-          const res = this.getWatchersForTokenPair(factory, fee, t0, t1, startTime)
-          if (res instanceof Promise) fetching.push(res)
-          else if (res !== undefined) prefetched.push(res)
+            const res = this.getWatchersForTokenPair(
+              factory,
+              fee,
+              t0,
+              t1,
+              startTime,
+            )
+            if (res instanceof Promise) fetching.push(res)
+            else if (res !== undefined) prefetched.push(res)
           })
         })
       }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Updated `poolCodesForTokenSchema` object in `schema.ts` to use the new syntax for `z.object`
- Updated `launch.json` in `.vscode` directory to use the new syntax for configurations
- Added `maxCallsInOneBatch` property to `EXTRACTOR_CONFIG` object in `config.ts`
- Updated `start` method in `Extractor.ts` to accept `tokensBaseSet` and `tokensAdditionalSet` parameters
- Added `prefetch` method in `Extractor.ts` to download pools for specified token sets
- Updated `getPoolCodesForTokensFull` method in `AlgebraExtractor.ts` to use new syntax for fetching pools
- Updated `getWatchersBetweenTokenSets` method in `AlgebraExtractor.ts` to use new syntax for fetching pools
- Updated `addPoolByAddress` method in `AlgebraExtractor.ts` to use new syntax for fetching pools
- Updated `getWatchersBetweenTokenSets` method in `UniV3Extractor.ts` to use new syntax for fetching pools
- Updated `getWatchersForTokenPair` method in `UniV3Extractor.ts` to use new syntax for fetching pools

> The following files were skipped due to too many changes: `packages/extractor/src/UniV3Extractor.ts`, `packages/extractor/src/UniV2Extractor.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->