### PR TITLE
chore: replace useCall with useEstimateGas

### DIFF
--- a/apps/web/src/ui/swap/simple/simple-swap-trade-review-dialog.tsx
+++ b/apps/web/src/ui/swap/simple/simple-swap-trade-review-dialog.tsx
@@ -383,7 +383,7 @@ export const SimpleSwapTradeReviewDialog: FC<{
 
     return async (confirm: () => void) => {
       try {
-        await sendTransactionAsync(simulation.request)
+        await sendTransactionAsync(simulation)
         confirm()
       } catch {}
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the `useSimulateTrade` hook to use `useEstimateGas` and handle `EstimateGasErrorType`.

### Detailed summary
- Refactored `useSimulateTrade` to use `useEstimateGas`
- Updated error handling to use `EstimateGasErrorType`
- Adjusted `isMinOutError` function to handle `EstimateGasErrorType`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->