### PR TITLE
chore: show 1 month APY on sushi bar

### DIFF
--- a/apps/evm/src/ui/stake/BarHeader.tsx
+++ b/apps/evm/src/ui/stake/BarHeader.tsx
@@ -15,7 +15,7 @@ import { formatPercent, shortenAddress } from 'sushi/format'
 import { useSushiBar } from './SushiBarProvider'
 
 export const BarHeader = () => {
-  const { apr, isLoading } = useSushiBar()
+  const { apy, isLoading } = useSushiBar()
 
   return (
     <div className="flex flex-col gap-6">
@@ -35,7 +35,9 @@ export const BarHeader = () => {
       </span>
       <div className="flex flex-wrap items-center gap-y-5 gap-x-[32px] text-secondary-foreground">
         <div className="flex items-center gap-1.5">
-          <span className="tracking-tighter font-semibold">APR</span>
+          <span className="tracking-tighter font-semibold whitespace-nowrap">
+            APY (1m)
+          </span>
           {isLoading ? (
             <SkeletonText className="w-12" fontSize="default" />
           ) : (
@@ -43,11 +45,11 @@ export const BarHeader = () => {
               <Tooltip delayDuration={0}>
                 <TooltipTrigger asChild>
                   <span className="underline decoration-dotted underline-offset-2">
-                    {formatPercent(apr)}
+                    {formatPercent(apy)}
                   </span>
                 </TooltipTrigger>
                 <TooltipContent>
-                  The APR displayed is algorithmic and subject to change.
+                  The APY displayed is algorithmic and subject to change.
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/apps/evm/src/ui/stake/SushiBarProvider.tsx
+++ b/apps/evm/src/ui/stake/SushiBarProvider.tsx
@@ -8,7 +8,7 @@ import { Amount, SUSHI, Type, XSUSHI, tryParseAmount } from 'sushi/currency'
 interface SushiBarContext {
   totalSupply: Amount<Type> | undefined
   sushiBalance: Amount<Type> | undefined
-  apr: string | undefined
+  apy: number | undefined
   isLoading: boolean
   isError: boolean
 }
@@ -21,11 +21,11 @@ export const SushiBarProvider: FC<{
 }> = ({ children }) => {
   const { data, isLoading, isError } = useBarData()
 
-  const [sushiBalance, totalSupply, apr] = useMemo(
+  const [sushiBalance, totalSupply, apy] = useMemo(
     () => [
       tryParseAmount(data?.xsushi?.sushiSupply, SUSHI[ChainId.ETHEREUM]),
       tryParseAmount(data?.xsushi?.xSushiSupply, XSUSHI[ChainId.ETHEREUM]),
-      data?.xsushi?.apr12m ? data?.xsushi?.apr12m : undefined,
+      data?.xsushi?.apr1m ? data.xsushi.apr1m * 12 : undefined,
     ],
     [data],
   )
@@ -36,11 +36,11 @@ export const SushiBarProvider: FC<{
         () => ({
           totalSupply,
           sushiBalance,
-          apr,
+          apy,
           isLoading,
           isError,
         }),
-        [sushiBalance, totalSupply, apr, isError, isLoading],
+        [sushiBalance, totalSupply, apy, isError, isLoading],
       )}
     >
       {children}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the `SushiBarProvider` and `BarHeader` components in the `evm` app. It introduces a new variable `apy` to replace `apr` and makes changes related to annual percentage yield (APY) calculations.

### Detailed summary:
- Replaced `apr` variable with `apy` variable in `SushiBarProvider` component
- Calculated `apy` based on `apr1m` value multiplied by 12
- Updated relevant dependencies and types in `SushiBarProvider`
- Updated `BarHeader` component to display "APY (1m)" instead of "APR"
- Updated tooltip content in `BarHeader` to mention APY instead of APR

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->