### PR TITLE
chore(pkgs/steer-sdk): decentralized network

### DIFF
--- a/packages/steer-sdk/src/constants.ts
+++ b/packages/steer-sdk/src/constants.ts
@@ -1,4 +1,5 @@
 import { ChainId } from 'sushi/chain'
+import { DECENTRALIZED_HOST_BY_SUBGRAPH_ID } from 'sushi/config/subgraph'
 
 export const STEER_SUPPORTED_CHAIN_IDS = [
   ChainId.POLYGON,
@@ -16,6 +17,7 @@ export const STEER_SUPPORTED_CHAIN_IDS = [
   ChainId.SCROLL,
   ChainId.FANTOM,
   ChainId.BLAST,
+  ChainId.ROOTSTOCK,
 ]
 
 export const SteerChainIds = STEER_SUPPORTED_CHAIN_IDS
@@ -41,17 +43,14 @@ export const STEER_PERIPHERY_ADDRESS: Record<SteerChainId, `0x${string}`> = {
   [ChainId.SCROLL]: '0xD90c8970708FfdFC403bdb56636621e3E9CCe921',
   [ChainId.FANTOM]: '0xcb77e4C30D92c8b959811E99213625C7b9490b96',
   [ChainId.BLAST]: '0xdca3251Ebe8f85458E8d95813bCb816460e4bef1',
+  [ChainId.ROOTSTOCK]: '0x37cff062d52dd6e9e39df619ccd30c037a36bb83',
 }
 
 export const STEER_SUBGRAPH_URL: Record<SteerChainId, string> = {
-  [ChainId.POLYGON]:
-    'api.thegraph.com/subgraphs/name/steerprotocol/steer-protocol-polygon',
-  [ChainId.BSC]:
-    'api.thegraph.com/subgraphs/name/steerprotocol/steer-protocol-bsc',
-  [ChainId.OPTIMISM]:
-    'api.thegraph.com/subgraphs/name/steerprotocol/steer-protocol-optimism',
-  [ChainId.ARBITRUM]:
-    'api.thegraph.com/subgraphs/name/steerprotocol/steer-protocol-arbitrum',
+  [ChainId.POLYGON]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/uQxLz6EarmJcr2ymRRmTnrRPi8cCqas4XcPQb71HBvw`,
+  [ChainId.BSC]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/GLDP56fPGDz3MtmhtfTkz5CxWiqiNLACVrsJ9RqQeL4U`,
+  [ChainId.OPTIMISM]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/GgW1EwNARL3dyo3acQ3VhraQQ66MHT7QnYuGcQc5geDG`,
+  [ChainId.ARBITRUM]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/HVC4Br5yprs3iK6wF8YVJXy4QZWBNXTCFp8LPe3UpcD4`,
   // [ChainId.Evmos]: 'subgraph.satsuma-prod.com/769a117cc018/steer/steer-protocol-evmos/api',
   [ChainId.THUNDERCORE]:
     'subgraph.steer.finance/thundercore/subgraphs/name/steerprotocol/steer-thundercore',
@@ -59,12 +58,10 @@ export const STEER_SUBGRAPH_URL: Record<SteerChainId, string> = {
     'subgraph.satsuma-prod.com/769a117cc018/steer/steer-protocol-metis/api',
   [ChainId.BASE]:
     'subgraph.satsuma-prod.com/769a117cc018/steer/steer-protocol-base/api',
-  [ChainId.AVALANCHE]:
-    'api.thegraph.com/subgraphs/name/rakeshbhatt10/avalance-test-subgraph',
+  [ChainId.AVALANCHE]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/GZotTj3rQJ8ZqVyodtK8TcnKcUxMgeF7mCJHGPYbu8dA`,
   [ChainId.POLYGON_ZKEVM]:
     'subgraph.steer.finance/zkevm/subgraphs/name/steerprotocol/steer-zkevm',
-  [ChainId.CELO]:
-    'api.thegraph.com/subgraphs/name/rakeshbhatt10/steer-test-celo',
+  [ChainId.CELO]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/BPaFHyfVrhv3pdjGodpQcWggAg1Bcrvc9SFc2t2BXeho`,
   [ChainId.KAVA]:
     'subgraph.steer.finance/kava/subgraphs/name/steerprotocol/steer-kava-evm',
   [ChainId.LINEA]:
@@ -76,4 +73,6 @@ export const STEER_SUBGRAPH_URL: Record<SteerChainId, string> = {
   [ChainId.BLAST]:
     'https://api.goldsky.com/api/public/project_clohj3ta78ok12nzs5m8yag0b/subgraphs/steer-protocol-blast/1.1.1/gn',
   // [ChainId.MANTA]: 'subgraph.steer.finance/manta/subgraphs/name/steerprotocol/steer-manta'
+  [ChainId.ROOTSTOCK]:
+    'https://api.goldsky.com/api/public/project_clohj3ta78ok12nzs5m8yag0b/subgraphs/steer-protocol-rootstock/1.1.1/gn',
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `STEER_SUBGRAPH_URL` constants with decentralized host URLs for different ChainIds.

### Detailed summary
- Added decentralized host URLs for `ChainId.POLYGON`, `ChainId.BSC`, `ChainId.OPTIMISM`, `ChainId.ARBITRUM`, `ChainId.AVALANCHE`, `ChainId.CELO`, `ChainId.ROOTSTOCK`
- Updated the URLs for `ChainId.BLAST` and `ChainId.ROOTSTOCK`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->