### PR TITLE
feat(apps/bonds): add extra decimal place

### DIFF
--- a/apps/evm/src/ui/bonds/bonds-market-details.tsx
+++ b/apps/evm/src/ui/bonds/bonds-market-details.tsx
@@ -83,7 +83,7 @@ export const BondsMarketDetails: FC<BondsMarketDetails> = ({
             }
           >
             {typeof payoutTokenPriceUSD === 'number' ? (
-              formatUSD(payoutTokenPriceUSD)
+              formatUSD(payoutTokenPriceUSD, '$0.000a')
             ) : (
               <SkeletonText fontSize="sm" />
             )}
@@ -97,7 +97,7 @@ export const BondsMarketDetails: FC<BondsMarketDetails> = ({
             }
           >
             {typeof discountedPrice === 'number' ? (
-              formatUSD(discountedPrice)
+              formatUSD(discountedPrice, '$0.000a')
             ) : (
               <SkeletonText fontSize="sm" />
             )}

--- a/apps/evm/src/ui/bonds/bonds-table/bonds-table-columns.tsx
+++ b/apps/evm/src/ui/bonds/bonds-table/bonds-table-columns.tsx
@@ -95,10 +95,10 @@ export const PRICE_COLUMN: ColumnDef<Bond, unknown> = {
   cell: ({ row: { original } }) => (
     <div className="flex flex-col space-y-1">
       <div className="text-sm font-medium">
-        {formatUSD(original.payoutToken.discountedPriceUSD)}
+        {formatUSD(original.payoutToken.discountedPriceUSD, '$0.000a')}
       </div>
       <div className="text-xs text-gray-500">
-        {formatUSD(original.payoutToken.priceUSD)} Market
+        {formatUSD(original.payoutToken.priceUSD, '$0.000a')} Market
       </div>
     </div>
   ),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the formatting of USD prices in the bonds table and market details components to include the currency symbol and a specific decimal format.

### Detailed summary
- Updated USD price formatting in `bonds-table-columns.tsx` for `payoutToken.discountedPriceUSD` and `payoutToken.priceUSD`.
- Updated USD price formatting in `bonds-market-details.tsx` for `payoutTokenPriceUSD`, `discountedPrice`, and `discountedPrice`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->