### PR TITLE
fix: wagmi import in SmartPositionsTable

### DIFF
--- a/apps/evm/src/ui/pool/SmartPositionsTable.tsx
+++ b/apps/evm/src/ui/pool/SmartPositionsTable.tsx
@@ -12,9 +12,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@sushiswap/ui'
-import { useSteerAccountPositionsFormatted } from '@sushiswap/wagmi'
+import { useAccount, useSteerAccountPositionsFormatted } from '@sushiswap/wagmi'
 import { formatPercent } from 'sushi'
-import { useAccount } from 'wagmi'
 import { APRHoverCard } from './APRHoverCard'
 import {
   STEER_NAME_COLUMN,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on importing the `useAccount` hook from `@sushiswap/wagmi` instead of `wagmi` in the `SmartPositionsTable.tsx` file.

### Detailed summary:
- Imported `useAccount` hook from `@sushiswap/wagmi` instead of `wagmi`.
- No other notable changes in the file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->