### PR TITLE
feat(apps/evm): log fallback to drpc request

### DIFF
--- a/apps/evm/src/lib/wagmi/production.ts
+++ b/apps/evm/src/lib/wagmi/production.ts
@@ -37,9 +37,15 @@ export const createProductionConfig = () => {
       acc[Number(chainId) as ChainId] = http(transportUrl, {
         onFetchResponse(_res) {
           if (typeof window !== 'undefined' && transportUrl.includes('drpc')) {
+            let fallback = 'undefined'
+            if (typeof window.isFallback !== 'undefined') {
+              fallback = window.isFallback ? 'true' : 'false'
+            }
+
             gtagEvent('drpc-response', {
               pathname: window.location.pathname,
               href: window.location.href,
+              fallback,
               chainId,
             })
           }

--- a/apps/evm/src/types/window.d.ts
+++ b/apps/evm/src/types/window.d.ts
@@ -1,0 +1,5 @@
+export declare global {
+  interface Window {
+    isFallback?: boolean
+  }
+}

--- a/apps/evm/src/ui/swap/simple/derivedstate-simple-swap-provider.tsx
+++ b/apps/evm/src/ui/swap/simple/derivedstate-simple-swap-provider.tsx
@@ -441,6 +441,13 @@ const useSimpleSwapTrade = () => {
     return () => unwatch()
   }, [config, resetFallback])
 
+  // Write the fallback value to the window object so it can be logged to GA
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.isFallback = isFallback
+    }
+  }, [isFallback])
+
   return (isFallback ? clientTrade : apiTrade) as ReturnType<typeof useApiTrade>
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1592,8 +1592,6 @@ importers:
         specifier: 3.21.4
         version: 3.21.4
 
-  packages/sushi/dist/_cjs: {}
-
   packages/ui:
     dependencies:
       '@fontsource-variable/inter':


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a global `isFallback` property to the `Window` interface for logging to Google Analytics. It also updates the `onFetchResponse` method to include the `fallback` value in the `gtagEvent`.

### Detailed summary
- Added `isFallback` property to the `Window` interface
- Updated `onFetchResponse` method to include `fallback` in `gtagEvent`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->