### PR TITLE
fix: useBalanceWeb3 config

### DIFF
--- a/packages/wagmi/src/hooks/balances/useBalanceWeb3.ts
+++ b/packages/wagmi/src/hooks/balances/useBalanceWeb3.ts
@@ -1,10 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
 import { ChainId } from 'sushi/chain'
 import { Type } from 'sushi/currency'
-import { http, Address, zeroAddress } from 'viem'
+import { Address, zeroAddress } from 'viem'
 
-import { createConfig, serialize, useBalance } from 'wagmi'
-import { polygon } from 'wagmi/chains'
+import { serialize, useBalance, useConfig } from 'wagmi'
 import { useWatchByInterval } from '../watch'
 import { queryFnUseBalances } from './useBalancesWeb3'
 
@@ -27,14 +26,7 @@ export const useBalanceWeb3 = ({
     query: { enabled },
   })
 
-  const config = createConfig({
-    chains: [polygon],
-    transports: {
-      [polygon.id]: http('http://127.0.0.1:8545'),
-    },
-  })
-
-  // const config = useConfig()
+  const config = useConfig()
 
   useWatchByInterval({ key: queryKey, interval: 10000 })
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes `createConfig` and `polygon` chain configuration, and replaces it with `useConfig` in `useBalanceWeb3.ts`.

### Detailed summary
- Removed `createConfig` and `polygon` chain configuration
- Replaced with `useConfig` in `useBalanceWeb3.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->