### PR TITLE
fix: empty button on mobile header

### DIFF
--- a/packages/wagmi/src/components/user-profile/index.tsx
+++ b/packages/wagmi/src/components/user-profile/index.tsx
@@ -61,9 +61,7 @@ export const UserProfile: FC<ProfileProps> = () => {
             ) : null
             // <JazzIcon diameter={20} address={address} />
           }
-          <span className="hidden sm:block">
-            {shortenAddress(address, isSm ? 3 : 2)}
-          </span>
+          <span>{shortenAddress(address, isSm ? 3 : 2)}</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the user-profile component in `wagmi` package to show the full address instead of a shortened version.

### Detailed summary
- Updated user-profile to display full address instead of shortened version.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->