### PR TITLE
chore: use Promise.allSettled in useAngleRewardsMultipleChains

### DIFF
--- a/packages/react-query/src/hooks/rewards/useAngleRewardsMultipleChains.ts
+++ b/packages/react-query/src/hooks/rewards/useAngleRewardsMultipleChains.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
+import { isPromiseRejected } from 'sushi'
 import { ChainId } from 'sushi/chain'
 
 import { useAllPrices } from '../prices'
 import { angleRewardsQueryFn, angleRewardsSelect } from './useAngleRewards'
-import { angleRewardsMultipleValidator } from './validator'
 
 interface UseAngleRewardsParams {
   chainIds: ChainId[]
@@ -20,18 +20,18 @@ export const useAngleRewardsMultipleChains = ({
     queryKey: ['getAngleRewardsMultiple', { chainIds, account, prices }],
     queryFn: async () => {
       if (account && prices) {
-        const res = await Promise.all(
+        const res = await Promise.allSettled(
           chainIds.map((chainId) =>
             angleRewardsQueryFn({ chainIds: [chainId], account }),
           ),
         )
-        const parsed = angleRewardsMultipleValidator.parse(res)
 
-        return parsed
+        return res
           .map((el, i) => {
+            if (isPromiseRejected(el)) return null
             const data = angleRewardsSelect({
               chainId: chainIds[i]!,
-              data: el[chainIds[i]!],
+              data: el.value[chainIds[i]!],
               prices: prices[chainIds[i]!],
             })
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates `useAngleRewardsMultipleChains` to use `Promise.allSettled` and refactors result handling for multiple chains.

### Detailed summary
- Replaces `Promise.all` with `Promise.allSettled` for better error handling
- Refactors result parsing logic for multiple chains with improved data extraction

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->