### PR TITLE
feat(pkgs/bonds-sdk): replace bsc subgraph

### DIFF
--- a/packages/bonds-sdk/src/constants.ts
+++ b/packages/bonds-sdk/src/constants.ts
@@ -34,7 +34,7 @@ export const BONDS_SUBGRAPH_URL: Record<BondChainId, string> = {
   [ChainId.ETHEREUM]:
     'api.thegraph.com/subgraphs/name/bond-protocol/bond-protocol-mainnet',
   [ChainId.BSC]:
-    'subgraph.satsuma-prod.com/beb9c043f4ac/spaces-team/bond-protocol-bsc/api',
+    'api.goldsky.com/api/public/project_clu16lu24lqh201x9f0qh135t/subgraphs/bond-protocol-bsc/0.0.1/gn',
   [ChainId.ARBITRUM]:
     'api.thegraph.com/subgraphs/name/bond-protocol/bond-protocol-arbitrum-mainnet',
   [ChainId.OPTIMISM]:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the subgraph URLs for BSC chain in the `constants.ts` file.

### Detailed summary
- Updated BSC subgraph URL to `api.goldsky.com/api/public/project_clu16lu24lqh201x9f0qh135t/subgraphs/bond-protocol-bsc/0.0.1/gn`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->