### PR TITLE
feat(jobs/pool): move to db client singleton

### DIFF
--- a/config/graph/src/index.ts
+++ b/config/graph/src/index.ts
@@ -116,6 +116,7 @@ export const THUNDERCORE_HOST = 'graph-node.thundercore.com/subgraphs/name'
 export const CORE_HOST = 'thegraph.coredao.org/subgraphs/name'
 export const LINEA_HOST = 'graph-query.linea.build/subgraphs/name'
 export const HAQQ_HOST = 'haqq.graph.p2p.org/subgraphs/name'
+export const PCS_STUDIO_HOST = 'api.studio.thegraph.com/query/45376'
 export const ZETACHAIN_HOST =
   'api.goldsky.com/api/public/project_cls39ugcfyhbq01xl9tsf6g38/subgraphs'
 export const SUSHI_GOLDSKY_HOST =
@@ -245,7 +246,7 @@ export const BLOCKS_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.ETHEREUM]: `${GRAPH_HOST}/blocklytics/ethereum-blocks`,
   [ChainId.GNOSIS]: `${GRAPH_HOST}/matthewlilley/xdai-blocks`,
   [ChainId.POLYGON]: `${GRAPH_HOST}/matthewlilley/polygon-blocks`,
-  [ChainId.POLYGON_ZKEVM]: `${STUDIO_HOST}/blocks-polygon-zkevm/v0.0.2`,
+  [ChainId.POLYGON_ZKEVM]: `${PCS_STUDIO_HOST}/polygon-zkevm-block/version/latest`,
   [ChainId.FANTOM]: `${GRAPH_HOST}/matthewlilley/fantom-blocks`,
   [ChainId.BSC]: `${GRAPH_HOST}/matthewlilley/bsc-blocks`,
   [ChainId.HARMONY]: `${GRAPH_HOST}/sushiswap/harmony-blocks`,

--- a/config/graph/src/index.ts
+++ b/config/graph/src/index.ts
@@ -330,7 +330,7 @@ export const SUSHISWAP_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.BTTC]: `${SUSHI_GOLDSKY_HOST}/sushi-v2/sushiswap-bttc/gn`,
   [ChainId.FILECOIN]: `${FILECOIN_HOST}/sushiswap/sushiswap-filecoin`,
   [ChainId.ZETACHAIN]: `${ZETACHAIN_HOST}/sushiswap-zetachain/1.0.0/gn`,
-  [ChainId.THUNDERCORE]: `${GRAPH_HOST}/sushi-v2/sushiswap-thundercore`,
+  [ChainId.THUNDERCORE]: `${THUNDERCORE_HOST}/sushi-v2/sushiswap-thundercore`,
   [ChainId.CORE]: `${CORE_HOST}/sushi-v2/sushiswap-core`,
   [ChainId.HAQQ]: `${HAQQ_HOST}/sushi/sushiswap-haqq`,
   [ChainId.LINEA]: `${LINEA_HOST}/sushiswap/sushiswap-linea`,

--- a/config/graph/src/index.ts
+++ b/config/graph/src/index.ts
@@ -265,7 +265,7 @@ export const BLOCKS_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.BOBA]: `${GRAPH_HOST}/sushiswap/blocks-boba`,
   [ChainId.BOBA_BNB]: `${GOLDSKY_COMMUNITY_HOST}/blocks/boba-bnb/gn`,
   [ChainId.BTTC]: `${GOLDSKY_COMMUNITY_HOST}/blocks/bttc-mainnet/gn`,
-  [ChainId.THUNDERCORE]: `${THUNDERCORE_HOST}/sushiswap/blocks-thundercore/gn`,
+  [ChainId.THUNDERCORE]: `${THUNDERCORE_HOST}/sushiswap/blocks-thundercore`,
   [ChainId.CORE]: `${CORE_HOST}/sushiswap/blocks-core`,
   [ChainId.BASE]: `${STUDIO_HOST}/blocks-base/v0.0.1`,
   [ChainId.LINEA]: `${LINEA_HOST}/sushiswap/blocks-linea`,

--- a/config/graph/src/index.ts
+++ b/config/graph/src/index.ts
@@ -117,9 +117,9 @@ export const CORE_HOST = 'thegraph.coredao.org/subgraphs/name'
 export const LINEA_HOST = 'graph-query.linea.build/subgraphs/name'
 export const HAQQ_HOST = 'haqq.graph.p2p.org/subgraphs/name'
 export const PCS_STUDIO_HOST = 'api.studio.thegraph.com/query/45376'
-export const ZETACHAIN_HOST =
-  'api.goldsky.com/api/public/project_cls39ugcfyhbq01xl9tsf6g38/subgraphs'
 export const SUSHI_GOLDSKY_HOST =
+  'api.goldsky.com/api/public/project_cls39ugcfyhbq01xl9tsf6g38/subgraphs'
+export const SUSHI_DEDICATED_GOLDSKY_HOST =
   'api.goldsky.com/api/public/project_clslspm3c0knv01wvgfb2fqyq/subgraphs'
 export const GOLDSKY_COMMUNITY_HOST =
   'api.goldsky.com/api/public/project_cl8ylkiw00krx0hvza0qw17vn/subgraphs'
