### PR TITLE
fix: duplicate LiquidityProviders in DataFetcher

### DIFF
--- a/packages/router/src/DataFetcher.ts
+++ b/packages/router/src/DataFetcher.ts
@@ -98,8 +98,6 @@ export class DataFetcher {
     } else {
       this.web3Client = createPublicClient(config[this.chainId])
     }
-
-    this.providers = [new NativeWrapProvider(this.chainId, this.web3Client)]
   }
 
   _providerIsIncluded(
@@ -113,6 +111,7 @@ export class DataFetcher {
 
   _setProviders(providers: LiquidityProviders[]) {
     // concrete providers
+    this.providers = [new NativeWrapProvider(this.chainId, this.web3Client)]
     ;[
       ApeSwapProvider,
       BiswapProvider,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
The focus of this PR is to update the providers in the DataFetcher class in the `DataFetcher.ts` file.

### Detailed summary:
- Removed the existing providers from the `providers` array.
- Added a new provider `NativeWrapProvider` to the `providers` array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->