### PR TITLE
fix: ignore UserRejectedRequestError

### DIFF
--- a/apps/web/src/lib/wagmi/hooks/approvals/hooks/useTokenApproval.ts
+++ b/apps/web/src/lib/wagmi/hooks/approvals/hooks/useTokenApproval.ts
@@ -133,7 +133,7 @@ export const useTokenApproval = ({
 
   const onError = useCallback((e: Error) => {
     if (e instanceof Error) {
-      if (!(e instanceof UserRejectedRequestError)) {
+      if (!(e.cause instanceof UserRejectedRequestError)) {
         createErrorToast(e.message, true)
       }
     }

--- a/apps/web/src/lib/wagmi/hooks/approvals/hooks/useTokenPermit.ts
+++ b/apps/web/src/lib/wagmi/hooks/approvals/hooks/useTokenPermit.ts
@@ -152,7 +152,7 @@ export const useTokenPermit = ({
       setSignature({ ...hexToSignature(signedData), message, domain })
     } catch (e) {
       if (e instanceof Error) {
-        if (!(e instanceof UserRejectedRequestError)) {
+        if (!(e.cause instanceof UserRejectedRequestError)) {
           createErrorToast(e.message, true)
         }
       }

--- a/apps/web/src/lib/wagmi/hooks/approvals/hooks/useTokenRevokeApproval.ts
+++ b/apps/web/src/lib/wagmi/hooks/approvals/hooks/useTokenRevokeApproval.ts
@@ -65,7 +65,7 @@ export const useTokenRevokeApproval = ({
 
   const onError = useCallback((e: Error) => {
     if (e instanceof Error) {
-      if (!(e instanceof UserRejectedRequestError)) {
+      if (!(e.cause instanceof UserRejectedRequestError)) {
         createErrorToast(e.message, true)
       }
     }

--- a/apps/web/src/lib/wagmi/hooks/bar/useBarDeposit.ts
+++ b/apps/web/src/lib/wagmi/hooks/bar/useBarDeposit.ts
@@ -48,7 +48,7 @@ export function useBarDeposit({ amount, enabled = true }: UseBarDepositParams) {
   )
 
   const onError = useCallback((e: Error) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e?.message, true)
     }
   }, [])

--- a/apps/web/src/lib/wagmi/hooks/bar/useBarWithdaw.ts
+++ b/apps/web/src/lib/wagmi/hooks/bar/useBarWithdaw.ts
@@ -51,7 +51,7 @@ export function useBarWithdraw({
   )
 
   const onError = useCallback((e: Error) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e?.message, true)
     }
   }, [])

--- a/apps/web/src/lib/wagmi/hooks/bentobox/hooks/useBentoBoxApproval.ts
+++ b/apps/web/src/lib/wagmi/hooks/bentobox/hooks/useBentoBoxApproval.ts
@@ -53,7 +53,7 @@ export const useBentoBoxApproval = ({
     console.error(msg, e)
 
     if (e instanceof Error) {
-      if (!(e instanceof UserRejectedRequestError)) {
+      if (!(e.cause instanceof UserRejectedRequestError)) {
         createErrorToast(e.message, true)
       }
     }

--- a/apps/web/src/lib/wagmi/hooks/master-chef/use-master-chef-deposit.ts
+++ b/apps/web/src/lib/wagmi/hooks/master-chef/use-master-chef-deposit.ts
@@ -38,7 +38,7 @@ export const useMasterChefDeposit = ({
   const contract = useMasterChefContract(chainId, chef)
 
   const onError = useCallback((e: Error) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e?.message, true)
     }
   }, [])

--- a/apps/web/src/lib/wagmi/hooks/master-chef/use-master-chef-withdraw.ts
+++ b/apps/web/src/lib/wagmi/hooks/master-chef/use-master-chef-withdraw.ts
@@ -63,7 +63,7 @@ export const useMasterChefWithdraw = ({
   )
 
   const onError = useCallback((e: Error) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e?.message, true)
     }
   }, [])

--- a/apps/web/src/lib/wagmi/hooks/master-chef/use-master-chef.ts
+++ b/apps/web/src/lib/wagmi/hooks/master-chef/use-master-chef.ts
@@ -258,7 +258,7 @@ export const useMasterChef: UseMasterChef = ({
   )
 
   const onError = useCallback((e: SendTransactionErrorType) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e?.message, true)
     }
   }, [])

--- a/apps/web/src/lib/wagmi/hooks/migrate/hooks/useV3Migrate.tsx
+++ b/apps/web/src/lib/wagmi/hooks/migrate/hooks/useV3Migrate.tsx
@@ -199,7 +199,7 @@ export const useV3Migrate = ({
 
   const onError = useCallback((e: Error) => {
     if (e instanceof Error) {
-      if (!(e instanceof UserRejectedRequestError)) {
+      if (!(e.cause instanceof UserRejectedRequestError)) {
         createErrorToast(e.message, true)
       }
     }

--- a/apps/web/src/lib/wagmi/hooks/rewards/hooks/useAcceptAngleConditions.ts
+++ b/apps/web/src/lib/wagmi/hooks/rewards/hooks/useAcceptAngleConditions.ts
@@ -90,7 +90,7 @@ export const useAcceptAngleConditions = (
 
   const onError = useCallback((e: Error) => {
     if (e instanceof Error) {
-      if (!(e instanceof UserRejectedRequestError)) {
+      if (!(e.cause instanceof UserRejectedRequestError)) {
         createErrorToast(e.message, true)
       }
     }

--- a/apps/web/src/lib/wagmi/hooks/rewards/hooks/useHarvestAngleRewards.ts
+++ b/apps/web/src/lib/wagmi/hooks/rewards/hooks/useHarvestAngleRewards.ts
@@ -71,7 +71,7 @@ export const useHarvestAngleRewards = ({
 
   const onError = useCallback((e: Error) => {
     if (e instanceof Error) {
-      if (!(e instanceof UserRejectedRequestError)) {
+      if (!(e.cause instanceof UserRejectedRequestError)) {
         createErrorToast(e.message, true)
       }
     }

--- a/apps/web/src/lib/wagmi/hooks/rewards/hooks/useIncentivizePoolWithRewards.ts
+++ b/apps/web/src/lib/wagmi/hooks/rewards/hooks/useIncentivizePoolWithRewards.ts
@@ -47,7 +47,7 @@ export const useIncentivizePoolWithRewards = ({
 
   const onError = useCallback((e: Error) => {
     if (e instanceof Error) {
-      if (!(e instanceof UserRejectedRequestError)) {
+      if (!(e.cause instanceof UserRejectedRequestError)) {
         createErrorToast(e.message, true)
       }
     }

--- a/apps/web/src/ui/bonds/bonds-buy-review-modal.tsx
+++ b/apps/web/src/ui/bonds/bonds-buy-review-modal.tsx
@@ -117,7 +117,7 @@ export const BondsBuyReviewModal: FC<BondsBuyReviewModal> = ({
   )
 
   const onError = useCallback((e: Error) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e?.message, true)
     }
   }, [])

--- a/apps/web/src/ui/bonds/bonds-positions-table/bonds-positions-table-columns.tsx
+++ b/apps/web/src/ui/bonds/bonds-positions-table/bonds-positions-table-columns.tsx
@@ -177,7 +177,7 @@ const CLAIM_CELL = ({ position }: { position: BondPosition }) => {
   )
 
   const onError = useCallback((e: Error) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e.message, true)
     }
   }, [])

--- a/apps/web/src/ui/pool/AddSectionReviewModalConcentrated.tsx
+++ b/apps/web/src/ui/pool/AddSectionReviewModalConcentrated.tsx
@@ -199,7 +199,7 @@ export const AddSectionReviewModalConcentrated: FC<
   )
 
   const onError = useCallback((e: Error) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e?.message, true)
     }
   }, [])

--- a/apps/web/src/ui/pool/AddSectionReviewModalLegacy.tsx
+++ b/apps/web/src/ui/pool/AddSectionReviewModalLegacy.tsx
@@ -365,7 +365,7 @@ export const AddSectionReviewModalLegacy: FC<AddSectionReviewModalLegacyProps> =
     )
 
     const onError = useCallback((e: Error) => {
-      if (e instanceof UserRejectedRequestError) {
+      if (!(e.cause instanceof UserRejectedRequestError)) {
         createErrorToast(e?.message, true)
       }
     }, [])

--- a/apps/web/src/ui/pool/ConcentratedLiquidityCollectButton.tsx
+++ b/apps/web/src/ui/pool/ConcentratedLiquidityCollectButton.tsx
@@ -114,7 +114,7 @@ export const ConcentratedLiquidityCollectButton: FC<
   )
 
   const onError = useCallback((e: Error) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e?.message, true)
     }
   }, [])

--- a/apps/web/src/ui/pool/ConcentratedLiquidityRemoveWidget.tsx
+++ b/apps/web/src/ui/pool/ConcentratedLiquidityRemoveWidget.tsx
@@ -148,7 +148,7 @@ export const ConcentratedLiquidityRemoveWidget: FC<
   )
 
   const onError = useCallback((e: Error) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e.message, true)
     }
   }, [])

--- a/apps/web/src/ui/pool/Steer/SteerLiquidityManagement/Add/SteerPositionAddReviewModal.tsx
+++ b/apps/web/src/ui/pool/Steer/SteerLiquidityManagement/Add/SteerPositionAddReviewModal.tsx
@@ -137,7 +137,7 @@ export const SteerPositionAddReviewModal: FC<SteerPositionAddReviewModalProps> =
     )
 
     const onError = useCallback((e: Error) => {
-      if (e instanceof UserRejectedRequestError) {
+      if (!(e.cause instanceof UserRejectedRequestError)) {
         createErrorToast(e?.message, true)
       }
     }, [])

--- a/apps/web/src/ui/pool/Steer/SteerLiquidityManagement/Remove/SteerPositionRemove.tsx
+++ b/apps/web/src/ui/pool/Steer/SteerLiquidityManagement/Remove/SteerPositionRemove.tsx
@@ -114,7 +114,7 @@ export const SteerPositionRemove: FC<SteerPositionRemoveProps> = ({
   )
 
   const onError = useCallback((e: Error) => {
-    if (e instanceof UserRejectedRequestError) {
+    if (!(e.cause instanceof UserRejectedRequestError)) {
       createErrorToast(e?.message, true)
     }
   }, [])

--- a/apps/web/src/ui/swap/cross-chain/cross-chain-swap-trade-review-dialog.tsx
+++ b/apps/web/src/ui/swap/cross-chain/cross-chain-swap-trade-review-dialog.tsx
@@ -287,7 +287,7 @@ export const CrossChainSwapTradeReviewDialog: FC<{ children: ReactNode }> = ({
 
   const onWriteError = useCallback(
     (e: Error) => {
-      if (e instanceof UserRejectedRequestError) {
+      if (e.cause instanceof UserRejectedRequestError) {
         onComplete()
         return
       }

--- a/apps/web/src/ui/swap/simple/simple-swap-trade-review-dialog.tsx
+++ b/apps/web/src/ui/swap/simple/simple-swap-trade-review-dialog.tsx
@@ -349,7 +349,7 @@ export const SimpleSwapTradeReviewDialog: FC<{
 
   const onSwapError = useCallback(
     (e: Error) => {
-      if (e instanceof UserRejectedRequestError) {
+      if (e.cause instanceof UserRejectedRequestError) {
         return
       }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update error handling in multiple files to check for `e.cause` instead of `e` for `UserRejectedRequestError`.

### Detailed summary
- Updated error handling to check `e.cause` for `UserRejectedRequestError` in various files
- Replaced `instanceof UserRejectedRequestError` with `e.cause instanceof UserRejectedRequestError` for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->