### PR TITLE
fix(jobs/pool): don't fail steer if aprs cant be fetched

### DIFF
--- a/jobs/pool/src/steer.ts
+++ b/jobs/pool/src/steer.ts
@@ -124,7 +124,14 @@ async function extractChain(chainId: SteerChainId) {
     payloads.push(...payloadsChunk)
   }
 
-  const aprs = await getVaultAprs({ chainId })
+  let aprs
+
+  try {
+    aprs = await getVaultAprs({ chainId })
+  } catch (e: any) {
+    console.error(`Failed to fetch aprs for chainId: ${chainId}`, e.message)
+    aprs = {}
+  }
 
   const vaultsWithPayloads = await Promise.allSettled(
     vaults.map(async (vault, i) => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves error handling in `steer.ts` by adding a try-catch block when fetching APRs for a specific chain ID.

### Detailed summary
- Added try-catch block for fetching APRs
- Logged error message if fetching APRs fails
- Assigned an empty object to `aprs` in case of error

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->