### PR TITLE
chore: remove Ruby from SKALE config

### DIFF
--- a/apis/extractor/src/config.ts
+++ b/apis/extractor/src/config.ts
@@ -785,16 +785,7 @@ export const EXTRACTOR_CONFIG: Record<
   },
   [ChainId.SKALE_EUROPA]: {
     client: createPublicClient(extractorClientConfig(ChainId.SKALE_EUROPA)),
-    factoriesV2: [
-      sushiswapV2Factory(ChainId.SKALE_EUROPA),
-      {
-        address: '0x71f7BbbB33550fa5d70CA3F7eeAD87529f2DC3C8' as Address,
-        provider: LiquidityProviders.Ruby,
-        fee: 0.003,
-        initCodeHash:
-          '0xba9f7d123cf1f1b0f57891be300d90939d1a591af80a90cfb7e904a821927963',
-      },
-    ],
+    factoriesV2: [sushiswapV2Factory(ChainId.SKALE_EUROPA)],
     factoriesV3: [sushiswapV3Factory(ChainId.SKALE_EUROPA)],
     tickHelperContractV3: SUSHISWAP_V3_TICK_LENS[
       ChainId.SKALE_EUROPA

--- a/packages/extractor/src/TokenManager.ts
+++ b/packages/extractor/src/TokenManager.ts
@@ -14,15 +14,21 @@ interface TokenCacheRecord {
 }
 
 // For some tokens that are not 100% ERC-20:
-const SpecialTokens: Record<
-  typeof ChainId.ETHEREUM,
-  Record<string, Omit<TokenCacheRecord, 'address'>>
+const SpecialTokens: Partial<
+  Record<ChainId, Record<string, Omit<TokenCacheRecord, 'address'>>>
 > = {
   [ChainId.ETHEREUM]: {
     '0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A': {
       name: 'DGD',
       symbol: 'DGD',
       decimals: 9,
+    },
+  },
+  [ChainId.SKALE_EUROPA]: {
+    '0xD2Aaa00700000000000000000000000000000000': {
+      name: 'Ether',
+      symbol: 'ETH',
+      decimals: 18,
     },
   },
 }

--- a/packages/sushi/src/router/liquidity-providers/LiquidityProvider.ts
+++ b/packages/sushi/src/router/liquidity-providers/LiquidityProvider.ts
@@ -42,7 +42,6 @@ export enum LiquidityProviders {
   DyorV2 = 'DyorV2',
   HyperBlast = 'HyperBlast',
   KinetixV3 = 'KinetixV3',
-  Ruby = 'Ruby',
 }
 
 export abstract class LiquidityProvider {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on removing the `Ruby` liquidity provider, updating factory configurations, and adding a special token for `SKALE_EUROPA`.

### Detailed summary
- Removed `Ruby` liquidity provider
- Updated factory configurations
- Added special token for `SKALE_EUROPA`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->