### PR TITLE
fix: override filecoin name

### DIFF
--- a/packages/sushi/src/chain/index.ts
+++ b/packages/sushi/src/chain/index.ts
@@ -117,6 +117,7 @@ export class Chain implements Chain {
         ...(this.explorers ?? []),
       ]
     } else if (data.chainId === ChainId.FILECOIN) {
+      this.name = 'Filecoin'
       this.explorers?.sort((explorer) => (explorer.name === 'Filfox' ? -1 : 1))
     } else if (data.chainId === ChainId.ZETACHAIN) {
       this.name = 'ZetaChain'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `name` property for `Filecoin` and `ZetaChain` in the `chain` module, and sorts explorers based on a condition.

### Detailed summary
- Update `name` property to 'Filecoin' when `chainId` is ChainId.FILECOIN
- Sort explorers array based on a condition involving the explorer name 'Filfox'
- Update `name` property to 'ZetaChain' when `chainId` is ChainId.ZETACHAIN

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->