### PR TITLE
fix: v3 swapFee units

### DIFF
--- a/packages/graph-client/src/subgraphs/sushi-v3/transforms/pool-v3-to-base.ts
+++ b/packages/graph-client/src/subgraphs/sushi-v3/transforms/pool-v3-to-base.ts
@@ -37,7 +37,7 @@ export function transformPoolV3ToBase<T extends RequiredBase>(
   pool: T,
   chainId: SushiSwapV3ChainId,
 ): PoolV3<PoolBase> {
-  const swapFee = Number(pool.swapFee) / 10000
+  const swapFee = Number(pool.swapFee) / 1000000
 
   return {
     id: getIdFromChainIdAddress(chainId, pool.id as Address),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the swap fee calculation in the `pool-v3-to-base.ts` file for the SushiSwap V3 subgraph.

### Detailed summary
- Updated swap fee calculation from dividing by 10,000 to dividing by 1,000,000 for more accurate results.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->