### PR TITLE
feat(pkgs/sushi): add pancakeswap token lists

### DIFF
--- a/packages/sushi/src/token-list/constants.ts
+++ b/packages/sushi/src/token-list/constants.ts
@@ -42,9 +42,12 @@ export const PLASMA_BNB_LIST =
 export const LINEA_LIST =
   'https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-mainnet-token-fulllist.json'
 
-export const PANCAKESWAP_EXTENDED = 'https://tokens.pancakeswap.finance/pancakeswap-extended.json'
-export const PANCAKESWAP_COINGECKO = 'https://tokens.pancakeswap.finance/coingecko.json'
-export const PANCAKESWAP_BNB = 'https://tokens.pancakeswap.finance/pancakeswap-bnb-mm.json'
+export const PANCAKESWAP_EXTENDED =
+  'https://tokens.pancakeswap.finance/pancakeswap-extended.json'
+export const PANCAKESWAP_COINGECKO =
+  'https://tokens.pancakeswap.finance/coingecko.json'
+export const PANCAKESWAP_BNB =
+  'https://tokens.pancakeswap.finance/pancakeswap-bnb-mm.json'
 
 // this is the default list of lists that are exposed to users
 // lower index == higher priority for token import
@@ -70,7 +73,7 @@ export const DEFAULT_TOKEN_LIST_OF_TOKEN_LISTS_TO_DISPLAY: string[] = [
   LINEA_LIST,
   PANCAKESWAP_EXTENDED,
   PANCAKESWAP_COINGECKO,
-  PANCAKESWAP_BNB
+  PANCAKESWAP_BNB,
 ]
 
 export const DEFAULT_LIST_OF_LISTS: string[] = [

--- a/packages/sushi/src/token-list/constants.ts
+++ b/packages/sushi/src/token-list/constants.ts
@@ -42,6 +42,10 @@ export const PLASMA_BNB_LIST =
 export const LINEA_LIST =
   'https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-mainnet-token-fulllist.json'
 
+export const PANCAKESWAP_EXTENDED = 'https://tokens.pancakeswap.finance/pancakeswap-extended.json'
+export const PANCAKESWAP_COINGECKO = 'https://tokens.pancakeswap.finance/coingecko.json'
+export const PANCAKESWAP_BNB = 'https://tokens.pancakeswap.finance/pancakeswap-bnb-mm.json'
+
 // this is the default list of lists that are exposed to users
 // lower index == higher priority for token import
 export const DEFAULT_TOKEN_LIST_OF_TOKEN_LISTS_TO_DISPLAY: string[] = [
@@ -64,6 +68,9 @@ export const DEFAULT_TOKEN_LIST_OF_TOKEN_LISTS_TO_DISPLAY: string[] = [
   CELO_LIST,
   PLASMA_BNB_LIST,
   LINEA_LIST,
+  PANCAKESWAP_EXTENDED,
+  PANCAKESWAP_COINGECKO,
+  PANCAKESWAP_BNB
 ]
 
 export const DEFAULT_LIST_OF_LISTS: string[] = [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds PancakeSwap token lists to the Sushi token list constants for enhanced token import options.

### Detailed summary
- Added `PANCAKESWAP_EXTENDED` token list URL
- Added `PANCAKESWAP_COINGECKO` token list URL
- Added `PANCAKESWAP_BNB` token list URL

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->