### PR TITLE
fix: base maxBatchesSimultaniously=5

### DIFF
--- a/apis/extractor/src/config.ts
+++ b/apis/extractor/src/config.ts
@@ -192,6 +192,7 @@ export const EXTRACTOR_CONFIG: Record<
     logDepth: 50,
     logging: true,
     maxCallsInOneBatch: 200,
+    maxBatchesSimultaniously: 5,
   },
   [ChainId.BOBA]: {
     client: createPublicClient(extractorClientConfig(ChainId.BOBA)),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR increases the maximum number of batches that can be processed simultaneously in the `config.ts` file for the `BOBA` chain.

### Detailed summary
- Added `maxBatchesSimultaniously` setting with a value of 5 for the `BOBA` chain.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->