### PR TITLE
feat(packages/steer-sdk): update steer subgraph urls, disable celo

### DIFF
--- a/packages/steer-sdk/src/constants.ts
+++ b/packages/steer-sdk/src/constants.ts
@@ -11,7 +11,7 @@ export const STEER_SUPPORTED_CHAIN_IDS = [
   ChainId.BASE,
   ChainId.AVALANCHE,
   ChainId.POLYGON_ZKEVM,
-  ChainId.CELO,
+  // ChainId.CELO, // No V3 Celo deployment yet
   ChainId.KAVA,
   ChainId.LINEA,
   ChainId.SCROLL,
@@ -37,7 +37,7 @@ export const STEER_PERIPHERY_ADDRESS: Record<SteerChainId, `0x${string}`> = {
   [ChainId.BASE]: '0x16BA7102271dC83Fff2f709691c2B601DAD7668e',
   [ChainId.AVALANCHE]: '0x5D8249e3F5f702e1Fd720167b40424fc2daDCd1e',
   [ChainId.POLYGON_ZKEVM]: '0xcA19bEc25A41443F35EeAE03411Dce87D8c0Edc4',
-  [ChainId.CELO]: '0xdca3251Ebe8f85458E8d95813bCb816460e4bef1',
+  // [ChainId.CELO]: '0xdca3251Ebe8f85458E8d95813bCb816460e4bef1',
   [ChainId.KAVA]: '0xf90107890B640387ec3b0474F0c61674AEbCb510',
   [ChainId.LINEA]: '0x0C5c5BEB833fD382b04e039f151942DC3D9A60ce',
   [ChainId.SCROLL]: '0xD90c8970708FfdFC403bdb56636621e3E9CCe921',
@@ -61,15 +61,14 @@ export const STEER_SUBGRAPH_URL: Record<SteerChainId, string> = {
   [ChainId.AVALANCHE]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/GZotTj3rQJ8ZqVyodtK8TcnKcUxMgeF7mCJHGPYbu8dA`,
   [ChainId.POLYGON_ZKEVM]:
     'subgraph.steer.finance/zkevm/subgraphs/name/steerprotocol/steer-zkevm',
-  [ChainId.CELO]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/BPaFHyfVrhv3pdjGodpQcWggAg1Bcrvc9SFc2t2BXeho`,
+  // [ChainId.CELO]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/BPaFHyfVrhv3pdjGodpQcWggAg1Bcrvc9SFc2t2BXeho`,
   [ChainId.KAVA]:
     'subgraph.steer.finance/kava/subgraphs/name/steerprotocol/steer-kava-evm',
   [ChainId.LINEA]:
-    'subgraph.steer.finance/linea/subgraphs/name/steerprotocol/steer-linea',
+  'https://api.goldsky.com/api/public/project_clohj3ta78ok12nzs5m8yag0b/subgraphs/steer-protocol-linea/1.1.2/gn',
   [ChainId.SCROLL]:
     'subgraph.steer.finance/scroll/subgraphs/name/steerprotocol/steer-scroll',
-  [ChainId.FANTOM]:
-    'api.thegraph.com/subgraphs/name/rakeshbhatt10/steer-protocol-fantom-test',
+  [ChainId.FANTOM]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/9uyX2WDuaxmcYh11ehUhU68M9uSCp5FXVQV2w4LqbpbV`,
   [ChainId.BLAST]:
     'api.goldsky.com/api/public/project_clohj3ta78ok12nzs5m8yag0b/subgraphs/steer-protocol-blast/1.1.1/gn',
   // [ChainId.MANTA]: 'subgraph.steer.finance/manta/subgraphs/name/steerprotocol/steer-manta'

--- a/packages/steer-sdk/src/constants.ts
+++ b/packages/steer-sdk/src/constants.ts
@@ -65,7 +65,7 @@ export const STEER_SUBGRAPH_URL: Record<SteerChainId, string> = {
   [ChainId.KAVA]:
     'subgraph.steer.finance/kava/subgraphs/name/steerprotocol/steer-kava-evm',
   [ChainId.LINEA]:
-  'https://api.goldsky.com/api/public/project_clohj3ta78ok12nzs5m8yag0b/subgraphs/steer-protocol-linea/1.1.2/gn',
+    'https://api.goldsky.com/api/public/project_clohj3ta78ok12nzs5m8yag0b/subgraphs/steer-protocol-linea/1.1.2/gn',
   [ChainId.SCROLL]:
     'subgraph.steer.finance/scroll/subgraphs/name/steerprotocol/steer-scroll',
   [ChainId.FANTOM]: `${DECENTRALIZED_HOST_BY_SUBGRAPH_ID}/9uyX2WDuaxmcYh11ehUhU68M9uSCp5FXVQV2w4LqbpbV`,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the constants file in the `steer-sdk` package by commenting out the Celo chain IDs and updating the subgraph URLs.

### Detailed summary
- Commented out Celo chain IDs due to no V3 Celo deployment yet
- Updated subgraph URLs for Linea, Fantom, and Blast chains

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->