### PR TITLE
fix: selected token row bg

### DIFF
--- a/packages/wagmi/src/components/token-selector/TokenSelectorRow.tsx
+++ b/packages/wagmi/src/components/token-selector/TokenSelectorRow.tsx
@@ -76,7 +76,7 @@ export const TokenSelectorRow: FC<TokenSelectorRow> = memo(
           onKeyDown={onClick}
           className={classNames(
             className,
-            selected ? 'bg-primary' : '',
+            selected ? 'bg-secondary' : '',
             `group flex items-center w-full hover:bg-muted focus:bg-accent h-full rounded-lg px-3 token-${currency?.symbol}`,
           )}
         >


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the background color of a selected token in the `TokenSelectorRow` component from primary to secondary.

### Detailed summary
- Changed background color to 'bg-secondary' when token is selected.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->