### PR TITLE
fix(apps/xswap): sodium dep

### DIFF
--- a/apps/evm/src/lib/swap/useCrossChainTrade/useSquid.ts
+++ b/apps/evm/src/lib/swap/useCrossChainTrade/useSquid.ts
@@ -1,4 +1,5 @@
-import { Squid } from '@0xsquid/sdk'
+'use client'
+
 import { useQuery } from '@tanstack/react-query'
 import { SquidIntegratorId } from 'sushi/config'
 
@@ -6,6 +7,8 @@ export const useSquid = () => {
   return useQuery({
     queryKey: ['squid'],
     queryFn: async () => {
+      const Squid = await import('@0xsquid/sdk').then((m) => m.Squid)
+
       const squid = new Squid({
         baseUrl: 'https://apiplus.squidrouter.com/',
         integratorId: SquidIntegratorId,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a new feature to use the `@0xsquid/sdk` client in the `useSquid` hook for cross-chain trades.

### Detailed summary
- Added `use client` import statement
- Imported `Squid` from `@0xsquid/sdk`
- Initialized `squid` with base URL and integrator ID

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->