### PR TITLE
fix: ci action setup versions

### DIFF
--- a/.github/workflows/apps-evm-e2e.yml
+++ b/.github/workflows/apps-evm-e2e.yml
@@ -42,7 +42,7 @@ jobs:
           submodules: true
 
       # Has to be before setup node for caching to work
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: ${{ matrix.pnpm-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 8.15.8
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the GitHub Actions workflow files to use version 4 of `pnpm/action-setup` instead of version 2.

### Detailed summary
- Updated `pnpm/action-setup` to version 4 in `.github/workflows/release.yml`
- Updated `pnpm/action-setup` to version 4 in `.github/workflows/apps-evm-e2e.yml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->