### PR TITLE
chore: update xswap copy

### DIFF
--- a/apps/evm/src/ui/swap/cross-chain-banner.tsx
+++ b/apps/evm/src/ui/swap/cross-chain-banner.tsx
@@ -54,7 +54,7 @@ export const CrossChainBanner: FC = () => {
                 </motion.div>
               </CardTitle>
               <CardDescription>
-                Swap tokens natively across 12 chains including Ethereum,
+                Swap tokens natively across 14 chains including Ethereum,
                 Arbitrum, Optimism, Polygon, Base and more!{' '}
                 <a
                   target="_blank"

--- a/apps/evm/src/ui/swap/swap-mode-buttons.tsx
+++ b/apps/evm/src/ui/swap/swap-mode-buttons.tsx
@@ -50,7 +50,7 @@ export const SwapModeButtons = () => {
             <CardHeader>
               <CardTitle>Cross-chain Swap</CardTitle>
               <CardDescription>
-                Swap tokens natively across 12 chains including Ethereum,
+                Swap tokens natively across 14 chains including Ethereum,
                 Arbitrum, Optimism, Polygon, Base and more!
               </CardDescription>
             </CardHeader>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the cross-chain swap banners to reflect support for 14 chains instead of 12.

### Detailed summary
- Updated cross-chain banners to mention support for 14 chains instead of 12.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->