### PR TITLE
fix: unclaimed fees column in v3 positions table

### DIFF
--- a/packages/wagmi/src/hooks/positions/actions/getConcentratedLiquidityPositionFees.ts
+++ b/packages/wagmi/src/hooks/positions/actions/getConcentratedLiquidityPositionFees.ts
@@ -71,6 +71,7 @@ export const getConcentratedLiquidityPositionFees = async ({
 
     try {
       result = await simulateContract(config, {
+        chainId: el.chainId,
         abi: abiShard,
         address: getV3NonFungiblePositionManagerContractConfig(el.chainId)
           .address,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding the `chainId` parameter to the `simulateContract` function call in `getConcentratedLiquidityPositionFees.ts`.

### Detailed summary
- Added `chainId` parameter to `simulateContract` function call.
- Passes `chainId` from `el` object to `simulateContract` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->