@@ -166,7 +166,7 @@ export const CHAIN_NAME: Record<number, string> = {
 
 export const SUBGRAPH_HOST: Record<number, string> = {
   [ChainId.ARBITRUM]: GRAPH_HOST,
-  [ChainId.ARBITRUM_NOVA]: SUSHI_GOLDSKY_HOST,
+  [ChainId.ARBITRUM_NOVA]: SUSHI_DEDICATED_GOLDSKY_HOST,
   [ChainId.AVALANCHE]: GRAPH_HOST,
   [ChainId.BSC]: GRAPH_HOST,
   [ChainId.CELO]: GRAPH_HOST,
@@ -185,8 +185,8 @@ export const SUBGRAPH_HOST: Record<number, string> = {
   [ChainId.POLYGON_ZKEVM]: STUDIO_HOST,
   [ChainId.BOBA]: GRAPH_HOST,
   // [ChainId.BOBA_AVAX]: SUSHI_HOST,
-  [ChainId.BOBA_BNB]: SUSHI_GOLDSKY_HOST,
-  [ChainId.BTTC]: SUSHI_GOLDSKY_HOST,
+  [ChainId.BOBA_BNB]: SUSHI_DEDICATED_GOLDSKY_HOST,
+  [ChainId.BTTC]: SUSHI_DEDICATED_GOLDSKY_HOST,
   [ChainId.OKEX]: '',
   [ChainId.HECO]: '',
   // [ChainId.KOVAN]: '',
@@ -197,8 +197,8 @@ export const SUBGRAPH_HOST: Record<number, string> = {
   [ChainId.SCROLL]: STUDIO_HOST,
   [ChainId.FILECOIN]: FILECOIN_HOST,
   [ChainId.HAQQ]: HAQQ_HOST,
-  [ChainId.ZETACHAIN]: ZETACHAIN_HOST,
-  [ChainId.BLAST]: SUSHI_GOLDSKY_HOST,
+  [ChainId.ZETACHAIN]: SUSHI_GOLDSKY_HOST,
+  [ChainId.BLAST]: SUSHI_DEDICATED_GOLDSKY_HOST,
 } as const
 
 export const BENTOBOX_ENABLED_NETWORKS = [
@@ -241,7 +241,7 @@ export const BENTOBOX_SUBGRAPH_URL: Record<BentoBoxChainId, string> = {
   [ChainId.OPTIMISM]: `${GRAPH_HOST}/sushiswap/bentobox-optimism`,
   [ChainId.HARMONY]: `${GRAPH_HOST}/sushiswap/bentobox-harmony`,
   [ChainId.KAVA]: `${KAVA_HOST}/sushiswap/bentobox-kava`,
-  [ChainId.BTTC]: `${SUSHI_GOLDSKY_HOST}/sushiswap/bentobox-bttc/gn`,
+  [ChainId.BTTC]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/bentobox-bttc/gn`,
 }
 
 export const BLOCKS_SUBGRAPH_URL: Record<number, string> = {
@@ -265,10 +265,10 @@ export const BLOCKS_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.KAVA]: `${KAVA_HOST}/sushiswap/blocks-kava`,
   // [ChainId.METIS]: `${METIS_HOST}/sushiswap/blocks-metis`,
   [ChainId.METIS]: `${WAGMI_METIS_HOST}/blocks`,
-  [ChainId.ARBITRUM_NOVA]: `${GOLDSKY_COMMUNITY_HOST}/blocks/arbitrum-nova/gn`,
+  [ChainId.ARBITRUM_NOVA]: `${SUSHI_GOLDSKY_HOST}/blocks/arbitrum-nova/gn`,
   [ChainId.BOBA]: `${GRAPH_HOST}/sushiswap/blocks-boba`,
-  [ChainId.BOBA_BNB]: `${GOLDSKY_COMMUNITY_HOST}/blocks/boba-bnb/gn`,
-  [ChainId.BTTC]: `${GOLDSKY_COMMUNITY_HOST}/blocks/bttc-mainnet/gn`,
+  [ChainId.BOBA_BNB]: `${SUSHI_GOLDSKY_HOST}/blocks/boba-bnb/gn`,
+  [ChainId.BTTC]: `${SUSHI_GOLDSKY_HOST}/blocks/bttc-mainnet/gn`,
   [ChainId.THUNDERCORE]: `${THUNDERCORE_HOST}/sushiswap/blocks-thundercore`,
   [ChainId.CORE]: `${CORE_HOST}/sushiswap/blocks-core`,
   [ChainId.BASE]: `${STUDIO_HOST}/blocks-base/v0.0.1`,
@@ -276,8 +276,8 @@ export const BLOCKS_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.SCROLL]: `${STUDIO_HOST}/blocks-scroll/v0.0.1`,
   [ChainId.FILECOIN]: `${FILECOIN_HOST}/sushiswap/blocks`,
   [ChainId.HAQQ]: `${HAQQ_HOST}/sushi/blocks-haqq`,
-  [ChainId.ZETACHAIN]: `${ZETACHAIN_HOST}/blocks-zetachain/1.0.0/gn`,
-  [ChainId.BLAST]: `${SUSHI_GOLDSKY_HOST}/sushiswap/blocks-blast/gn`,
+  [ChainId.ZETACHAIN]: `${SUSHI_GOLDSKY_HOST}/blocks-zetachain/1.0.0/gn`,
+  [ChainId.BLAST]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/blocks-blast/gn`,
 } as const
 
 export const SECONDS_BETWEEN_BLOCKS: Record<number, number> = {
@@ -321,28 +321,28 @@ export const SUSHISWAP_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.MOONBEAM]: `${GRAPH_HOST}/sushi-v2/sushiswap-moonbeam`,
   [ChainId.MOONRIVER]: `${GRAPH_HOST}/sushi-v2/sushiswap-moonriver`,
   [ChainId.HARMONY]: `${GRAPH_HOST}/olastenberg/sushiswap-harmony-fix`,
-  [ChainId.ARBITRUM_NOVA]: `${SUSHI_GOLDSKY_HOST}/sushi-0m/sushiswap-arbitrum-nova/gn`,
+  [ChainId.ARBITRUM_NOVA]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushi-0m/sushiswap-arbitrum-nova/gn`,
   [ChainId.OPTIMISM]: `${GRAPH_HOST}/sushi-subgraphs/sushiswap-optimism`,
   [ChainId.BOBA]: `${GRAPH_HOST}/sushi-v2/sushiswap-boba`,
   [ChainId.POLYGON]: `${GRAPH_HOST}/sushi-v2/sushiswap-polygon`,
-  [ChainId.BOBA_BNB]: `${SUSHI_GOLDSKY_HOST}/sushi-0m/sushiswap-boba-bnb/gn`,
+  [ChainId.BOBA_BNB]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushi-0m/sushiswap-boba-bnb/gn`,
   [ChainId.BASE]: `${STUDIO_HOST}/sushiswap-base/v0.0.1`,
   [ChainId.SCROLL]: `${STUDIO_HOST}/sushiswap-scroll/v0.0.1`,
   [ChainId.KAVA]: `${KAVA_HOST}/sushi-v2/sushiswap-kava`,
   [ChainId.METIS]: `${METIS_0XGRAPH_HOST}/sushiswap/sushiswap-metis`,
-  [ChainId.BTTC]: `${SUSHI_GOLDSKY_HOST}/sushi-v2/sushiswap-bttc/gn`,
+  [ChainId.BTTC]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushi-v2/sushiswap-bttc/gn`,
   [ChainId.FILECOIN]: `${FILECOIN_HOST}/sushiswap/sushiswap-filecoin`,
-  [ChainId.ZETACHAIN]: `${ZETACHAIN_HOST}/sushiswap-zetachain/1.0.0/gn`,
+  [ChainId.ZETACHAIN]: `${SUSHI_GOLDSKY_HOST}/sushiswap-zetachain/1.0.0/gn`,
   [ChainId.THUNDERCORE]: `${THUNDERCORE_HOST}/sushi-v2/sushiswap-thundercore`,
   [ChainId.CORE]: `${CORE_HOST}/sushi-v2/sushiswap-core`,
   [ChainId.HAQQ]: `${HAQQ_HOST}/sushi/sushiswap-haqq`,
   [ChainId.LINEA]: `${LINEA_HOST}/sushiswap/sushiswap-linea`,
   [ChainId.POLYGON_ZKEVM]: `${STUDIO_HOST}/v2-polygon-zkevm/v0.0.1`,
-  [ChainId.BLAST]: `${SUSHI_GOLDSKY_HOST}/sushiswap/sushiswap-blast/gn`,
+  [ChainId.BLAST]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/sushiswap-blast/gn`,
 } as const
 
 export const SUSHISWAP_V3_SUBGRAPH_URL: Record<number, string> = {
-  [ChainId.ARBITRUM_NOVA]: `${SUSHI_GOLDSKY_HOST}/sushi-v3/v3-arbitrum-nova/gn`,
+  [ChainId.ARBITRUM_NOVA]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushi-v3/v3-arbitrum-nova/gn`,
   [ChainId.ARBITRUM]: `${GRAPH_HOST}/sushi-v3/v3-arbitrum`,
   [ChainId.AVALANCHE]: `${GRAPH_HOST}/sushi-v3/v3-avalanche`,
   [ChainId.BSC]: `${GRAPH_HOST}/sushi-v3/v3-bsc`,
@@ -362,11 +362,11 @@ export const SUSHISWAP_V3_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.SCROLL]: `${STUDIO_HOST}/v3-scroll/v0.0.1`,
   [ChainId.KAVA]: `${KAVA_HOST}/sushi-v3/v3-kava`,
   [ChainId.METIS]: `${METIS_0XGRAPH_HOST}/sushiswap/v3-metis`,
-  [ChainId.BTTC]: `${SUSHI_GOLDSKY_HOST}/sushi-v3/v3-bttc/gn`,
+  [ChainId.BTTC]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushi-v3/v3-bttc/gn`,
   [ChainId.FILECOIN]: `${FILECOIN_HOST}/sushiswap/v3-filecoin`,
   [ChainId.HAQQ]: `${HAQQ_HOST}/sushi/v3-haqq`,
-  [ChainId.ZETACHAIN]: `${ZETACHAIN_HOST}/v3-zetachain/1.0.0/gn`,
-  [ChainId.BLAST]: `${SUSHI_GOLDSKY_HOST}/sushiswap/v3-blast/gn`,
+  [ChainId.ZETACHAIN]: `${SUSHI_GOLDSKY_HOST}/v3-zetachain/1.0.0/gn`,
+  [ChainId.BLAST]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/v3-blast/gn`,
 }
 
 export const TRIDENT_SUBGRAPH_URL: Record<number, string> = {
@@ -374,7 +374,7 @@ export const TRIDENT_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.OPTIMISM]: `${GRAPH_HOST}/sushi-v2/trident-optimism`,
   [ChainId.KAVA]: `${KAVA_HOST}/sushi-qa/trident-kava`,
   [ChainId.METIS]: `${METIS_HOST}/sushi-v2/trident-metis`,
-  [ChainId.BTTC]: `${SUSHI_GOLDSKY_HOST}/sushi-v2/trident-bttc/gn`,
+  [ChainId.BTTC]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushi-v2/trident-bttc/gn`,
   [ChainId.ARBITRUM]: `${GRAPH_HOST}/sushi-v2/trident-arbitrum`,
   [ChainId.BSC]: `${GRAPH_HOST}/sushi-v2/trident-bsc`,
   [ChainId.AVALANCHE]: `${GRAPH_HOST}/sushi-v2/trident-avalanche`,
@@ -393,8 +393,8 @@ export const MINICHEF_SUBGRAPH_URL = {
   [ChainId.KAVA]: `${KAVA_HOST}/sushiswap/kava-minichef`, //block subgraph not synced yet
   [ChainId.METIS]: `${METIS_0XGRAPH_HOST}/sushiswap/minichef-metis`,
   [ChainId.BOBA]: `${GRAPH_HOST}/sushiswap/minichef-boba`,
-  [ChainId.ARBITRUM_NOVA]: `${SUSHI_GOLDSKY_HOST}/sushiswap/minichef-arbitrum-nova/gn`,
-  [ChainId.BTTC]: `${SUSHI_GOLDSKY_HOST}/sushiswap/minichef-bttc/gn`,
+  [ChainId.ARBITRUM_NOVA]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/minichef-arbitrum-nova/gn`,
+  [ChainId.BTTC]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/minichef-bttc/gn`,
   [ChainId.OPTIMISM]: `${GRAPH_HOST}/sushiswap/minichef-optimism`,
   [ChainId.AVALANCHE]: `${GRAPH_HOST}/sushiswap/minichef-avalanche`,
   [ChainId.BSC]: `${GRAPH_HOST}/sushiswap/minichef-bsc`,

--- a/config/graph/src/index.ts
+++ b/config/graph/src/index.ts
@@ -123,6 +123,8 @@ export const SUSHI_GOLDSKY_HOST =
   'api.goldsky.com/api/public/project_clslspm3c0knv01wvgfb2fqyq/subgraphs'
 export const GOLDSKY_COMMUNITY_HOST =
   'api.goldsky.com/api/public/project_cl8ylkiw00krx0hvza0qw17vn/subgraphs'
+export const WAGMI_METIS_HOST = 'metis.graph.wagmi.com/subgraphs/name'
+export const METIS_0XGRAPH_HOST = 'metisapi.0xgraph.xyz/subgraphs/name'
 
 export const CHAIN_NAME: Record<number, string> = {
   [ChainId.ARBITRUM]: 'Arbitrum',
@@ -261,7 +263,8 @@ export const BLOCKS_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.MOONBEAM]: `${GRAPH_HOST}/sushiswap/moonbeam-blocks`,
   [ChainId.OPTIMISM]: `${GRAPH_HOST}/beethovenxfi/optimism-blocks`,
   [ChainId.KAVA]: `${KAVA_HOST}/sushiswap/blocks-kava`,
-  [ChainId.METIS]: `${METIS_HOST}/sushiswap/blocks-metis`,
+  // [ChainId.METIS]: `${METIS_HOST}/sushiswap/blocks-metis`,
+  [ChainId.METIS]: `${WAGMI_METIS_HOST}/blocks`,
   [ChainId.ARBITRUM_NOVA]: `${GOLDSKY_COMMUNITY_HOST}/blocks/arbitrum-nova/gn`,
   [ChainId.BOBA]: `${GRAPH_HOST}/sushiswap/blocks-boba`,
   [ChainId.BOBA_BNB]: `${GOLDSKY_COMMUNITY_HOST}/blocks/boba-bnb/gn`,
@@ -326,7 +329,7 @@ export const SUSHISWAP_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.BASE]: `${STUDIO_HOST}/sushiswap-base/v0.0.1`,
   [ChainId.SCROLL]: `${STUDIO_HOST}/sushiswap-scroll/v0.0.1`,
   [ChainId.KAVA]: `${KAVA_HOST}/sushi-v2/sushiswap-kava`,
-  [ChainId.METIS]: `${METIS_HOST}/sushi-v2/sushiswap-metis`,
+  [ChainId.METIS]: `${METIS_0XGRAPH_HOST}/sushiswap/sushiswap-metis`,
   [ChainId.BTTC]: `${SUSHI_GOLDSKY_HOST}/sushi-v2/sushiswap-bttc/gn`,
   [ChainId.FILECOIN]: `${FILECOIN_HOST}/sushiswap/sushiswap-filecoin`,
   [ChainId.ZETACHAIN]: `${ZETACHAIN_HOST}/sushiswap-zetachain/1.0.0/gn`,
@@ -358,7 +361,7 @@ export const SUSHISWAP_V3_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.LINEA]: `${LINEA_HOST}/sushi-v3/v3-linea`,
   [ChainId.SCROLL]: `${STUDIO_HOST}/v3-scroll/v0.0.1`,
   [ChainId.KAVA]: `${KAVA_HOST}/sushi-v3/v3-kava`,
-  [ChainId.METIS]: `${METIS_HOST}/sushi-v3/v3-metis`,
+  [ChainId.METIS]: `${METIS_0XGRAPH_HOST}/sushiswap/v3-metis`,
   [ChainId.BTTC]: `${SUSHI_GOLDSKY_HOST}/sushi-v3/v3-bttc/gn`,
   [ChainId.FILECOIN]: `${FILECOIN_HOST}/sushiswap/v3-filecoin`,
   [ChainId.HAQQ]: `${HAQQ_HOST}/sushi/v3-haqq`,
@@ -388,7 +391,7 @@ export const MINICHEF_SUBGRAPH_URL = {
   [ChainId.FANTOM]: `${GRAPH_HOST}/sushiswap/fantom-minichef`,
   [ChainId.MOONBEAM]: `${GRAPH_HOST}/sushiswap/moonbeam-minichef`,
   [ChainId.KAVA]: `${KAVA_HOST}/sushiswap/kava-minichef`, //block subgraph not synced yet
-  [ChainId.METIS]: `${METIS_HOST}/sushiswap/metis-minichef`,
+  [ChainId.METIS]: `${METIS_0XGRAPH_HOST}/sushiswap/minichef-metis`,
   [ChainId.BOBA]: `${GRAPH_HOST}/sushiswap/minichef-boba`,
   [ChainId.ARBITRUM_NOVA]: `${SUSHI_GOLDSKY_HOST}/sushiswap/minichef-arbitrum-nova/gn`,
   [ChainId.BTTC]: `${SUSHI_GOLDSKY_HOST}/sushiswap/minichef-bttc/gn`,

--- a/jobs/pool/resolvers/blocks/blocksByChainIds.ts
+++ b/jobs/pool/resolvers/blocks/blocksByChainIds.ts
@@ -31,7 +31,7 @@ export const _blocksByChainIds = async (
           context: {
             ...context,
             chainId,
-            url: BLOCKS_SUBGRAPH_URL[chainId],
+            api: BLOCKS_SUBGRAPH_URL[chainId],
           },
           info,
         }).then((blocks: BlocksTypes.Block[]) => {

--- a/jobs/pool/src/etl/incentive/load.ts
+++ b/jobs/pool/src/etl/incentive/load.ts
@@ -1,5 +1,6 @@
-import { Prisma, createDirectClient } from '@sushiswap/database'
+import { Prisma } from '@sushiswap/database'
 import { performance } from 'perf_hooks'
+import { client } from 'src/lib/prisma'
 
 /**
  * Merges(Create/Update) incentives.
@@ -26,7 +27,6 @@ async function updateIncentives(incentives: Prisma.IncentiveCreateManyInput[]) {
   }
   console.log(`LOAD - Preparing to update ${incentives.length} incentives`)
 
-  const client = await createDirectClient()
   const incentivesToUpdate = incentives.map((incentive) => {
     return client.incentive.update({
       select: {
@@ -46,8 +46,6 @@ async function updateIncentives(incentives: Prisma.IncentiveCreateManyInput[]) {
   const updatedIncentives = await Promise.all(incentivesToUpdate)
   const endTime = performance.now()
 
-  await client.$disconnect()
-
   console.log(
     `LOAD - Updated ${updatedIncentives.length} incentives. (${(
       (endTime - startTime) /
@@ -64,8 +62,6 @@ async function createIncentives(incentives: Prisma.IncentiveCreateManyInput[]) {
   let count = 0
   const batchSize = 500
   const startTime = performance.now()
-
-  const client = await createDirectClient()
 
   for (let i = 0; i < incentives.length; i += batchSize) {
     const created = await client.incentive.createMany({
@@ -85,8 +81,6 @@ async function createIncentives(incentives: Prisma.IncentiveCreateManyInput[]) {
 }
 
 async function hasIncentives() {
-  const client = await createDirectClient()
   const count = await client.incentive.count()
-  await client.$disconnect()
   return count > 0
 }

--- a/jobs/pool/src/etl/incentive/transform.ts
+++ b/jobs/pool/src/etl/incentive/transform.ts
@@ -1,4 +1,5 @@
-import { Prisma, createDirectClient } from '@sushiswap/database'
+import { Prisma } from '@sushiswap/database'
+import { client } from 'src/lib/prisma'
 
 /**
  * Filters token incentives to only include the ones that are new or have changed.
@@ -18,7 +19,6 @@ export async function filterIncentives(
     rewardPerDay: true,
   })
 
-  const client = await createDirectClient()
   const incentiveFound = await client.incentive.findMany({
     select: incentiveSelect,
   })
@@ -84,8 +84,6 @@ export async function filterIncentives(
     }
     return false
   })
-
-  await client.$disconnect()
 
   console.log(
     `TRANSFORM - Filtering incentives\n

--- a/jobs/pool/src/etl/pool/load.ts
+++ b/jobs/pool/src/etl/pool/load.ts
@@ -1,5 +1,6 @@
-import { Prisma, createDirectClient } from '@sushiswap/database'
+import { Prisma } from '@sushiswap/database'
 import { performance } from 'perf_hooks'
+import { client } from 'src/lib/prisma'
 
 function clipDecimal(value: any) {
   if (Number(value) >= 1e32) {
@@ -10,7 +11,6 @@ function clipDecimal(value: any) {
 
 export async function upsertPools(pools: Prisma.SushiPoolCreateManyInput[]) {
   if (pools.length === 0) return
-  const client = await createDirectClient()
   const poolsWithIncentives = await client.sushiPool.findMany({
     where: {
       id: {
@@ -529,7 +529,6 @@ export async function upsertPools(pools: Prisma.SushiPoolCreateManyInput[]) {
       }),
     ])
 
-    await client.$disconnect()
     console.error(
       `LOAD - Updated ${updated} and created ${created.count} pools. `,
     )
@@ -539,7 +538,6 @@ export async function upsertPools(pools: Prisma.SushiPoolCreateManyInput[]) {
 }
 
 export async function updatePoolsWithIncentivesTotalApr() {
-  const client = await createDirectClient()
   const startTime = performance.now()
 
   const updatedPoolsCount = await client.$executeRaw`
@@ -559,8 +557,6 @@ export async function updatePoolsWithIncentivesTotalApr() {
 
   const endTime = performance.now()
 
-  await client.$disconnect()
-
   console.log(
     `LOAD - Updated ${updatedPoolsCount} pools with total APR (${(
       (endTime - startTime) /
@@ -570,7 +566,6 @@ export async function updatePoolsWithIncentivesTotalApr() {
 }
 
 export async function updatePoolsWithSteerVaults() {
-  const client = await createDirectClient()
   const startTime = performance.now()
 
   const poolsUpdatedCount = await client.$executeRaw`
@@ -590,8 +585,6 @@ export async function updatePoolsWithSteerVaults() {
   `
 
   const endTime = performance.now()
-
-  await client.$disconnect()
 
   console.log(
     `LOAD - Updated ${poolsUpdatedCount} pools with steer vaults (${(

--- a/jobs/pool/src/etl/steer/load.ts
+++ b/jobs/pool/src/etl/steer/load.ts
@@ -1,8 +1,7 @@
-import { Prisma, createDirectClient } from '@sushiswap/database'
+import { Prisma } from '@sushiswap/database'
+import { client } from 'src/lib/prisma'
 
 export async function upsertVaults(vaults: Prisma.SteerVaultCreateManyInput[]) {
-  const client = await createDirectClient()
-
   const vaultTokens = vaults.flatMap((vault) => [
     vault.token0Id,
     vault.token1Id,
@@ -380,14 +379,10 @@ export async function upsertVaults(vaults: Prisma.SteerVaultCreateManyInput[]) {
     },
   })
 
-  await client.$disconnect()
-
   console.log(`LOAD - Updated ${updated} and created ${created.count} vaults. `)
 }
 
 export async function enableVaults(vaultIds: string[]) {
-  const client = await createDirectClient()
-
   const enabled = await client.steerVault.updateMany({
     data: {
       isEnabled: true,
@@ -396,14 +391,10 @@ export async function enableVaults(vaultIds: string[]) {
     where: { id: { in: vaultIds } },
   })
 
-  await client.$disconnect()
-
   console.log(`LOAD - Deprecated ${enabled.count} vaults.`)
 }
 
 export async function deprecateVaults(vaultIds: string[]) {
-  const client = await createDirectClient()
-
   const deprecated = await client.steerVault.updateMany({
     data: {
       apr: 0,
@@ -416,8 +407,6 @@ export async function deprecateVaults(vaultIds: string[]) {
     },
     where: { id: { in: vaultIds } },
   })
-
-  await client.$disconnect()
 
   console.log(`LOAD - Deprecated ${deprecated.count} vaults.`)
 }

--- a/jobs/pool/src/etl/token/load.ts
+++ b/jobs/pool/src/etl/token/load.ts
@@ -1,4 +1,5 @@
-import { Prisma, createDirectClient } from '@sushiswap/database'
+import { Prisma } from '@sushiswap/database'
+import { client } from 'src/lib/prisma'
 import { ChainId } from 'sushi'
 import { Address } from 'viem'
 
@@ -6,7 +7,6 @@ export async function createTokens(tokens: Prisma.TokenCreateManyInput[]) {
   if (tokens.length === 0) {
     return
   }
-  const client = await createDirectClient()
   const created = await client.token.createMany({
     data: tokens,
     skipDuplicates: true,
@@ -14,8 +14,6 @@ export async function createTokens(tokens: Prisma.TokenCreateManyInput[]) {
   if (created.count > 0) {
     console.log(`LOAD - Created ${created.count} tokens. `)
   }
-
-  await client.$disconnect()
 }
 
 export async function getMissingTokens(
@@ -24,7 +22,6 @@ export async function getMissingTokens(
   if (tokens.length === 0) {
     return []
   }
-  const client = await createDirectClient()
   const tokensFound = await client.token.findMany({
     select: {
       id: true,
@@ -39,8 +36,6 @@ export async function getMissingTokens(
       },
     },
   })
-
-  await client.$disconnect()
 
   return tokens
     .filter(

--- a/jobs/pool/src/incentives.ts
+++ b/jobs/pool/src/incentives.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config'
 import './lib/wagmi.js'
 
-import { Prisma, createDirectClient } from '@sushiswap/database'
+import { Prisma } from '@sushiswap/database'
 import { MINICHEF_SUBGRAPH_URL } from '@sushiswap/graph-config'
 import { performance } from 'perf_hooks'
 import { ChainId } from 'sushi/chain'
@@ -39,9 +39,6 @@ export async function execute() {
     )
   } catch (e) {
     console.error(e)
-    await (await createDirectClient()).$disconnect()
-  } finally {
-    await (await createDirectClient()).$disconnect()
   }
 }
 

--- a/jobs/pool/src/lib/prisma.ts
+++ b/jobs/pool/src/lib/prisma.ts
@@ -1,0 +1,3 @@
+import { createDirectClient } from '@sushiswap/database'
+
+export const client = await createDirectClient()

--- a/jobs/pool/src/merkl-incentives.ts
+++ b/jobs/pool/src/merkl-incentives.ts
@@ -1,12 +1,7 @@
 import 'dotenv/config'
 import './lib/wagmi.js'
 
-import {
-  ChefType,
-  Prisma,
-  RewarderType,
-  createDirectClient,
-} from '@sushiswap/database'
+import { ChefType, Prisma, RewarderType } from '@sushiswap/database'
 import { fetchToken } from '@wagmi/core'
 import { fetch } from '@whatwg-node/fetch'
 import { performance } from 'perf_hooks'
@@ -175,9 +170,6 @@ export async function execute() {
     )
   } catch (e) {
     console.error(e)
-    await (await createDirectClient()).$disconnect()
-  } finally {
-    await (await createDirectClient()).$disconnect()
   }
 }
 

--- a/jobs/pool/src/misc/manage-token.ts
+++ b/jobs/pool/src/misc/manage-token.ts
@@ -1,8 +1,8 @@
 import '../lib/wagmi.js'
 
 import { isAddress } from '@ethersproject/address'
-import { createDirectClient } from '@sushiswap/database'
 import { fetchToken } from '@wagmi/core'
+import { client } from 'src/lib/prisma.js'
 import { ChainId, chainIds, chains } from 'sushi/chain'
 import { Address } from 'viem'
 import { config } from '../lib/wagmi.js'
@@ -39,7 +39,6 @@ class Token {
 }
 
 export async function main() {
-  const client = await createDirectClient()
   // const token = new Token(56288, '0x4a2c2838c3907D024916c3f4Fe07832745Ae4bec', 'APPROVED')
   const token = new Token(1, '0x', 'DISAPPROVED')
   try {
@@ -107,9 +106,6 @@ export async function main() {
     }
   } catch (e) {
     console.error(e)
-    await client.$disconnect()
-  } finally {
-    await client.$disconnect()
   }
 }
 

--- a/jobs/pool/src/pools.ts
+++ b/jobs/pool/src/pools.ts
@@ -1,4 +1,4 @@
-import { Prisma, Protocol, createDirectClient } from '@sushiswap/database'
+import { Prisma, Protocol } from '@sushiswap/database'
 import {
   MAX_FIRST,
   SUSHISWAP_ENABLED_NETWORKS,
@@ -114,9 +114,6 @@ export async function execute(protocol: Protocol) {
     )
   } catch (e) {
     console.error(e)
-    await (await createDirectClient()).$disconnect()
-  } finally {
-    await (await createDirectClient()).$disconnect()
   }
 }
 

--- a/jobs/pool/src/pools.ts
+++ b/jobs/pool/src/pools.ts
@@ -169,70 +169,72 @@ async function extract(protocol: Protocol) {
     sdk.TwoMonthBlocks({ chainIds: SWAP_ENABLED_NETWORKS }),
   ])
 
-  for (const subgraph of subgraphs) {
-    const sdk = getBuiltGraphSDK({
-      chainId: subgraph.chainId,
-      api: subgraph.url,
-    })
-    const blocks: Blocks = {
-      oneHour:
-        Number(
-          oneHourBlocks.oneHourBlocks.find(
-            (block) => block.chainId === subgraph.chainId,
-          )?.number,
-        ) ?? undefined,
-      twoHour:
-        Number(
-          twoHourBlocks.twoHourBlocks.find(
-            (block) => block.chainId === subgraph.chainId,
-          )?.number,
-        ) ?? undefined,
-      oneDay:
-        Number(
-          oneDayBlocks.oneDayBlocks.find(
-            (block) => block.chainId === subgraph.chainId,
-          )?.number,
-        ) ?? undefined,
-      twoDay:
-        Number(
-          twoDayBlocks.twoDayBlocks.find(
-            (block) => block.chainId === subgraph.chainId,
-          )?.number,
-        ) ?? undefined,
-      oneWeek:
-        Number(
-          oneWeekBlocks.oneWeekBlocks.find(
-            (block) => block.chainId === subgraph.chainId,
-          )?.number,
-        ) ?? undefined,
-      twoWeek:
-        Number(
-          twoWeekBlocks.twoWeekBlocks.find(
-            (block) => block.chainId === subgraph.chainId,
-          )?.number,
-        ) ?? undefined,
-      oneMonth:
-        Number(
-          oneMonthBlocks.oneMonthBlocks.find(
-            (block) => block.chainId === subgraph.chainId,
-          )?.number,
-        ) ?? undefined,
-      twoMonth:
-        Number(
-          twoMonthBlocks.twoMonthBlocks.find(
-            (block) => block.chainId === subgraph.chainId,
-          )?.number,
-        ) ?? undefined,
-    }
+  await Promise.allSettled(
+    subgraphs.map(async (subgraph) => {
+      const sdk = getBuiltGraphSDK({
+        chainId: subgraph.chainId,
+        api: subgraph.url,
+      })
+      const blocks: Blocks = {
+        oneHour:
+          Number(
+            oneHourBlocks.oneHourBlocks.find(
+              (block) => block.chainId === subgraph.chainId,
+            )?.number,
+          ) ?? undefined,
+        twoHour:
+          Number(
+            twoHourBlocks.twoHourBlocks.find(
+              (block) => block.chainId === subgraph.chainId,
+            )?.number,
+          ) ?? undefined,
+        oneDay:
+          Number(
+            oneDayBlocks.oneDayBlocks.find(
+              (block) => block.chainId === subgraph.chainId,
+            )?.number,
+          ) ?? undefined,
+        twoDay:
+          Number(
+            twoDayBlocks.twoDayBlocks.find(
+              (block) => block.chainId === subgraph.chainId,
+            )?.number,
+          ) ?? undefined,
+        oneWeek:
+          Number(
+            oneWeekBlocks.oneWeekBlocks.find(
+              (block) => block.chainId === subgraph.chainId,
+            )?.number,
+          ) ?? undefined,
+        twoWeek:
+          Number(
+            twoWeekBlocks.twoWeekBlocks.find(
+              (block) => block.chainId === subgraph.chainId,
+            )?.number,
+          ) ?? undefined,
+        oneMonth:
+          Number(
+            oneMonthBlocks.oneMonthBlocks.find(
+              (block) => block.chainId === subgraph.chainId,
+            )?.number,
+          ) ?? undefined,
+        twoMonth:
+          Number(
+            twoMonthBlocks.twoMonthBlocks.find(
+              (block) => block.chainId === subgraph.chainId,
+            )?.number,
+          ) ?? undefined,
+      }
 
-    const pairs = await fetchPairs(sdk, subgraph, blocks)
-    if (pairs === undefined) {
-      console.warn('No pairs found, skipping')
-      continue
-    }
-    console.log(`${subgraph.url}, batches: ${pairs.currentPools.length}`)
-    result.push({ chainId: subgraph.chainId, data: pairs })
-  }
+      const pairs = await fetchPairs(sdk, subgraph, blocks)
+      if (pairs === undefined) {
+        console.warn('No pairs found, skipping')
+        return
+      }
+      console.log(`${subgraph.url}, batches: ${pairs.currentPools.length}`)
+      result.push({ chainId: subgraph.chainId, data: pairs })
+    }),
+  )
   return result
 }
 

--- a/jobs/pool/src/pools.ts
+++ b/jobs/pool/src/pools.ts
@@ -172,7 +172,7 @@ async function extract(protocol: Protocol) {
   for (const subgraph of subgraphs) {
     const sdk = getBuiltGraphSDK({
       chainId: subgraph.chainId,
-      url: subgraph.url,
+      api: subgraph.url,
     })
     const blocks: Blocks = {
       oneHour:

--- a/jobs/pool/tsconfig.json
+++ b/jobs/pool/tsconfig.json
@@ -5,9 +5,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": ".",
-    "target": "ES2020",
+    "target": "ES2022",
     "lib": ["ESNext"],
-    "module": "ES2020",
+    "module": "ES2022",
     "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "resolveJsonModule": true,

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -42,7 +42,7 @@
     "check": "tsc --pretty --noEmit",
     "clean": "rm -rf .turbo node_modules dist",
     "dev": "tsc -w",
-    "generate": "prisma generate --data-proxy",
+    "generate": "prisma generate",
     "prepublishOnly": "pnpm build",
     "pull": "prisma db pull",
     "push": "prisma db push --skip-generate",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates target and module settings to ES2022, removes unnecessary `createDirectClient` calls, and refactors imports to use `client` from `prisma.ts`.

### Detailed summary
- Updated `tsconfig.json` to target ES2022 and module ES2022
- Removed redundant `createDirectClient` calls in multiple files
- Refactored imports to use `client` from `prisma.ts`

> The following files were skipped due to too many changes: `jobs/pool/src/pools.ts`, `config/graph/src/index.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->