### PR TITLE
feat: enable rootstock

### DIFF
--- a/apps/evm/src/config.ts
+++ b/apps/evm/src/config.ts
@@ -20,7 +20,7 @@ export const DISABLED_CHAIN_IDS = [
   ChainId.PALM,
   ChainId.HECO,
   ChainId.OKEX,
-  ChainId.ROOTSTOCK,
+  ChainId.SKALE_EUROPA,
 ] as const
 
 const PREFERRED_CHAINID_ORDER = [
@@ -65,8 +65,7 @@ export const SUPPORTED_CHAIN_IDS = Array.from(
     (typeof TESTNET_CHAIN_IDS)[number] | (typeof DISABLED_CHAIN_IDS)[number]
   > =>
     !TESTNET_CHAIN_IDS.includes(c as (typeof TESTNET_CHAIN_IDS)[number]) &&
-    !DISABLED_CHAIN_IDS.includes(c as (typeof DISABLED_CHAIN_IDS)[number]) &&
-    c !== ChainId.SKALE_EUROPA,
+    !DISABLED_CHAIN_IDS.includes(c as (typeof DISABLED_CHAIN_IDS)[number]),
 )
 
 export const DISABLED_ANALYTICS_CHAIN_IDS = [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to remove `ChainId.SKALE_EUROPA` from `SUPPORTED_CHAIN_IDS` and `DISABLED_ANALYTICS_CHAIN_IDS`.

### Detailed summary
- Removed `ChainId.SKALE_EUROPA` from `SUPPORTED_CHAIN_IDS`
- Updated the condition in the filter function to exclude `ChainId.SKALE_EUROPA`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->