### PR TITLE
fix(tokens): garbage source addresses kill the search

### DIFF
--- a/packages/react-query/src/hooks/tokenlist/useOtherTokenLists.ts
+++ b/packages/react-query/src/hooks/tokenlist/useOtherTokenLists.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { ChainId } from 'sushi/chain'
 import { Token } from 'sushi/currency'
-import { getAddress } from 'viem'
+import { getAddress, isAddress } from 'viem'
 
 import { isPromiseFulfilled } from 'sushi'
 import { BLACKLIST_TOKEN_IDS, DEFAULT_LIST_OF_LISTS } from 'sushi/token-list'
@@ -48,7 +48,7 @@ export const useOtherTokenListsQuery = ({
 
     const _data = tokenListQuery.data.reduce<Record<string, Token>>(
       (acc, { chainId: _chainId, name, symbol, address, decimals }) => {
-        if (!_query || chainId !== _chainId) return acc
+        if (!_query || chainId !== _chainId || !isAddress(address)) return acc
         // Filter out dupes
         if (defaultTokenList[`${_chainId}:${getAddress(address)}`]) return acc
         if (blacklisted.includes(address.toLowerCase())) return acc


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `isAddress` import from `viem` module.
- Added a condition in the `useOtherTokenListsQuery` function to filter out tokens with invalid addresses.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->