### PR TITLE
feat: add routing source to swap widget

### DIFF
--- a/apps/evm/src/ui/swap/simple/derivedstate-simple-swap-provider.tsx
+++ b/apps/evm/src/ui/swap/simple/derivedstate-simple-swap-provider.tsx
@@ -440,5 +440,6 @@ const useSimpleSwapTrade = () => {
 export {
   DerivedstateSimpleSwapProvider,
   useDerivedStateSimpleSwap,
+  useFallback,
   useSimpleSwapTrade,
 }

--- a/apps/evm/src/ui/swap/simple/simple-swap-trade-stats.tsx
+++ b/apps/evm/src/ui/swap/simple/simple-swap-trade-stats.tsx
@@ -16,6 +16,7 @@ import {
 import { TradeRoutePathView } from '../trade-route-path-view'
 import {
   useDerivedStateSimpleSwap,
+  useFallback,
   useSimpleSwapTrade,
 } from './derivedstate-simple-swap-provider'
 
@@ -25,6 +26,7 @@ export const SimpleSwapTradeStats: FC = () => {
     state: { chainId, swapAmountString, recipient },
   } = useDerivedStateSimpleSwap()
   const { isInitialLoading: isLoading, data: trade } = useSimpleSwapTrade()
+  const { isFallback } = useFallback(chainId)
   const loading = Boolean(isLoading && !trade?.writeArgs)
 
   return (
@@ -96,6 +98,21 @@ export const SimpleSwapTradeStats: FC = () => {
             ) : trade?.gasSpent ? (
               `${trade.gasSpent} ${Native.onChain(chainId).symbol}`
             ) : null}
+          </span>
+        </div>
+
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-gray-700 dark:text-slate-400">
+            Routing source
+          </span>
+          <span className="text-sm font-semibold text-gray-700 text-right dark:text-slate-400">
+            {loading || !trade ? (
+              <SkeletonBox className="h-4 py-0.5 w-[120px]" />
+            ) : !isFallback ? (
+              'SushiSwap API'
+            ) : (
+              'SushiSwap Client'
+            )}
           </span>
         </div>
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new hook `useFallback` to handle fallback logic in the Simple Swap UI. It adds conditional rendering based on the fallback status.

### Detailed summary
- Added `useFallback` hook for fallback logic handling
- Conditionally render routing source based on fallback status in SimpleSwapTradeStats

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->