### PR TITLE
chore: enable skale europa

### DIFF
--- a/apps/evm/src/config.ts
+++ b/apps/evm/src/config.ts
@@ -21,7 +21,6 @@ export const DISABLED_CHAIN_IDS = [
   ChainId.PALM,
   ChainId.HECO,
   ChainId.OKEX,
-  ChainId.SKALE_EUROPA,
 ] as const
 
 const PREFERRED_CHAINID_ORDER = [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes `ChainId.SKALE_EUROPA` from the `PREFERRED_CHAINID_ORDER` array in `config.ts`.

### Detailed summary
- Removed `ChainId.SKALE_EUROPA` from `PREFERRED_CHAINID_ORDER` array

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->