### PR TITLE
feat: use amplitude for telemetry logging

### DIFF
--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -41,9 +41,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
+    "@amplitude/analytics-browser": "^2.9.3",
     "@tsconfig/esm": "1.0.4",
     "@tsconfig/strictest": "2.0.2",
-    "@types/gtag.js": "0.0.19",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "react": "18.2.0",

--- a/packages/telemetry/src/sendAnalyticsEvent.ts
+++ b/packages/telemetry/src/sendAnalyticsEvent.ts
@@ -1,7 +1,12 @@
+import { init, track } from '@amplitude/analytics-browser'
+
+typeof window !== 'undefined' && init('1a4621bcd5f74de90bb1cd5253e28f06')
+
 export function sendAnalyticsEvent(
   eventName: string,
   eventProperties?: Record<string, unknown>,
 ) {
-  typeof window.gtag !== 'undefined' &&
-    window.gtag('event', eventName, eventProperties)
+  const origin = window.location.origin
+
+  track(eventName, { ...eventProperties, origin })
 }

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -11,9 +11,6 @@
     "dist",
     ".turbo"
   ],
-  "types": [
-    "@types/gtag.js"
-  ],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1703,15 +1703,15 @@ importers:
 
   packages/telemetry:
     devDependencies:
+      '@amplitude/analytics-browser':
+        specifier: ^2.9.3
+        version: 2.9.3
       '@tsconfig/esm':
         specifier: 1.0.4
         version: 1.0.4
       '@tsconfig/strictest':
         specifier: 2.0.2
         version: 2.0.2
-      '@types/gtag.js':
-        specifier: 0.0.19
-        version: 0.0.19
       '@types/react':
         specifier: 18.2.14
         version: 18.2.14
@@ -2251,6 +2251,48 @@ packages:
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  /@amplitude/analytics-browser@2.9.3:
+    resolution: {integrity: sha512-PnkJrJGRUfdE9nFgQZbWvUjNGnbcFojQROfj7KQeKGJTzQZXMt+xafmfXWDnhsf0JRgbk273Wh7Z6WNXxS1seA==}
+    dependencies:
+      '@amplitude/analytics-client-common': 2.2.4
+      '@amplitude/analytics-core': 2.3.0
+      '@amplitude/analytics-types': 2.6.0
+      '@amplitude/plugin-page-view-tracking-browser': 2.2.17
+      tslib: 2.6.3
+    dev: true
+
+  /@amplitude/analytics-client-common@2.2.4:
+    resolution: {integrity: sha512-+zOW3/Yb4LzK1DfhFCnSOcb8vgeZgIQffLM6yrgzKGedtQOnwDQeKTDI3aaMzckXQPVcJs1M6bJcT/l5TmAkDw==}
+    dependencies:
+      '@amplitude/analytics-connector': 1.5.0
+      '@amplitude/analytics-core': 2.3.0
+      '@amplitude/analytics-types': 2.6.0
+      tslib: 2.6.3
+    dev: true
+
+  /@amplitude/analytics-connector@1.5.0:
+    resolution: {integrity: sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g==}
+    dev: true
+
+  /@amplitude/analytics-core@2.3.0:
+    resolution: {integrity: sha512-Knafvocs29cPOHM3GHyBkP4nXUrh/oXnj2fULoSyh/03Bt63UPoyQCNS/EtQB/dOUhapTP35ZU9yZnrY+jvndQ==}
+    dependencies:
+      '@amplitude/analytics-types': 2.6.0
+      tslib: 2.6.3
+    dev: true
+
+  /@amplitude/analytics-types@2.6.0:
+    resolution: {integrity: sha512-7MSENvLCTGjec7K45JT+RcOuoPTCvq1MMq/HRLiQK/BMR4taX7f/uXldEc8b//o+ZZP45IBqFroR7Bl8LwJQrQ==}
+    dev: true
+
+  /@amplitude/plugin-page-view-tracking-browser@2.2.17:
+    resolution: {integrity: sha512-s19LUuPMvOhvM/36XOUeVSMGOhtSOPA6bhhrR4x/lEsyylsS+rfi6/fILd2B5gojplXKMvVlJXEP+t1fjIr1HA==}
+    dependencies:
+      '@amplitude/analytics-client-common': 2.2.4
+      '@amplitude/analytics-types': 2.6.0
+      tslib: 2.6.3
+    dev: true
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to replace `gtag.js` with `@amplitude/analytics-browser` for improved analytics tracking.

### Detailed summary
- Replaced `@types/gtag.js` with `@amplitude/analytics-browser`
- Updated `sendAnalyticsEvent` function to use `@amplitude/analytics-browser`
- Updated dependencies and devDependencies in `package.json` and `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->