### PR TITLE
fix: network icon classnames

### DIFF
--- a/packages/ui/src/icons/network/circle/EthereumCircle.tsx
+++ b/packages/ui/src/icons/network/circle/EthereumCircle.tsx
@@ -2,12 +2,13 @@ import * as React from 'react'
 
 import { EthereumNaked } from '../naked/EthereumNaked'
 
+import classNames from 'classnames'
 import { IconComponent } from '../../../types'
 
 export const EthereumCircle: IconComponent = (props) => (
   <EthereumNaked
     {...props}
-    className="text-white"
+    className={classNames(props.className, 'text-white')}
     circle={<rect rx={64} width={128} height={128} fill="#627EEA" />}
   />
 )

--- a/packages/ui/src/icons/network/circle/GnosisCircle.tsx
+++ b/packages/ui/src/icons/network/circle/GnosisCircle.tsx
@@ -2,12 +2,13 @@ import * as React from 'react'
 
 import { GnosisNaked } from '../naked/GnosisNaked'
 
+import classNames from 'classnames'
 import { IconComponent } from '../../../types'
 
 export const GnosisCircle: IconComponent = (props) => (
   <GnosisNaked
     {...props}
-    className="text-gray-700"
+    className={classNames(props.className, 'text-gray-700')}
     circle={<rect width="128" height="128" fill="#d0e2ef" rx="64" />}
   />
 )

--- a/packages/ui/src/icons/network/circle/TelosCircle.tsx
+++ b/packages/ui/src/icons/network/circle/TelosCircle.tsx
@@ -2,12 +2,13 @@ import * as React from 'react'
 
 import { TelosNaked } from '../naked/TelosNaked'
 
+import classNames from 'classnames'
 import { IconComponent } from '../../../types'
 
 export const TelosCircle: IconComponent = (props) => (
   <TelosNaked
     {...props}
-    className="!text-white"
+    className={classNames(props.className, '!text-white')}
     circle={<rect width={128} height={128} rx={64} fill="#5613FF" />}
   />
 )


### PR DESCRIPTION
resolves this spacing issue with some icons
<img width="291" alt="image" src="https://github.com/user-attachments/assets/1beb0587-d4aa-4c37-a418-01e800957a57">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `TelosCircle`, `GnosisCircle`, and `EthereumCircle` components by adding the `classNames` library to dynamically manage class names for styling.

### Detailed summary
- Added `classNames` library for dynamic class management
- Changed static class names to dynamic ones using `classNames` for `TelosCircle`, `GnosisCircle`, and `EthereumCircle` components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->