### PR TITLE
feat(pkgs/bonds-sdk): add bsc

### DIFF
--- a/packages/bonds-sdk/src/constants.ts
+++ b/packages/bonds-sdk/src/constants.ts
@@ -22,6 +22,7 @@ export type VestingType = (typeof VestingType)[keyof typeof VestingType]
 
 export const BONDS_ENABLED_CHAIN_IDS = [
   ChainId.ETHEREUM,
+  ChainId.BSC,
   ChainId.ARBITRUM,
   ChainId.OPTIMISM,
   ChainId.POLYGON,
@@ -32,6 +33,8 @@ export type BondChainId = (typeof BONDS_ENABLED_CHAIN_IDS)[number]
 export const BONDS_SUBGRAPH_URL: Record<BondChainId, string> = {
   [ChainId.ETHEREUM]:
     'api.thegraph.com/subgraphs/name/bond-protocol/bond-protocol-mainnet',
+  [ChainId.BSC]:
+    'subgraph.satsuma-prod.com/beb9c043f4ac/spaces-team/bond-protocol-bsc/api',
   [ChainId.ARBITRUM]:
     'api.thegraph.com/subgraphs/name/bond-protocol/bond-protocol-arbitrum-mainnet',
   [ChainId.OPTIMISM]:
@@ -45,6 +48,7 @@ export const isBondChainId = (chainId: ChainId): chainId is BondChainId =>
 
 export const REFERRER_ADDRESS: Record<BondChainId, Address> = {
   [ChainId.ETHEREUM]: '0x19B3Eb3Af5D93b77a5619b047De0EED7115A19e7',
+  [ChainId.BSC]: '0xc6fD91aD4919Fd91e2c84077ba648092cB499638',
   [ChainId.ARBITRUM]: '0x978982772b8e4055B921bf9295c0d74eB36Bc54e',
   [ChainId.OPTIMISM]: '0x1219Bfa3A499548507b4917E33F17439b67A2177',
   [ChainId.POLYGON]: '0x850a57630A2012B2494779fBc86bBc24F2a7baeF',


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for BSC chain in the bonds SDK constants.

### Detailed summary
- Added `ChainId.BSC` to `BONDS_ENABLED_CHAIN_IDS`
- Included BSC subgraph URL in `BONDS_SUBGRAPH_URL`
- Added BSC referrer address to `REFERRER_ADDRESS`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->