### PR TITLE
fix: incorrect token in useRewarder

### DIFF
--- a/packages/wagmi/src/hooks/master-chef/use-rewarder.ts
+++ b/packages/wagmi/src/hooks/master-chef/use-rewarder.ts
@@ -171,28 +171,26 @@ export const useRewarder: UseRewarder = ({
 
     // ! POSSIBLY BROKE IT, TEST
     return {
-      data: data
-        .filter((el): el is NonNullable<(typeof data)[0]> => !!el)
-        .reduce<(Amount<Token> | undefined)[]>((acc, result, index) => {
-          if (typeof result === 'bigint') {
-            acc.push(
-              result
-                ? Amount.fromRawAmount(rewardTokens[index], result)
-                : undefined,
-            )
-          } else {
-            acc.push(
-              ...result[1].map((rewardAmount, index2: number) => {
-                return Amount.fromRawAmount(
-                  rewardTokens[index + index2],
-                  rewardAmount,
-                )
-              }),
-            )
-          }
+      data: data.reduce<(Amount<Token> | undefined)[]>((acc, result, index) => {
+        if (typeof result === 'bigint') {
+          acc.push(
+            result
+              ? Amount.fromRawAmount(rewardTokens[index], result)
+              : undefined,
+          )
+        } else if (typeof result !== 'undefined') {
+          acc.push(
+            ...result[1].map((rewardAmount, index2: number) => {
+              return Amount.fromRawAmount(
+                rewardTokens[index + index2],
+                rewardAmount,
+              )
+            }),
+          )
+        }
 
-          return acc
-        }, []),
+        return acc
+      }, []),
       isLoading,
       isError,
     }


### PR DESCRIPTION
Resolves an issue where the wrong reward token is displayed for V2 pairs.

Example of SUSHI being displayed instead of MARS4: https://www.sushi.com/pool/1:0xb50580b0d81d9fe860746387cef9a8fc36d48d49

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `use-rewarder.ts` file in `master-chef` hook by optimizing the reward calculation logic.

### Detailed summary
- Refactored reward calculation logic to handle `undefined` values more efficiently
- Improved code readability and maintainability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->