### PR TITLE
chore: add sushi changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -20,7 +20,6 @@
     "@sushiswap/notifications",
     "@sushiswap/ui",
     "@sushiswap/pool-job",
-    "@sushiswap/aptos",
     "@sushiswap/tron",
     "web"
   ]

--- a/.changeset/loud-donkeys-camp.md
+++ b/.changeset/loud-donkeys-camp.md
@@ -1,0 +1,5 @@
+---
+"sushi": minor
+---
+
+configuration

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1589,10 +1589,6 @@ importers:
         specifier: 3.23.8
         version: 3.23.8
 
-  packages/sushi/dist/_cjs: {}
-
-  packages/sushi/dist/_esm: {}
-
   packages/telemetry:
     devDependencies:
       '@tsconfig/esm':
@@ -22165,7 +22161,6 @@ packages:
 
   web3-provider-engine@14.2.1:
     resolution: {integrity: sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==}
-    deprecated: 'This package has been deprecated, see the README for details: https://github.com/MetaMask/web3-provider-engine'
 
   web3-providers-http@1.10.3:
     resolution: {integrity: sha512-6dAgsHR3MxJ0Qyu3QLFlQEelTapVfWNTu5F45FYh8t7Y03T1/o+YAkVxsbY5AdmD+y5bXG/XPJ4q8tjL6MgZHw==}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the configuration for SushiSwap and removes the deprecated package '@sushiswap/aptos'.

### Detailed summary
- Updated SushiSwap configuration
- Removed deprecated package '@sushiswap/aptos'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->