### PR TITLE
chore: update default slippage

### DIFF
--- a/apps/web/src/app/(non-evm)/aptos/(common)/components/AddSection/AddSectionWidget.tsx
+++ b/apps/web/src/app/(non-evm)/aptos/(common)/components/AddSection/AddSectionWidget.tsx
@@ -14,6 +14,7 @@ import {
 } from '@sushiswap/ui'
 import { useParams } from 'next/navigation'
 import React, { FC, useEffect } from 'react'
+import { DEFAULT_SLIPPAGE } from 'sushi/config'
 import { usePool } from '~aptos/pool/lib/use-pool'
 import { useTokensFromPool } from '~aptos/pool/lib/use-tokens-from-pool'
 import { PoolAddCurrencyInput } from '~aptos/pool/ui/pool/add/pool-add-currency-input'
@@ -66,7 +67,7 @@ export const AddSectionWidget: FC = () => {
             options={{
               slippageTolerance: {
                 storageKey: SlippageToleranceStorageKey.AddLiquidity,
-                defaultValue: '0.5',
+                defaultValue: DEFAULT_SLIPPAGE,
                 title: 'Add Liquidity Slippage',
               },
             }}

--- a/apps/web/src/app/(non-evm)/aptos/(common)/components/RemoveSection/RemoveSectionLegacy.tsx
+++ b/apps/web/src/app/(non-evm)/aptos/(common)/components/RemoveSection/RemoveSectionLegacy.tsx
@@ -7,6 +7,7 @@ import { classNames } from '@sushiswap/ui'
 import { Dots } from '@sushiswap/ui'
 import { Provider } from 'aptos'
 import React, { useMemo, useState } from 'react'
+import { DEFAULT_SLIPPAGE } from 'sushi/config'
 import { networkNameToNetwork } from '~aptos/(common)/config/chains'
 import { formatNumberWithDecimals } from '~aptos/(common)/lib/common/format-number-with-decimals'
 import { useNetwork } from '~aptos/(common)/lib/common/use-network'
@@ -46,7 +47,7 @@ export const RemoveSectionLegacy = ({
     return (
       Math.floor(
         +(slippageTolerance === 'AUTO' || slippageTolerance === ''
-          ? '0.5'
+          ? DEFAULT_SLIPPAGE
           : slippageTolerance) * 100,
       ) / 10000
     )

--- a/apps/web/src/app/(non-evm)/aptos/(common)/components/RemoveSection/RemoveSectionWidget.tsx
+++ b/apps/web/src/app/(non-evm)/aptos/(common)/components/RemoveSection/RemoveSectionWidget.tsx
@@ -18,6 +18,7 @@ import {
 } from '@sushiswap/ui'
 import { FC, ReactNode } from 'react'
 import { formatUSD } from 'sushi'
+import { DEFAULT_SLIPPAGE } from 'sushi/config'
 import { CardCurrencyAmountItem } from '~aptos/(common)/components/CardCurrencyAmountItem'
 import { useStablePrice } from '~aptos/(common)/lib/common/use-stable-price'
 import { Token as TokenType } from '~aptos/(common)/lib/types/token'
@@ -73,7 +74,7 @@ export const RemoveSectionWidget: FC<RemoveSectionWidgetProps> = ({
             options={{
               slippageTolerance: {
                 storageKey: SlippageToleranceStorageKey.RemoveLiquidity,
-                defaultValue: '0.5',
+                defaultValue: DEFAULT_SLIPPAGE,
                 title: 'Remove Liquidity Slippage',
               },
             }}

--- a/apps/web/src/app/(non-evm)/aptos/pool/ui/pool/add/pool-add-provider/actions/setSlippageTolerance.ts
+++ b/apps/web/src/app/(non-evm)/aptos/pool/ui/pool/add/pool-add-provider/actions/setSlippageTolerance.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SLIPPAGE } from 'sushi/config'
 import { Actions, State } from '../types'
 import { setSlippageAmount0 } from './setSlippageAmount0'
 import { setSlippageAmount1 } from './setSlippageAmount1'
@@ -28,6 +29,6 @@ export function setSlippageTolerance(state: State, action: Actions): State {
   }
 }
 
-export function parseSlippageTolerance(value: string, auto = '0.5') {
+export function parseSlippageTolerance(value: string, auto = DEFAULT_SLIPPAGE) {
   return parseFloat(value === 'AUTO' ? auto : value) / 100
 }

--- a/apps/web/src/app/(non-evm)/aptos/swap/ui/simple/simple-swap-provider/simple-swap-provider.tsx
+++ b/apps/web/src/app/(non-evm)/aptos/swap/ui/simple/simple-swap-provider/simple-swap-provider.tsx
@@ -10,6 +10,7 @@ import {
   useMemo,
   useReducer,
 } from 'react'
+import { DEFAULT_SLIPPAGE } from 'sushi/config'
 import { getBaseTokensWithoutKey } from '~aptos/(common)/lib/common/use-base-tokens'
 import { useNetwork } from '~aptos/(common)/lib/common/use-network'
 import { Token } from '~aptos/(common)/lib/types/token'
@@ -89,9 +90,9 @@ export const SimpleSwapProvider: FC<SimpleSwapProvider> = ({ children }) => {
               parseFloat(
                 slippageTolerance
                   ? slippageTolerance === 'AUTO'
-                    ? '0.5'
+                    ? DEFAULT_SLIPPAGE
                     : slippageTolerance
-                  : '0.5',
+                  : DEFAULT_SLIPPAGE,
               )) /
               100,
         }

--- a/apps/web/src/app/(non-evm)/aptos/swap/ui/simple/simple-swap-trade-review-dialog.tsx
+++ b/apps/web/src/app/(non-evm)/aptos/swap/ui/simple/simple-swap-trade-review-dialog.tsx
@@ -19,6 +19,7 @@ import {
 } from '@sushiswap/ui'
 import { Provider } from 'aptos'
 import React, { FC } from 'react'
+import { DEFAULT_SLIPPAGE } from 'sushi/config'
 import { ModalType } from '~aptos/(common)//components/Modal/ModalProvider'
 import { Modal } from '~aptos/(common)/components/Modal/Modal'
 import { networkNameToNetwork } from '~aptos/(common)/config/chains'
@@ -191,7 +192,9 @@ export const SimpleSwapTradeReviewDialog: FC = () => {
                   </List.KeyValue>
                   <List.KeyValue
                     title={`Min. received after slippage (${
-                      slippageTolerance === 'AUTO' ? '0.5' : slippageTolerance
+                      slippageTolerance === 'AUTO'
+                        ? DEFAULT_SLIPPAGE
+                        : slippageTolerance
                     }%)`}
                     subtitle="The minimum amount you are guaranteed to receive."
                   >

--- a/packages/sushi/src/config/default-slippage.ts
+++ b/packages/sushi/src/config/default-slippage.ts
@@ -1,1 +1,1 @@
-export const DEFAULT_SLIPPAGE = '0.1'
+export const DEFAULT_SLIPPAGE = '0.5'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the slippage tolerance handling in various components to use a default value stored in `DEFAULT_SLIPPAGE`.

### Detailed summary
- Updated `parseSlippageTolerance` to use `DEFAULT_SLIPPAGE`
- Replaced hardcoded slippage tolerance values with `DEFAULT_SLIPPAGE` in multiple components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->