### PR TITLE
chore(apps/web): furo redirect

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -7,7 +7,7 @@ const bundleAnalyzer = withBundleAnalyzer({
   enabled: false && process.env.NODE_ENV !== 'development',
 })
 
-const FURO_URL = 'https://furo.sushi.com'
+const FURO_URL = 'https://pay.sushi.com'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = bundleAnalyzer({
@@ -68,6 +68,16 @@ const nextConfig = bundleAnalyzer({
         permanent: true,
         destination: '/swap?chainId=2046399126',
       },
+      {
+        source: '/furo',
+        permanent: true,
+        destination: `${FURO_URL}`,
+      },
+      {
+        source: '/furo/:path*',
+        permanent: true,
+        destination: `${FURO_URL}/:path*`,
+      },
     ]
   },
   async rewrites() {
@@ -94,14 +104,6 @@ const nextConfig = bundleAnalyzer({
       //   ],
       //   destination: '/pay/:path*',
       // },
-      {
-        source: '/furo',
-        destination: `${FURO_URL}/furo`,
-      },
-      {
-        source: '/furo/:path*',
-        destination: `${FURO_URL}/furo/:path*`,
-      },
     ]
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1586,10 +1586,6 @@ importers:
         specifier: 3.23.8
         version: 3.23.8
 
-  packages/sushi/dist/_cjs: {}
-
-  packages/sushi/dist/_esm: {}
-
   packages/telemetry:
     devDependencies:
       '@tsconfig/esm':
@@ -22154,6 +22150,7 @@ packages:
 
   web3-provider-engine@14.2.1:
     resolution: {integrity: sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==}
+    deprecated: 'This package has been deprecated, see the README for details: https://github.com/MetaMask/web3-provider-engine'
 
   web3-providers-http@1.10.3:
     resolution: {integrity: sha512-6dAgsHR3MxJ0Qyu3QLFlQEelTapVfWNTu5F45FYh8t7Y03T1/o+YAkVxsbY5AdmD+y5bXG/XPJ4q8tjL6MgZHw==}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update deprecated packages and redirect URLs to a new domain.

### Detailed summary
- Updated deprecated `web3-provider-engine` package
- Changed `FURO_URL` from `https://furo.sushi.com` to `https://pay.sushi.com`
- Updated URL redirects for `/furo` and `/furo/:path*` to point to the new domain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->