### PR TITLE
fix(xswap): layerzero explorer link

### DIFF
--- a/apps/evm/src/lib/swap/useLayerZeroScanLink.ts
+++ b/apps/evm/src/lib/swap/useLayerZeroScanLink.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@layerzerolabs/scan-client'
 import { useQuery } from '@tanstack/react-query'
 import { ChainId } from 'sushi/chain'
-import { STARGATE_CHAIN_ID, StargateChainId } from 'sushi/config'
+import { STARGATE_CHAIN_ID } from 'sushi/config'
 
 const client = createClient('mainnet')
 
@@ -16,6 +16,8 @@ export const useLayerZeroScanLink = ({
   network1: ChainId
   txHash: string | undefined
 }) => {
+  console.log(tradeId, txHash)
+
   return useQuery({
     queryKey: ['lzLink', { txHash, network0, network1, tradeId }],
     queryFn: async () => {
@@ -26,14 +28,9 @@ export const useLayerZeroScanLink = ({
       ) {
         const result = await client.getMessagesBySrcTxHash(txHash)
         if (result.messages.length > 0) {
-          const { srcUaAddress, dstUaAddress, srcUaNonce, status, dstTxHash } =
-            result.messages[0]
+          const { status, dstTxHash } = result.messages[0]
           return {
-            link: `https://layerzeroscan.com/${
-              STARGATE_CHAIN_ID[network0 as StargateChainId]
-            }/address/${srcUaAddress}/message/${
-              STARGATE_CHAIN_ID[network1 as StargateChainId]
-            }/address/${dstUaAddress}/nonce/${srcUaNonce}`,
+            link: `https://layerzeroscan.com/tx/${txHash}`,
             status,
             dstTxHash,
           }

--- a/apps/evm/src/ui/bonds/bonds-market-page-header/bonds-market-page-header.tsx
+++ b/apps/evm/src/ui/bonds/bonds-market-page-header/bonds-market-page-header.tsx
@@ -206,7 +206,7 @@ export const BondsMarketPageHeader = async ({ id }: { id: MarketId }) => {
               </Button>
             </LinkExternal>
           </div>
-          <div className="flex items-center gap-1.5">
+          {/* <div className="flex items-center gap-1.5">
             <span className="tracking-tighter font-semibold">Issuer</span>
             {bond.issuer ? (
               <LinkExternal target="_blank" href={bond.issuer.link}>
@@ -223,7 +223,7 @@ export const BondsMarketPageHeader = async ({ id }: { id: MarketId }) => {
             ) : (
               <div className="text-secondary-foreground">Unknown</div>
             )}
-          </div>
+          </div> */}
         </div>
       </div>
     </div>

--- a/apps/evm/src/ui/bonds/bonds-table/bonds-table.tsx
+++ b/apps/evm/src/ui/bonds/bonds-table/bonds-table.tsx
@@ -10,7 +10,7 @@ import React, { FC, useMemo, useState } from 'react'
 import {
   BOND_ASSET_COLUMN,
   DISCOUNT_COLUMN,
-  ISSUER_COLUMN,
+  // ISSUER_COLUMN,
   PAYOUT_ASSET_COLUMN,
   PRICE_COLUMN,
   VESTING_COLUMN,
@@ -22,7 +22,7 @@ const COLUMNS = [
   DISCOUNT_COLUMN,
   BOND_ASSET_COLUMN,
   VESTING_COLUMN,
-  ISSUER_COLUMN,
+  // ISSUER_COLUMN,
 ] satisfies ColumnDef<Bond, unknown>[]
 
 const emptyArray: any[] = []

--- a/apps/evm/src/ui/swap/cross-chain/cross-chain-swap-confirmation-dialog.tsx
+++ b/apps/evm/src/ui/swap/cross-chain/cross-chain-swap-confirmation-dialog.tsx
@@ -82,7 +82,7 @@ export const ConfirmationDialogContent: FC<ConfirmationDialogContent> = ({
             rel="noreferrer noopener noreferer"
             href={lzUrl || ''}
           >
-            <Dots>to destination chain</Dots>
+            <Dots>to the destination chain</Dots>
           </a>
         </Button>{' '}
         <span className="flex items-center gap-1">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on making various changes and improvements in the EVM app, specifically related to the swap functionality, bonds table, bonds market page header, and layer zero scan link.

### Detailed summary:
- In the `cross-chain-swap-confirmation-dialog.tsx` file:
  - Updated the text from "to destination chain" to "to the destination chain" in a link.
- In the `bonds-table.tsx` file:
  - Commented out the `ISSUER_COLUMN` import and usage.
- In the `bonds-market-page-header.tsx` file:
  - Commented out a section related to the issuer.
- In the `useLayerZeroScanLink.ts` file:
  - Removed the import of `StargateChainId` from `sushi/config`.
  - Removed unused console.log statement.
  - Modified the logic related to generating a layer zero scan link.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->