### PR TITLE
chore: add OX to token selector

### DIFF
--- a/packages/hooks/src/usePinnedTokens.ts
+++ b/packages/hooks/src/usePinnedTokens.ts
@@ -324,6 +324,13 @@ export const DEFAULT_BASES = {
       address: '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA',
     }),
     USDC[ChainId.BASE],
+    new Token({
+      chainId: ChainId.BASE,
+      symbol: 'OX',
+      name: 'OX Coin',
+      decimals: 18,
+      address: '0xba0Dda8762C24dA9487f5FA026a9B64b695A07Ea',
+    }),
   ],
   [ChainId.SCROLL]: [
     Native.onChain(ChainId.SCROLL),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a new token, 'OX Coin', with symbol 'OX' on ChainId.BASE.

### Detailed summary
- Added a new token 'OX Coin' with symbol 'OX' on ChainId.BASE
- Token has 18 decimals and address '0xba0Dda8762C24dA9487f5FA026a9B64b695A07Ea'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->