### PR TITLE
fix: merkl hook on RewardsSection

### DIFF
--- a/apps/evm/src/ui/pool/RewardsSection.tsx
+++ b/apps/evm/src/ui/pool/RewardsSection.tsx
@@ -37,7 +37,8 @@ export const RewardsSection: FC = () => {
   const { address } = useAccount()
   const { chainIds, tokenSymbols } = usePoolFilters()
   const { data, isInitialLoading } = useAngleRewardsMultipleChains({
-    chainIds: ANGLE_ENABLED_NETWORKS,
+    // chainIds: ANGLE_ENABLED_NETWORKS,
+    chainIds: [],
     account: address,
   })
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `RewardsSection.tsx` file in the EVM app to pass an empty array as `chainIds` instead of `ANGLE_ENABLED_NETWORKS`.

### Detailed summary
- Updated `chainIds` to be an empty array instead of `ANGLE_ENABLED_NETWORKS` in `useAngleRewardsMultipleChains` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->