### PR TITLE
fix(apps/blog): category filtering

### DIFF
--- a/apps/web/src/app/(cms)/blog/components/category-filter/category-filter-client.tsx
+++ b/apps/web/src/app/(cms)/blog/components/category-filter/category-filter-client.tsx
@@ -31,7 +31,7 @@ export function CategoryFilterClient({ categories }: CategoryFilterClient) {
 
       setSearch((prev) => ({
         ...prev,
-        categories: prevToNew(prev.categories!, slug),
+        categories: prevToNew(prev.categories || [], slug),
       }))
     },
     [setSearch, selectedCategories],


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `category-filter-client.tsx` file in the blog component of the CMS app to handle an edge case when `prev.categories` is null.

### Detailed summary
- Updated logic to handle `prev.categories` being null by defaulting to an empty array
- Ensured `categories` are correctly updated in the search state

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->