### PR TITLE
fix: include QueryClientProvider in cms

### DIFF
--- a/apps/web/src/app/(cms)/providers.tsx
+++ b/apps/web/src/app/(cms)/providers.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import { ThemeProvider } from 'next-themes'
+import { QueryClientProvider } from 'src/providers/query-client-provider'
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <ThemeProvider>{children}</ThemeProvider>
+  return (
+    <ThemeProvider>
+      <QueryClientProvider>{children}</QueryClientProvider>
+    </ThemeProvider>
+  )
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a `QueryClientProvider` to the existing `Providers` component in `apps/web/src/app/(cms)/providers.tsx`.

### Detailed summary
- Added `QueryClientProvider` import from 'src/providers/query-client-provider'
- Wrapped `children` in `QueryClientProvider` within the `ThemeProvider` block

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->