### PR TITLE
chore: disable sentry

### DIFF
--- a/apps/evm/next.config.mjs
+++ b/apps/evm/next.config.mjs
@@ -1,4 +1,4 @@
-import { withSentryConfig } from '@sentry/nextjs'
+// import { withSentryConfig } from '@sentry/nextjs'
 import defaultNextConfig from '@sushiswap/nextjs-config'
 import { withAxiom } from 'next-axiom'
 
@@ -95,49 +95,51 @@ const nextConfig = {
 }
 
 /** @type {import('@sentry/nextjs').SentryWebpackPluginOptions} */
-const sentryWebpackPluginOptions = {
-  // Additional config options for the Sentry webpack plugin. Keep in mind that
-  // the following options are set automatically, and overriding them is not
-  // recommended:
-  //   release, url, configFile, stripPrefix, urlPrefix, include, ignore
+// const sentryWebpackPluginOptions = {
+//   // Additional config options for the Sentry webpack plugin. Keep in mind that
+//   // the following options are set automatically, and overriding them is not
+//   // recommended:
+//   //   release, url, configFile, stripPrefix, urlPrefix, include, ignore
 
-  org: 'sushi-j9',
-  project: 'evm',
+//   org: 'sushi-j9',
+//   project: 'evm',
 
-  // An auth token is required for uploading source maps.
-  authToken: process.env.SENTRY_AUTH_TOKEN,
+//   // An auth token is required for uploading source maps.
+//   authToken: process.env.SENTRY_AUTH_TOKEN,
 
-  silent: true, // Suppresses all logs
+//   silent: true, // Suppresses all logs
 
-  // For all available options, see:
-  // https://github.com/getsentry/sentry-webpack-plugin#options.
-}
+//   // For all available options, see:
+//   // https://github.com/getsentry/sentry-webpack-plugin#options.
+// }
 
-export default withSentryConfig(
-  withAxiom(nextConfig),
-  sentryWebpackPluginOptions,
-  {
-    hideSourceMaps: true,
-    widenClientFileUpload: true,
-    automaticVercelMonitors: true,
-  },
-  // {
-  //   // For all available options, see:
-  //   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+export default withAxiom(nextConfig)
 
-  //   // Upload a larger set of source maps for prettier stack traces (increases build time)
-  //   widenClientFileUpload: true,
+// export default withSentryConfig(
+//   withAxiom(nextConfig),
+//   sentryWebpackPluginOptions,
+//   {
+//     hideSourceMaps: true,
+//     widenClientFileUpload: true,
+//     automaticVercelMonitors: true,
+//   },
+//   // {
+//   //   // For all available options, see:
+//   //   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
-  //   // Transpiles SDK to be compatible with IE11 (increases bundle size)
-  //   transpileClientSDK: false,
+//   //   // Upload a larger set of source maps for prettier stack traces (increases build time)
+//   //   widenClientFileUpload: true,
 
-  //   // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
-  //   tunnelRoute: '/monitoring',
+//   //   // Transpiles SDK to be compatible with IE11 (increases bundle size)
+//   //   transpileClientSDK: false,
 
-  //   // Hides source maps from generated client bundles
-  //   hideSourceMaps: true,
+//   //   // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
+//   //   tunnelRoute: '/monitoring',
 
-  //   // Automatically tree-shake Sentry logger statements to reduce bundle size
-  //   disableLogger: true,
-  // },
-)
+//   //   // Hides source maps from generated client bundles
+//   //   hideSourceMaps: true,
+
+//   //   // Automatically tree-shake Sentry logger statements to reduce bundle size
+//   //   disableLogger: true,
+//   // },
+// )


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes Sentry configuration and focuses on integrating `next-axiom` into the `evm` project.

### Detailed summary
- Removed Sentry configuration from `next.config.mjs`
- Integrated `next-axiom` using `withAxiom` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->