### PR TITLE
fix: useAllPrices

### DIFF
--- a/packages/react-query/src/hooks/prices/useAllPrices.ts
+++ b/packages/react-query/src/hooks/prices/useAllPrices.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import { withoutScientificNotation } from 'sushi/format'
 import { Fraction } from 'sushi/math'
 import { getAddress, isAddress, parseUnits } from 'viem'
 
@@ -7,10 +8,11 @@ const hydrate = (data: Record<string, number>) => {
   return Object.entries(data).reduce<Record<string, Record<string, Fraction>>>(
     (acc, [chainId, addresses]) => {
       acc[chainId] = Object.entries(addresses).reduce<Record<string, Fraction>>(
-        (acc, [address, price]) => {
-          if (isAddress(address)) {
+        (acc, [address, _price]) => {
+          const price = withoutScientificNotation(_price.toFixed(18))
+          if (isAddress(address) && typeof price !== 'undefined') {
             acc[getAddress(address)] = new Fraction(
-              parseUnits(price.toFixed(18), 18).toString(),
+              parseUnits(price, 18).toString(),
               parseUnits('1', 18).toString(),
             )
           }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to improve the handling of price formatting in the `useAllPrices` hook by adding a function to remove scientific notation.

### Detailed summary
- Added import for `withoutScientificNotation` from 'sushi/format'
- Modified price handling to remove scientific notation before parsing
- Added condition to check if price is defined before processing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->