### PR TITLE
chore(jobs/pool): Dockerfile, bump node to 20

### DIFF
--- a/jobs/pool/Dockerfile
+++ b/jobs/pool/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 # Install git and pnpm
 RUN apk add --no-cache git libc6-compat grep


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the base image in the `Dockerfile` to `node:20-alpine`.

### Detailed summary
- Changed base image to `node:20-alpine` in `jobs/pool/Dockerfile`
- Installed `git`, `pnpm`, `libc6-compat`, and `grep` in the Docker image

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->