### PR TITLE
chore: include gasPrice in useSimulateTrade

### DIFF
--- a/apps/evm/src/lib/hooks/useSimulateTrade.ts
+++ b/apps/evm/src/lib/hooks/useSimulateTrade.ts
@@ -39,6 +39,7 @@ export function useSimulateTrade({
     functionName: trade?.functionName,
     args: trade?.writeArgs as any,
     value: trade?.value || 0n,
+    gasPrice: trade?.gasPrice,
     query: {
       retry: (i, error) => {
         if (

--- a/packages/react-query/src/hooks/trade/types.ts
+++ b/packages/react-query/src/hooks/trade/types.ts
@@ -44,6 +44,7 @@ export interface UseTradeReturn {
   route: TradeType['route']
   value?: bigint | undefined
   tokenTax: Percent | false | undefined
+  gasPrice: bigint | null | undefined
 }
 
 export type UseTradeQuerySelect = (data: TradeType) => UseTradeReturn

--- a/packages/react-query/src/hooks/trade/useTrade.ts
+++ b/packages/react-query/src/hooks/trade/useTrade.ts
@@ -206,6 +206,7 @@ export const useTrade = (variables: UseTradeParams) => {
           writeArgs,
           value,
           tokenTax,
+          gasPrice,
         }
       }
 
@@ -222,6 +223,7 @@ export const useTrade = (variables: UseTradeParams) => {
         functionName: 'processRoute',
         value: undefined,
         tokenTax: undefined,
+        gasPrice: undefined,
       }
     },
     [

--- a/packages/wagmi/src/hooks/trade/use-client-trade.ts
+++ b/packages/wagmi/src/hooks/trade/use-client-trade.ts
@@ -85,6 +85,7 @@ export const useClientTrade = (variables: UseTradeParams) => {
           functionName: 'processRoute',
           value: undefined,
           tokenTax: undefined,
+          gasPrice: undefined,
         }
 
       const route = Router.findSpecialRoute(
@@ -224,6 +225,7 @@ export const useClientTrade = (variables: UseTradeParams) => {
                 writeArgs,
                 value,
                 tokenTax,
+                gasPrice,
               }),
             250,
           ),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add the `gasPrice` property to the trade-related hooks and types.

### Detailed summary
- Added `gasPrice` property to trade-related hooks and types in multiple files.
- Updated `useTradeQuerySelect` type in `types.ts`.
- Initialized `gasPrice` as `undefined` in `useTrade` and `useClientTrade` hooks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->