### PR TITLE
fix: v2 pool liquidity fiat value

### DIFF
--- a/apps/evm/src/ui/pool/PoolComposition.tsx
+++ b/apps/evm/src/ui/pool/PoolComposition.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { Pool } from '@sushiswap/client'
-import { usePrices } from '@sushiswap/react-query'
 import {
   Card,
   CardContent,
@@ -15,7 +14,6 @@ import {
 import React, { FC } from 'react'
 import { usePoolGraphData, useTokenAmountDollarValues } from 'src/lib/hooks'
 import { ChainId } from 'sushi/chain'
-import { Native } from 'sushi/currency'
 import { formatUSD } from 'sushi/format'
 
 interface PoolCompositionProps {
@@ -23,7 +21,6 @@ interface PoolCompositionProps {
 }
 
 export const PoolComposition: FC<PoolCompositionProps> = ({ pool }) => {
-  const { data: prices } = usePrices({ chainId: pool.chainId })
   const { data, isLoading } = usePoolGraphData({
     poolAddress: pool.address,
     chainId: pool.chainId as ChainId,
@@ -37,16 +34,7 @@ export const PoolComposition: FC<PoolCompositionProps> = ({ pool }) => {
     <Card>
       <CardHeader>
         <CardTitle>Pool Liquidity</CardTitle>
-        <CardDescription>
-          {formatUSD(
-            (data?.liquidityNative ?? 0) *
-              Number(
-                prices?.[Native.onChain(pool.chainId).wrapped.address]?.toFixed(
-                  10,
-                ),
-              ),
-          )}
-        </CardDescription>
+        <CardDescription>{formatUSD(data?.liquidityUSD ?? 0)}</CardDescription>
       </CardHeader>
       <CardContent>
         <CardGroup>


### PR DESCRIPTION
Addresses incorrect fiat value displayed for V2 pools total liquidity.

https://www.sushi.com/pool/137%3A0xc4e595acdd7d12fec385e5da5d43160e8a0bac0e
<img width="408" alt="image" src="https://github.com/sushiswap/sushiswap/assets/82962873/78d71b2c-d0fb-48ee-a1e2-b0da55341592">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `usePrices` import and related code, and replaces the `CardDescription` content with the `liquidityUSD` value from the `data` object.

### Detailed summary
- Removed `usePrices` import and related code.
- Replaced `CardDescription` content with `liquidityUSD` value from `data` object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->