### PR TITLE
fix: api endpoint for xswap

### DIFF
--- a/packages/react-query/src/hooks/trade/useTrade.ts
+++ b/packages/react-query/src/hooks/trade/useTrade.ts
@@ -15,6 +15,7 @@ import {
   WNATIVE_ADDRESS,
 } from 'sushi/currency'
 import { Percent, ZERO } from 'sushi/math'
+import { RouterLiquiditySource } from 'sushi/router'
 import { type Address, type Hex, stringify } from 'viem'
 import { usePrice } from '../prices'
 import { apiAdapter02To01 } from './apiAdapter'
@@ -30,8 +31,13 @@ const API_BASE_URL =
   process.env['NEXT_PUBLIC_API_BASE_URL'] ||
   'https://staging.sushi.com/swap'
 
-function getApiVersion(chainId: ChainId) {
-  if (isRouteProcessor4ChainId(chainId)) {
+function getApiVersion(
+  chainId: ChainId,
+  source: RouterLiquiditySource = RouterLiquiditySource.Sender,
+) {
+  if (source === RouterLiquiditySource.XSwap) {
+    return '/v3.2'
+  } else if (isRouteProcessor4ChainId(chainId)) {
     return '/v4'
   } else if (isRouteProcessor3_2ChainId(chainId)) {
     return '/v3.2'
@@ -67,11 +73,12 @@ export const useTradeQuery = (
         slippagePercentage,
         gasPrice,
         recipient,
+        source,
       },
     ],
     queryFn: async () => {
       const params = new URL(
-        `${API_BASE_URL}/swap${getApiVersion(chainId)}/${chainId}`,
+        `${API_BASE_URL}/swap${getApiVersion(chainId, source)}/${chainId}`,
       )
       // params.searchParams.set('chainId', `${chainId}`)
       params.searchParams.set(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new parameter `source` to `useTradeQuery` hook to specify the router liquidity source.

### Detailed summary
- Added `RouterLiquiditySource` import
- Updated `getApiVersion` function to handle `source` parameter
- Modified `useTradeQuery` to include `source` parameter in query URL

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->