### PR TITLE
chore: bump pnpm version

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Set up pnpm
       uses: pnpm/action-setup@v2
       with:
-        version: 8.15.3
+        version: 8.15.8
 
     - name: Set up node
       uses: actions/setup-node@v3

--- a/.github/workflows/apps-evm-e2e.yml
+++ b/.github/workflows/apps-evm-e2e.yml
@@ -33,7 +33,7 @@ jobs:
         block-number: [55359656]
         chain-id: [137]
         node-version: [20]
-        pnpm-version: [8.15.3]
+        pnpm-version: [8.15.8]
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 8.15.3
+          version: 8.15.8
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/jobs/pool/Dockerfile
+++ b/jobs/pool/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine
 
 # Install git and pnpm
 RUN apk add --no-cache git libc6-compat grep python3 make g++
-RUN npm install -g pnpm@8.15.8 turbo@1.10.15
+RUN npm install -g pnpm@8.15.8 turbo@1.12.4
 
 # Do ARG stuff
 ARG SCRIPT_PATH="./"

--- a/jobs/pool/Dockerfile
+++ b/jobs/pool/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine
 
 # Install git and pnpm
 RUN apk add --no-cache git libc6-compat grep python3 make g++
-RUN npm install -g pnpm@8.15.3 turbo@1.10.15
+RUN npm install -g pnpm@8.15.8 turbo@1.10.15
 
 # Do ARG stuff
 ARG SCRIPT_PATH="./"

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "ts-jest": "29.1.1",
     "turbo": "1.12.4"
   },
-  "packageManager": "pnpm@8.15.3",
+  "packageManager": "pnpm@8.15.8",
   "engines": {
     "node": ">=20.x",
-    "pnpm": "8.15.3"
+    "pnpm": "8.15.8"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the versions of `pnpm` and `turbo` dependencies across multiple files and workflows to `8.15.8` and `1.12.4` respectively.

### Detailed summary
- Updated `pnpm` version from `8.15.3` to `8.15.8` in workflows and package.json
- Updated `turbo` version from `1.10.15` to `1.12.4` in Dockerfile

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->