### PR TITLE
Revert "try tracking with vercel custom events"

### DIFF
--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -40,9 +40,6 @@
     "dev": "tsc --watch",
     "test": "jest --passWithNoTests"
   },
-  "dependencies": {
-    "@vercel/analytics": "1.3.1"
-  },
   "devDependencies": {
     "@tsconfig/esm": "1.0.4",
     "@tsconfig/strictest": "2.0.2",

--- a/packages/telemetry/src/sendAnalyticsEvent.ts
+++ b/packages/telemetry/src/sendAnalyticsEvent.ts
@@ -1,14 +1,7 @@
-import { track } from '@vercel/analytics'
-
 export function sendAnalyticsEvent(
   eventName: string,
   eventProperties?: Record<string, unknown>,
 ) {
-  if (typeof window.gtag !== 'undefined') {
+  typeof window.gtag !== 'undefined' &&
     window.gtag('event', eventName, eventProperties)
-  }
-  track(
-    eventName,
-    eventProperties as Record<string, string | number | boolean | null>,
-  )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1711,10 +1711,6 @@ importers:
         version: 3.21.4
 
   packages/telemetry:
-    dependencies:
-      '@vercel/analytics':
-        specifier: 1.3.1
-        version: 1.3.1(next@14.2.3)(react@18.2.0)
     devDependencies:
       '@tsconfig/esm':
         specifier: 1.0.4


### PR DESCRIPTION
Reverts sushiswap/sushiswap#1545

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update dependencies, add a new dev dependency, and refactor the `sendAnalyticsEvent` function in the `telemetry` package.

### Detailed summary
- Updated `@vercel/analytics` dependency to version `1.3.1(next@14.2.3)(react@18.2.0)`
- Added `@tsconfig/strictest` as a new devDependency
- Refactored `sendAnalyticsEvent` function in `sendAnalyticsEvent.ts` to include a condition for `window.gtag` and remove `track` function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->