### PR TITLE
chore: remove DeferUntilWalletReady from stake providers

### DIFF
--- a/apps/evm/src/app/stake/providers.tsx
+++ b/apps/evm/src/app/stake/providers.tsx
@@ -2,16 +2,13 @@
 
 import { SplashController, ThemeProvider } from '@sushiswap/ui'
 import { SushiBarProvider } from 'src/ui/stake'
-import { DeferUntilWalletReady } from 'src/ui/swap/defer-until-wallet-ready'
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider>
-      <DeferUntilWalletReady>
-        <SplashController>
-          <SushiBarProvider>{children}</SushiBarProvider>
-        </SplashController>
-      </DeferUntilWalletReady>
+      <SplashController>
+        <SushiBarProvider>{children}</SushiBarProvider>
+      </SplashController>
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes `DeferUntilWalletReady` component from the `Providers` function in `apps/evm/src/app/stake/providers.tsx`.

### Detailed summary
- Removed `DeferUntilWalletReady` component
- Updated the structure of the `Providers` function to only include `SplashController` and `SushiBarProvider` components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->