### PR TITLE
fix: disable permit token approvals on harmony

### DIFF
--- a/apps/web/src/lib/wagmi/systems/Checker/ApproveERC20WithPermit.tsx
+++ b/apps/web/src/lib/wagmi/systems/Checker/ApproveERC20WithPermit.tsx
@@ -23,6 +23,7 @@ import { FC, useEffect, useState } from 'react'
 import { Amount, Type } from 'sushi/currency'
 
 import { TTLStorageKey } from '@sushiswap/hooks'
+import { ChainId } from 'sushi/chain'
 import { Address } from 'viem'
 import { useAccount, useBytecode } from 'wagmi'
 import {
@@ -33,6 +34,7 @@ import {
   PermitInfo,
   useTokenPermit,
 } from '../../hooks/approvals/hooks/useTokenPermit'
+import { ApproveERC20 } from './ApproveERC20'
 import { useApprovedActions } from './Provider'
 
 enum ApprovalType {
@@ -43,6 +45,7 @@ enum ApprovalType {
 
 interface ApproveERC20WithPermitProps extends ButtonProps {
   id: string
+  chainId: ChainId
   amount: Amount<Type> | undefined
   contract: Address | undefined
   enabled?: boolean
@@ -51,7 +54,22 @@ interface ApproveERC20WithPermitProps extends ButtonProps {
   tag: string
 }
 
-const ApproveERC20WithPermit: FC<ApproveERC20WithPermitProps> = ({
+const PERMIT_DISABLED_CHAIN_IDS = [ChainId.HARMONY]
+
+const isPermitSupportedChainId = (chainId: number) =>
+  !PERMIT_DISABLED_CHAIN_IDS.includes(
+    chainId as (typeof PERMIT_DISABLED_CHAIN_IDS)[number],
+  )
+
+const ApproveERC20WithPermit: FC<ApproveERC20WithPermitProps> = (props) => {
+  return isPermitSupportedChainId(props.chainId) ? (
+    <_ApproveERC20WithPermit {...props} />
+  ) : (
+    <ApproveERC20 {...props} />
+  )
+}
+
+const _ApproveERC20WithPermit: FC<ApproveERC20WithPermitProps> = ({
   id,
   amount,
   contract,

--- a/apps/web/src/ui/pool/RemoveSectionLegacy.tsx
+++ b/apps/web/src/ui/pool/RemoveSectionLegacy.tsx
@@ -240,7 +240,7 @@ export const RemoveSectionLegacy: FC<RemoveSectionLegacyProps> =
 
         const withNative =
           token1IsNative ||
-          Native.onChain(_pool.chainId).wrapped.address === pool.token1.address
+          Native.onChain(_pool.chainId).wrapped.address === pool.token0.address
 
         const config = (() => {
           if (signature?.message?.deadline) {
@@ -455,6 +455,7 @@ export const RemoveSectionLegacy: FC<RemoveSectionLegacyProps> =
                     variant="outline"
                     fullWidth
                     id="approve-remove-liquidity-slp"
+                    chainId={_pool.chainId}
                     amount={amountToRemove}
                     contract={
                       getSushiSwapRouterContractConfig(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `RemoveSectionLegacy` component and add support for different `ChainId` in the `ApproveERC20WithPermit` component.

### Detailed summary
- Update `RemoveSectionLegacy` to check `pool.token0` address
- Add `ChainId` import from `sushi/chain`
- Modify `ApproveERC20WithPermit` to support multiple `ChainId`
- Introduce `_ApproveERC20WithPermit` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->