### PR TITLE
chore: move mainnet to start of publicChains

### DIFF
--- a/packages/sushi/src/config/viem.ts
+++ b/packages/sushi/src/config/viem.ts
@@ -616,6 +616,7 @@ export const publicTransports = {
 } as const satisfies Record<ChainId, Transport>
 
 export const publicChains = [
+  mainnet,
   arbitrumNova,
   arbitrum,
   avalanche,
@@ -627,7 +628,6 @@ export const publicChains = [
   blast,
   celo as unknown as Omit<typeof mainnet, 'id'> & { id: 42220 },
   cronos,
-  mainnet,
   fantom,
   fuse,
   gnosis,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the `mainnet` chain to the `publicChains` array in `viem.ts`.

### Detailed summary
- Added `mainnet` to the `publicChains` array in `viem.ts`.
- Reordered the chain entries in the `publicChains` array.
- Modified the `celo` entry to include specific properties.
- Removed duplicate `mainnet` entry.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->