### PR TITLE
fix: currency input loading state

### DIFF
--- a/apps/web/src/lib/wagmi/components/web3-input/Currency/CurrencyInput.tsx
+++ b/apps/web/src/lib/wagmi/components/web3-input/Currency/CurrencyInput.tsx
@@ -151,7 +151,7 @@ const CurrencyInput: FC<CurrencyInputProps> = ({
         hideSearch={hideSearch}
       >
         <Button
-          data-state={isLoading ? 'inactive' : 'active'}
+          data-state={currencyLoading ? 'inactive' : 'active'}
           size="lg"
           variant={currency ? 'secondary' : 'default'}
           id={id}
@@ -181,7 +181,7 @@ const CurrencyInput: FC<CurrencyInputProps> = ({
       </TokenSelector>
     )
   }, [
-    isLoading,
+    currencyLoading,
     id,
     onSelect,
     currencies,
@@ -213,7 +213,9 @@ const CurrencyInput: FC<CurrencyInputProps> = ({
           )}
         >
           <SkeletonBox className="w-2/3 h-[32px] rounded-lg" />
-          <SkeletonBox className="w-1/3 h-[32px] rounded-lg" />
+          {currencyLoading ? (
+            <SkeletonBox className="w-1/3 h-[32px] rounded-lg" />
+          ) : null}
         </div>
         <div
           data-state={isLoading ? 'inactive' : 'active'}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `CurrencyInput` component in the `web3-input` module to use `currencyLoading` instead of `isLoading`.

### Detailed summary
- Replaced `isLoading` with `currencyLoading` throughout `CurrencyInput`
- Conditionally render SkeletonBox based on `currencyLoading`
- Updated `data-state` attribute based on `currencyLoading` value

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->