### PR TITLE
fix: no value for chainId url param

### DIFF
--- a/apps/evm/src/ui/swap/simple/derivedstate-simple-swap-provider.tsx
+++ b/apps/evm/src/ui/swap/simple/derivedstate-simple-swap-provider.tsx
@@ -92,7 +92,7 @@ const DerivedstateSimpleSwapProvider: FC<DerivedStateSimpleSwapProviderProps> =
     // This handles the case where some params might not be provided by the user
     const defaultedParams = useMemo(() => {
       const params = new URLSearchParams(searchParams)
-      if (!params.has('chainId'))
+      if (!params.has('chainId') || !params.get('chainId'))
         params.set(
           'chainId',
           (chain?.id && isSupportedChainId(chain.id)


### PR DESCRIPTION
https://www.sushi.com/swap?chainId currently throws an error because chainId param has no value

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a check to ensure that the `chainId` parameter is not empty before setting a default value in the `defaultedParams` constant.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->