### PR TITLE
fix: allow popups in onramper widget

### DIFF
--- a/packages/ui/src/components/onramper.tsx
+++ b/packages/ui/src/components/onramper.tsx
@@ -67,7 +67,7 @@ export const OnramperPanel: FC<OnramperPanelProps> = ({ address }) => {
               width="100%"
               title="Onramper widget"
               allow="accelerometer; autoplay; camera; gyroscope; payment"
-              sandbox="allow-scripts allow-same-origin"
+              sandbox="allow-scripts allow-popups allow-same-origin"
             />
           </div>
         </DialogPrimitive.Content>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the sandbox attribute in the `Onramper` component in `onramper.tsx`.

### Detailed summary
- Updated sandbox attribute in `Onramper` component from "allow-scripts allow-same-origin" to "allow-scripts allow-popups allow-same-origin"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->