### PR TITLE
fix: pool explorer link

### DIFF
--- a/apps/evm/src/ui/pool/PoolHeader.tsx
+++ b/apps/evm/src/ui/pool/PoolHeader.tsx
@@ -96,7 +96,7 @@ export const PoolHeader: FC<PoolHeader> = ({
               })}
             >
               <LinkExternal
-                href={Chain.from(pool.chainId)?.getTokenUrl(address)}
+                href={Chain.from(pool.chainId)?.getAccountUrl(address)}
               >
                 {token0.symbol}/{token1.symbol}
               </LinkExternal>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `PoolHeader.tsx` file to change the `getTokenUrl` function to `getAccountUrl` in the `LinkExternal` component.

### Detailed summary
- Updated the `href` prop in `LinkExternal` from `getTokenUrl` to `getAccountUrl` using the `Chain` object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->