### PR TITLE
fix: low slippage error for tax tokens

### DIFF
--- a/apps/evm/src/lib/hooks/usePersistedSlippageError.ts
+++ b/apps/evm/src/lib/hooks/usePersistedSlippageError.ts
@@ -9,7 +9,10 @@ export const usePersistedSlippageError = ({
 
   // Need to perform some funky business because wagmi isn't keeping the previous error while its refetching
   useEffect(() => {
-    if (error?.message.includes('Minimal ouput balance violation')) {
+    if (
+      error?.message.includes('Minimal ouput balance violation') ||
+      error?.message.includes('MinimalOutputBalanceViolation')
+    ) {
       setShow(true)
       setPersistedError(error)
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `usePersistedSlippageError` hook to handle a new error message related to minimal output balance violation.

### Detailed summary
- Updated the condition to show error message to include 'MinimalOutputBalanceViolation' besides existing message.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->