### PR TITLE
fix: handle encoded MinimalOutput error in usePersistedSlippageError

### DIFF
--- a/apps/evm/src/lib/hooks/usePersistedSlippageError.ts
+++ b/apps/evm/src/lib/hooks/usePersistedSlippageError.ts
@@ -11,7 +11,8 @@ export const usePersistedSlippageError = ({
   useEffect(() => {
     if (
       error?.message.includes('Minimal ouput balance violation') ||
-      error?.message.includes('MinimalOutputBalanceViolation')
+      error?.message.includes('MinimalOutputBalanceViolation') ||
+      error?.message.includes('0x963b34a5')
     ) {
       setShow(true)
       setPersistedError(error)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `usePersistedSlippageError` hook to handle an additional error message and show the error message.

### Detailed summary
- Updated condition to check for a new error message '0x963b34a5'.
- Set `show` state to true and save the error message when the new error message is encountered.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->