### PR TITLE
fix(pkgs/graph-client): graphql renames

### DIFF
--- a/apps/evm/src/ui/pool/columns.tsx
+++ b/apps/evm/src/ui/pool/columns.tsx
@@ -281,7 +281,8 @@ export const VALUE_COLUMN = {
   id: 'value',
   header: 'Value',
   accessorFn: (row) =>
-    (Number(row.unstakedBalance) / Number(row.pool.liquidity)) *
+    (Number(row.unstakedBalance + row.stakedBalance) /
+      Number(row.pool.liquidity)) *
     Number(row.pool.liquidityUSD),
   cell: (props) => (
     <span>

--- a/apps/evm/src/ui/pool/columns.tsx
+++ b/apps/evm/src/ui/pool/columns.tsx
@@ -284,12 +284,12 @@ export const VALUE_COLUMN = {
     (Number(row.unstakedBalance + row.stakedBalance) /
       Number(row.pool.liquidity)) *
     Number(row.pool.liquidityUSD),
-  cell: (props) => (
+  cell: ({ row: { original } }) => (
     <span>
       {formatUSD(
-        (Number(props.row.original.unstakedBalance) /
-          Number(props.row.original.pool.liquidity)) *
-          Number(props.row.original.pool.liquidityUSD),
+        (Number(original.unstakedBalance + original.stakedBalance) /
+          Number(original.pool.liquidity)) *
+          Number(original.pool.liquidityUSD),
       )}
     </span>
   ),

--- a/packages/graph-client/src/subgraphs/bonds/queries/positions.ts
+++ b/packages/graph-client/src/subgraphs/bonds/queries/positions.ts
@@ -13,7 +13,7 @@ import { graphql } from '../graphql'
 export const BondUserPositionsQuery = graphql(
   `
   query UserPositions($first: Int = 1000, $skip: Int = 0, $block: Block_height, $orderBy: OwnerBalance_orderBy, $orderDirection: OrderDirection, $where: OwnerBalance_filter) {
-    positions: ownerBalances(first: $first, skip: $skip, block: $block, orderBy: $orderBy, orderDirection: $orderDirection, where: $where) {
+    ownerBalances(first: $first, skip: $skip, block: $block, orderBy: $orderBy, orderDirection: $orderDirection, where: $where) {
       id
       owner
       balance
@@ -51,7 +51,7 @@ export async function getBondUserPositions(
     options,
   })
 
-  return result.positions.map((position) => {
+  return result.ownerBalances.map((position) => {
     const bondTokenUnderlying = position.bondToken
       ? convertIdToMultichainId(
           copyIdToAddress(

--- a/packages/graph-client/src/subgraphs/master-chef-v1/queries/user-positions.ts
+++ b/packages/graph-client/src/subgraphs/master-chef-v1/queries/user-positions.ts
@@ -13,7 +13,7 @@ import { graphql } from '../graphql'
 export const MasterChefV1UserPositionsQuery = graphql(
   `
   query UserPositions($first: Int = 1000, $skip: Int = 0, $block: Block_height, $orderBy: User_orderBy, $orderDirection: OrderDirection, $where: User_filter) {
-    positions: users(first: $first, skip: $skip, block: $block, orderBy: $orderBy, orderDirection: $orderDirection, where: $where) {
+    users(first: $first, skip: $skip, block: $block, orderBy: $orderBy, orderDirection: $orderDirection, where: $where) {
       id
       address
       balance: amount
@@ -43,7 +43,7 @@ export async function getMasterChefV1UserPositions(
     options,
   })
 
-  return result.positions.flatMap((position) => {
+  return result.users.flatMap((position) => {
     if (!position.pool) {
       return []
     }

--- a/packages/graph-client/src/subgraphs/master-chef-v2/queries/user-positions.ts
+++ b/packages/graph-client/src/subgraphs/master-chef-v2/queries/user-positions.ts
@@ -13,7 +13,7 @@ import { graphql } from '../graphql'
 export const MasterChefV2UserPositionsQuery = graphql(
   `
   query UserPositions($first: Int = 1000, $skip: Int = 0, $block: Block_height, $orderBy: User_orderBy, $orderDirection: OrderDirection, $where: User_filter) {
-    positions: users(first: $first, skip: $skip, block: $block, orderBy: $orderBy, orderDirection: $orderDirection, where: $where) {
+    users(first: $first, skip: $skip, block: $block, orderBy: $orderBy, orderDirection: $orderDirection, where: $where) {
       id
       address
       balance: amount
@@ -43,7 +43,7 @@ export async function getMasterChefV2UserPositions(
     options,
   })
 
-  return result.positions.flatMap((position) => {
+  return result.users.flatMap((position) => {
     if (!position.pool) {
       return []
     }

--- a/packages/graph-client/src/subgraphs/mini-chef/queries/rewarders.ts
+++ b/packages/graph-client/src/subgraphs/mini-chef/queries/rewarders.ts
@@ -15,7 +15,7 @@ query MiniChefRewarders(
   $where: Rewarder_filter
   $block: Block_height
 ) {
-  rewarders: rewarders(first: $first, skip: $skip, where: $where, block: $block) {
+  rewarders(first: $first, skip: $skip, where: $where, block: $block) {
     id
     rewardToken
     rewardPerSecond

--- a/packages/graph-client/src/subgraphs/mini-chef/queries/user-positions.ts
+++ b/packages/graph-client/src/subgraphs/mini-chef/queries/user-positions.ts
@@ -14,7 +14,7 @@ import { graphql } from '../graphql'
 export const MiniChefUserPositionsQuery = graphql(
   `
   query UserPositions($first: Int = 1000, $skip: Int = 0, $block: Block_height, $orderBy: User_orderBy, $orderDirection: OrderDirection, $where: User_filter) {
-    positions: users(first: $first, skip: $skip, block: $block, orderBy: $orderBy, orderDirection: $orderDirection, where: $where) {
+    users(first: $first, skip: $skip, block: $block, orderBy: $orderBy, orderDirection: $orderDirection, where: $where) {
       id
       address
       balance: amount
@@ -45,7 +45,7 @@ export async function getMiniChefUserPositions(
     options,
   })
 
-  return result.positions.flatMap((position) => {
+  return result.users.flatMap((position) => {
     if (!position.pool) {
       return []
     }

--- a/packages/graph-client/src/subgraphs/sushi-v2/queries/factory.ts
+++ b/packages/graph-client/src/subgraphs/sushi-v2/queries/factory.ts
@@ -12,7 +12,7 @@ import { graphql } from '../graphql'
 
 export const SushiV2FactoriesQuery = graphql(`
   query Factories {
-    factories: uniswapFactories(first: 1) {
+    uniswapFactories(first: 1) {
       id
       totalLiquidityUSD
       untrackedVolumeUSD
@@ -40,9 +40,9 @@ export async function getSushiV2Factory(
     options,
   )
 
-  if (result.factories[0]) {
+  if (result.uniswapFactories[0]) {
     return convertIdToMultichainId(
-      copyIdToAddress(addChainId(chainId, result.factories[0])),
+      copyIdToAddress(addChainId(chainId, result.uniswapFactories[0])),
     )
   }
 

--- a/packages/graph-client/src/subgraphs/sushi-v2/queries/pool-with-buckets.ts
+++ b/packages/graph-client/src/subgraphs/sushi-v2/queries/pool-with-buckets.ts
@@ -15,7 +15,7 @@ import { graphql } from '../graphql'
 export const SushiV2PoolBucketsQuery = graphql(
   `
   query PoolBuckets($id: ID!, $id_Bytes: Bytes!, $block: Block_height, $hourDataFirst: Int = 168, $dayDataFirst: Int = 1000) {
-    pool: pair(id: $id, block: $block) {
+    pair(id: $id, block: $block) {
       ...PoolFields
 
       poolHourData: pairHourData(first: $hourDataFirst, orderBy: hourStartUnix, orderDirection: desc) {
@@ -72,10 +72,10 @@ export async function getSushiV2PoolBuckets(
     options,
   )
 
-  if (result.pool) {
+  if (result.pair) {
     return {
-      ...transformPoolV2ToBase(result.pool, chainId),
-      poolHourData: transformBucketsV2ToStd(result.pool.poolHourData),
+      ...transformPoolV2ToBase(result.pair, chainId),
+      poolHourData: transformBucketsV2ToStd(result.pair.poolHourData),
       poolDayData: transformBucketsV2ToStd(result.poolDayData),
     }
   }

--- a/packages/graph-client/src/subgraphs/sushi-v2/transforms/bucket-v2-to-std.ts
+++ b/packages/graph-client/src/subgraphs/sushi-v2/transforms/bucket-v2-to-std.ts
@@ -3,7 +3,7 @@ import type { SushiV2PoolBucketsQuery } from 'src/subgraphs/sushi-v2/queries/poo
 import type { PoolBucket } from 'sushi/types'
 
 type FetchedBucket = NonNullable<
-  ResultOf<typeof SushiV2PoolBucketsQuery>['pool']
+  ResultOf<typeof SushiV2PoolBucketsQuery>['pair']
 >['poolHourData'][number]
 
 export function transformBucketsV2ToStd(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update queries and transformations in various subgraphs for consistency and accuracy.

### Detailed summary
- Updated query names and fields in `mini-chef`, `sushi-v2`, `master-chef-v1`, `master-chef-v2`, and `bonds` subgraphs.
- Modified calculations in UI for pool values in `columns.tsx`.
- Adjusted query and result names in `pool-with-buckets.ts` for Sushi V2 subgraph.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->