### PR TITLE
fix(apps/aptos): fix msafe

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,7 @@
     "@hookform/resolvers": "3.3.1",
     "@layerzerolabs/scan-client": "0.0.6",
     "@martianwallet/aptos-wallet-adapter": "^0.0.5",
-    "@msafe/aptos-wallet-adapter": "^1.0.14",
+    "@msafe/aptos-wallet-adapter": "^1.1.3",
     "@next/bundle-analyzer": "^14.2.3",
     "@octokit/auth-app": "4.0.7",
     "@orbs-network/twap-ui-sushiswap": "1.1.40",

--- a/apps/web/src/app/(non-evm)/aptos/(common)/ui/user-profile/connect-button.tsx
+++ b/apps/web/src/app/(non-evm)/aptos/(common)/ui/user-profile/connect-button.tsx
@@ -32,7 +32,7 @@ export function ConnectButton(props: ButtonProps) {
             const Icon = WalletIcons[wallet.name]
             return (
               <DropdownMenuItem
-                onClick={() => onSelect(wallet.name as WalletName)}
+                onClick={() => onSelect(wallet.name)}
                 key={wallet.name}
               >
                 <Icon className="w-4 h-4 mr-2" />

--- a/apps/web/src/app/(non-evm)/aptos/providers.tsx
+++ b/apps/web/src/app/(non-evm)/aptos/providers.tsx
@@ -10,7 +10,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { FewchaWallet } from 'fewcha-plugin-wallet-adapter'
 import { PetraWallet } from 'petra-plugin-wallet-adapter'
 import { Modal } from '~aptos/(common)/components/Modal/Modal'
-import { chains } from '~aptos/(common)/config/chains'
 
 const wallets = [
   new PetraWallet(),
@@ -18,9 +17,7 @@ const wallets = [
   new FewchaWallet(),
   new MartianWallet(),
   new RiseWallet(),
-  new MSafeWalletAdapter(
-    Object.values(chains).map((chain) => chain.other.MSafeOrigin),
-  ),
+  new MSafeWalletAdapter(),
 ]
 
 export function Providers({ children }: { children: React.ReactNode }) {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "patchedDependencies": {
       "@rainbow-me/rainbowkit@2.1.3": "patches/@rainbow-me__rainbowkit@2.1.3.patch",
       "@aptos-labs/aptos-client@0.1.0": "patches/@aptos-labs__aptos-client@0.1.0.patch",
-      "@msafe/aptos-wallet-adapter@1.0.14": "patches/@msafe__aptos-wallet-adapter@1.0.14.patch"
+      "@msafe/aptos-wallet-adapter@1.1.3": "patches/@msafe__aptos-wallet-adapter@1.1.3.patch"
     }
   }
 }

--- a/patches/@msafe__aptos-wallet-adapter@1.1.3.patch
+++ b/patches/@msafe__aptos-wallet-adapter@1.1.3.patch
@@ -1,15 +1,14 @@
 diff --git a/src/index.ts b/src/index.ts
-index 35d2757a46df570e20dd0002f2bcff22dfa3fb5f..3e58a9142a7f230c583cacafbac92407a44a7f2a 100644
+index ea19ab90c0a3add8447d6006d611ffb120f9662c..3da90e1647208afaef1b46f09f5e4f87349aebc3 100644
 --- a/src/index.ts
 +++ b/src/index.ts
-@@ -56,10 +56,6 @@ export class MSafeWalletAdapter implements AdapterPlugin {
-         .catch((e) => {
+@@ -60,9 +60,6 @@ export class MSafeWalletAdapter implements AdapterPlugin {
            console.log("🚀 ~ file: index.ts:57 ~ MSafeWalletAdapter:", e);
          });
--    } else {
+     } else {
 -      console.log(
 -        "🚀 ~ file: index.ts:63 ~ MSafeWalletAdapter: not in msafe wallet:"
 -      );
      }
    }
- 
+   url = "https://aptos.m-safe.io/";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,9 @@ patchedDependencies:
   '@aptos-labs/aptos-client@0.1.0':
     hash: t5ob2d47ycxvxflm53kwwzv4kq
     path: patches/@aptos-labs__aptos-client@0.1.0.patch
-  '@msafe/aptos-wallet-adapter@1.0.14':
-    hash: ftc7erqshkl7atv4bibkhe3fk4
-    path: patches/@msafe__aptos-wallet-adapter@1.0.14.patch
+  '@msafe/aptos-wallet-adapter@1.1.3':
+    hash: ztcfam72g3tcfvfy23kjubyhqa
+    path: patches/@msafe__aptos-wallet-adapter@1.1.3.patch
   '@rainbow-me/rainbowkit@2.1.3':
     hash: kb2qto7toymzcybuekyapbgkh4
     path: patches/@rainbow-me__rainbowkit@2.1.3.patch
@@ -496,13 +496,13 @@ importers:
     dependencies:
       '@aptos-labs/wallet-adapter-ant-design':
         specifier: 2.2.0
-        version: 2.2.0(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0)(date-fns@2.30.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 2.2.0(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)(date-fns@2.30.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@aptos-labs/wallet-adapter-core':
         specifier: 3.10.0
-        version: 3.10.0(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0)
+        version: 3.10.0(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)
       '@aptos-labs/wallet-adapter-react':
         specifier: 2.3.1
-        version: 2.3.1(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0)(react@18.2.0)
+        version: 2.3.1(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)(react@18.2.0)
       '@aptstats/aptos-wallet-framework':
         specifier: ^0.0.6
         version: 0.0.6(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.4))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.4))(@types/babel__core@7.20.5)(aptos@1.21.0)(bufferutil@4.0.8)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@types/node@22.1.0)(typescript@5.4.5))(type-fest@4.18.3)(typescript@5.4.5)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.16)
@@ -537,8 +537,8 @@ importers:
         specifier: ^0.0.5
         version: 0.0.5
       '@msafe/aptos-wallet-adapter':
-        specifier: ^1.0.14
-        version: 1.0.14(patch_hash=ftc7erqshkl7atv4bibkhe3fk4)
+        specifier: ^1.1.3
+        version: 1.1.3(patch_hash=ztcfam72g3tcfvfy23kjubyhqa)(@aptos-labs/ts-sdk@1.27.0)(@mizuwallet-sdk/core@1.3.0(@aptos-labs/ts-sdk@1.27.0)(graphql-request@7.0.1(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@next/bundle-analyzer':
         specifier: ^14.2.3
         version: 14.2.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -700,7 +700,7 @@ importers:
         version: 2.1.0(encoding@0.1.13)
       petra-plugin-wallet-adapter:
         specifier: ^0.4.5
-        version: 0.4.5(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0)
+        version: 0.4.5(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2144,8 +2144,33 @@ packages:
     peerDependencies:
       ajv: '>=8'
 
+  '@aptos-connect/wallet-adapter-plugin@1.0.1':
+    resolution: {integrity: sha512-yrnzO9gWMPqhgV0hz3Qv9XP98hefX/V7Pcj911SLM3NWktc+mL/5CW6BKz4VKcqnhewotd2Tek43VDZTSHKoeQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.21.0
+
+  '@aptos-connect/wallet-api@0.1.1':
+    resolution: {integrity: sha512-If666Wz7m+ZK/RzDhm5Wy3oDkhnv14wKHW0jEVtXtHwTzYEgaOdC92RhZHqzPAqysipKSatBJJNVk58PzJLAUQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.20.0
+
+  '@aptos-connect/web-transport@0.0.7':
+    resolution: {integrity: sha512-4dYv/696bEZc75041ewKsWxg48/dTEDqP0TpIfK3KndGepKWDM9q3Lj8iZo+8Z9nhzxwulEqiAO7c0nvzXxVFA==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.20.0
+
   '@aptos-labs/aptos-cli@0.1.2':
     resolution: {integrity: sha512-MCi+9xPDG/Fx6c6b9ACqyQBYJLHqKJQKB8lay/1sUNJ2mNBB2OU1Lkmd5pmjUG1JbZ5cg2Fmgid5iMKdTnphhA==}
+    hasBin: true
+
+  '@aptos-labs/aptos-cli@0.2.0':
+    resolution: {integrity: sha512-6kljJFRsTLXCvgkNhBoOLhVyo7rmih+8+XAtdeciIXkZYwzwVS3TFPLMqBUO2HcY6gYtQQRmTG52R5ihyi/bXA==}
     hasBin: true
 
   '@aptos-labs/aptos-client@0.0.2':
@@ -2164,6 +2189,10 @@ packages:
     resolution: {integrity: sha512-k1xaQSIdi6NTgIEwGG2xoPHnwkKFARsJjWnYBnp0OIz4LX2rDy/BiLSYeXDmLu8ku7SxyydNpTVimHlCOY4FEw==}
     engines: {node: '>=11.0.0'}
 
+  '@aptos-labs/ts-sdk@1.27.0':
+    resolution: {integrity: sha512-LsQpkrVEXGLaDFSLXvvU0+1X27kTlGBiy1rZqfcaW2hARN9m/Bc/AjztxXKeEXS/D7QmEJAeB6RS7CLM8aqC3w==}
+    engines: {node: '>=11.0.0'}
+
   '@aptos-labs/wallet-adapter-ant-design@2.2.0':
     resolution: {integrity: sha512-1Vbf8ukgfOblbzEB8bsN5GIjfT3XWJS4e1YIDRR09b2hhFqroYJAPhuuLuDWn//ZNgR6Q0TxJmvTzUzwj2DaOQ==}
     peerDependencies:
@@ -2172,9 +2201,6 @@ packages:
 
   '@aptos-labs/wallet-adapter-core@0.1.7':
     resolution: {integrity: sha512-g3HvX31kuFT5HqEe9Vh0ZgV1u0Otsfx54yeAwL7RO8CioBVBjYELhMsOYz0BOjecmAKhQ14G60VU8MqDyzYkIA==}
-
-  '@aptos-labs/wallet-adapter-core@0.2.3':
-    resolution: {integrity: sha512-QjUVRYSL05pxdjYo2bScxEZ8wi6ww4sf5mBW5w89F5mDfnDz2XEmZQYfQtV3bxoyqnNWPEjagTds4tKMXDhF1w==}
 
   '@aptos-labs/wallet-adapter-core@2.1.0':
     resolution: {integrity: sha512-ZSCCsFt2heEh9IDaObbzw8EwqfzJGCWGBoaGouBtOYn2DVkh5R0P9xRj6ryF9cuO+tkfP+8KZmZ9m4c+xsJN2g==}
@@ -2193,6 +2219,12 @@ packages:
       '@aptos-labs/ts-sdk': ^1.11.0
       aptos: ^1.21.0
 
+  '@aptos-labs/wallet-adapter-core@4.14.0':
+    resolution: {integrity: sha512-egP19gQSoqFXRHRZCeqZ/CXmjr0o76ACuMrfDjbwWez+Ii6mFb6sp+n6YGPmfvTFlw34P0bwbVa4zW6Ad3qIWA==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.18.1
+      aptos: ^1.21.0
+
   '@aptos-labs/wallet-adapter-react@2.3.1':
     resolution: {integrity: sha512-zNrtxRaafYCakZDrYYEz0DfVnZ3iYjuY3L+EButad6JPm27jvHhCggWRqmrhabms8WXVsTE2DLN6VT1x2Zt4sg==}
     peerDependencies:
@@ -2200,6 +2232,18 @@ packages:
 
   '@aptos-labs/wallet-standard@0.0.11':
     resolution: {integrity: sha512-8dygyPBby7TaMJjUSyeVP4R1WC9D/FPpX9gVMMLaqTKCXrSbkzhGDxcuwbMZ3ziEwRmx3zz+d6BIJbDhd0hm5g==}
+
+  '@aptos-labs/wallet-standard@0.1.0':
+    resolution: {integrity: sha512-DC4cWuvgXKBVQC+seGQc/nwIZoggZmGOIoN8EtEKHBSBMijwVfgRjD6cXPx8xWaXANyr5d32BGnWvYfMyWk3Pg==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.17.0
+      '@wallet-standard/core': ^1.0.3
+
+  '@aptos-labs/wallet-standard@0.1.0-ms.1':
+    resolution: {integrity: sha512-3aWEmdqMcll8D2lzhBZuYUW1o49TDpqw4QRAkHk00tSC3SwAkuukoW8g/M9lB5nHFxaX7UzuxeaYv8l6/mhJVQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.17.0
+      '@wallet-standard/core': ^1.0.3
 
   '@aptstats/aptos-wallet-framework@0.0.2':
     resolution: {integrity: sha512-HcagZHjKPGopDcs51XSfj2AX8yVaUONixjbGOOX+ydeBkMPFOoiDFeGXCVa3MklNncap1VGE+F/izND5gUDs3A==}
@@ -2236,6 +2280,19 @@ packages:
     resolution: {integrity: sha512-XmxKi/dUodbD0zXW7nTzwOyCtaYAh3UE/fkz+Q5zigoACTkSwRIwqmApeCO9Vy+/g/urtqVGA2Mgt4FNnAOXxw==}
     peerDependencies:
       hardhat: ^2.0.0
+
+  '@atomrigslab/aptos-wallet-adapter@0.1.21':
+    resolution: {integrity: sha512-LwT0OTOaGglctggMcihXLd4mzBFwRoJsR0aeFBHQRfTxZV1agNTgN/PxJl6N13+WYAvzc00j/WByxAmWgonorA==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.9.0
+
+  '@atomrigslab/dekey-web-wallet-provider@1.2.1':
+    resolution: {integrity: sha512-GMEGjARgle9lIRopvxm4uis+sRr/ih26HzBgFbnLsk8+G94Z5dE87EclAIGFQUSAxYj7SmSk6xpx7//qUJDW/A==}
+    engines: {node: '>=12.0.0'}
+
+  '@atomrigslab/providers@1.1.0':
+    resolution: {integrity: sha512-QLYxSCVrxwlN1oZ7vLnZbKZxkbZ6QG77Bj4pmTEowIpTcq7qZdBtU9pn+vqJAso1nnA3+AkmPuE9Jnx7+Jo1zQ==}
+    engines: {node: '>=12.0.0'}
 
   '@aw-web-design/x-default-browser@1.4.126':
     resolution: {integrity: sha512-Xk1sIhyNC/esHGGVjL/niHLowM0csl/kFO5uawBy4IrWwy0o1G8LGt3jP6nmWGz+USxeeqbihAmp/oVZju6wug==}
@@ -3721,6 +3778,14 @@ packages:
       aptos:
         optional: true
 
+  '@blocto/sdk@0.10.3':
+    resolution: {integrity: sha512-9Ot5R3YULaX8IIRGyVYXhoGC01H+kaXCqwfLWzUSKciNYT2GxiF547LEAnT1a7e5HMrJdqjQ+94OsS32fHmq9A==}
+    peerDependencies:
+      aptos: ^1.3.14
+    peerDependenciesMeta:
+      aptos:
+        optional: true
+
   '@changesets/apply-release-plan@6.1.4':
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
 
@@ -4889,6 +4954,26 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  '@identity-connect/api@0.6.3':
+    resolution: {integrity: sha512-wLbGY10+YBtYfEPyA1in5c6TvS2dm7vv8kz1hA+pdSOEOniguBoZOtSXpaIfnjL7t7NBVZNRZ9NaMp4rpgcQHQ==}
+
+  '@identity-connect/crypto@0.2.4':
+    resolution: {integrity: sha512-31C89CHwE+2jSmIzaFEXOHpOLbdwPH5cctynSaQzLX18UsATtiMGoWQA8/LlGkM/7HUrQgbWmB2szcEGzYakCQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+
+  '@identity-connect/dapp-sdk@0.9.2':
+    resolution: {integrity: sha512-jeS8P75G6OprcxzOjZK3xY7x5rSIzQCLSQgR+e1GVhyOYdJ7BLCHnUv3X5uAqZs9owZ4DmkqhkhjQ/tCuzxnlw==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': ^0.1.0
+
+  '@identity-connect/wallet-api@0.1.1':
+    resolution: {integrity: sha512-PGcJQrSnk6PLr/w5D1FKRP/Ip0DH8nvDuWe/5ZfStrGwKhG0L8yDZPbAmDfSOH2mUvVtafmayRYv/FOnqGtLLw==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      aptos: ^1.20.0
+
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
 
@@ -5196,6 +5281,10 @@ packages:
     resolution: {integrity: sha512-yUdzsJK04Ev98Ck4D7lmRNQ8FPioXYhEUZOMS01LXW8qTvPGiRVXmVltj2p4wrLkh0vW7u6nv0mNl5xzC5Qmfg==}
     engines: {node: '>=16.0.0'}
 
+  '@metamask/object-multiplex@1.3.0':
+    resolution: {integrity: sha512-czcQeVYdSNtabd+NcYQnrM69MciiJyd1qvKH8WM2Id3C0ZiUUX5Xa/MK+/VUk633DBhVOwdNzAKIQ33lGyA+eQ==}
+    engines: {node: '>=12.0.0'}
+
   '@metamask/object-multiplex@2.0.0':
     resolution: {integrity: sha512-+ItrieVZie3j2LfYE0QkdW3dsEMfMEp419IGx1zyeLqjRZ14iQUPRO0H6CGgfAAoC0x6k2PfCAGRwJUA9BMrqA==}
     engines: {node: ^16.20 || ^18.16 || >=20}
@@ -5261,11 +5350,29 @@ packages:
     resolution: {integrity: sha512-dbIc3C7alOe0agCuBHM1h71UaEaEqOk2W8rAtEn8QGz4haH2Qq7MoK6i7v2guzvkJVVh79c+QCzIqphC3KvrJg==}
     engines: {node: '>=16.0.0'}
 
+  '@microsoft/fetch-event-source@2.0.1':
+    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
+
   '@microsoft/tsdoc-config@0.16.2':
     resolution: {integrity: sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==}
 
   '@microsoft/tsdoc@0.14.2':
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
+
+  '@mizuwallet-sdk/aptos-wallet-adapter@0.1.5':
+    resolution: {integrity: sha512-t4XY+pqK2Ax7ESOAlMPAm8WqU0ln4oJ/voig8pSJNJL+EUviRiTdMJ6zIoYRo2KNNAx0dFPdQEZEhqWwoTmEvQ==}
+    peerDependencies:
+      '@mizuwallet-sdk/core': '>=1.2.0'
+      '@mizuwallet-sdk/protocol': 0.0.1
+
+  '@mizuwallet-sdk/core@1.3.0':
+    resolution: {integrity: sha512-UjYuPcVasglfUETWL+9GBKHVvO5L3bsKb8yOxO0LOG5WeSiMps0Ya7KnWffi97XOyTtrXo0NGD39ojOcTYQMzQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': '>=1.14.0'
+      graphql-request: '>=7.0.1'
+
+  '@mizuwallet-sdk/protocol@0.0.1':
+    resolution: {integrity: sha512-LTkygWdCL4ao7XvmrUq570waMMA9EKDWV/GH7/NbTndLUQqJDp5hIM08E99FdplpI02mdA89/o6uTtfmd/Pstg==}
 
   '@molt/command@0.9.0':
     resolution: {integrity: sha512-1JI8dAlpqlZoXyKWVQggX7geFNPxBpocHIXQCsnxDjKy+3WX4SGyZVJXuLlqRRrX7FmQCuuMAfx642ovXmPA9g==}
@@ -5298,11 +5405,11 @@ packages:
     resolution: {integrity: sha512-7/dEK/nWQXOkJ70bqb2KyNfSWbNvWqKKq1C8juj+0Mg/AorgD8O5wE3naddK0G+aXuNMqRuc4jlsYHHWHtIzVw==}
     deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/motion
 
-  '@msafe/aptos-wallet-adapter@1.0.14':
-    resolution: {integrity: sha512-6z/PyD7mT3QZ/diUvEysOby85wyMQ35Az39kOxr0kpMartINTSQk6ek3WJFxgneFq9Glaz/OvrLeHphh3+OiSw==}
+  '@msafe/aptos-wallet-adapter@1.1.3':
+    resolution: {integrity: sha512-/5ftbNac9j2Vc6YOqET4IdkhiJnMzuy9LcnGP8ptLWHVuye5P/pAjIpv0A07gOM4/siUJQzlXkBxXdLYF9p8wQ==}
 
-  '@msafe/aptos-wallet@3.0.6':
-    resolution: {integrity: sha512-qKqpTffCY3d+6vRcPioGTfcTeziCRm1HqQSDRST8eKNhOBjb9jfDdy920vNTwKM+guguIlrL/pEws4zO8EWkDQ==}
+  '@msafe/aptos-wallet@6.1.1':
+    resolution: {integrity: sha512-g/2TPRqyChciaw/S69EBr7CgzYJBT1LJulU0nMNnkehJc+ZX/fNN+5JXEuea+a0rXsk/flcbCSfvT2JtS0+/mQ==}
 
   '@mysten/bcs@0.3.0':
     resolution: {integrity: sha512-Me6OkrS+idPq+ZUM1MEcKP9YOTacZKLwo0gf8rfeImQ+G25tqPRhjpccZGOUJGOKh+gojH2vjkWi2TYJv9kNCg==}
@@ -8624,6 +8731,9 @@ packages:
   '@types/chai@4.3.5':
     resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}
 
+  '@types/chrome@0.0.136':
+    resolution: {integrity: sha512-XDEiRhLkMd+SB7Iw3ZUIj/fov3wLd4HyTdLltVszkgl1dBfc3Rb7oPMVZ2Mz2TLqnF7Ow+StbR8E7r9lqpb4DA==}
+
   '@types/cli-progress@3.11.0':
     resolution: {integrity: sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==}
 
@@ -8804,6 +8914,12 @@ packages:
   '@types/express@4.17.17':
     resolution: {integrity: sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==}
 
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
   '@types/find-cache-dir@3.2.1':
     resolution: {integrity: sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==}
 
@@ -8821,6 +8937,9 @@ packages:
 
   '@types/gtag.js@0.0.19':
     resolution: {integrity: sha512-KHoDzrf9rSd0mooKN576PjExpdk/XRrNu4RQnmigsScSTSidwyOUe9kDrHz9UPKjiBrx2QEsSkexbJSgS0j72w==}
+
+  '@types/har-format@1.2.15':
+    resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
 
   '@types/hast@2.3.5':
     resolution: {integrity: sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==}
@@ -12699,6 +12818,9 @@ packages:
   eciesjs@0.3.18:
     resolution: {integrity: sha512-RQhegEtLSyIiGJmFTZfvCTHER/fymipXFVx6OwSRYD6hOuy+6Kjpk0dGvIfP9kxn/smBpxQy71uxpGO406ITCw==}
 
+  ed2curve@0.3.0:
+    resolution: {integrity: sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==}
+
   edge-runtime@2.5.7:
     resolution: {integrity: sha512-gA4qSVP0sNwJlkdQ2nahDPASlSl8twUd17o+JolPa1EtXpLTGzIpOETvodgJwXIxa+zaD8bnAXCdsWrx2PhlVQ==}
     engines: {node: '>=16'}
@@ -13671,6 +13793,10 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  extension-port-stream@2.1.1:
+    resolution: {integrity: sha512-qknp5o5rj2J9CRKfVB8KJr+uXQlrojNZzdESUPhKYLXf97TPcGf6qWWKmpsNNtUyOdzFhab1ON0jzouNxHHvow==}
+    engines: {node: '>=12.0.0'}
+
   extension-port-stream@3.0.0:
     resolution: {integrity: sha512-an2S5quJMiy5bnZKEf6AkfH/7r8CzHvhchU40gxN+OM6HPhe7Z9T1FUychcf2M9PpPOO0Hf7BAEfJkw2TDIBDw==}
     engines: {node: '>=12.0.0'}
@@ -13700,6 +13826,9 @@ packages:
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
+  fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -15792,6 +15921,9 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-base64@3.7.7:
+    resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
+
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
@@ -15906,6 +16038,9 @@ packages:
   json-rpc-error@2.0.0:
     resolution: {integrity: sha512-EwUeWP+KgAZ/xqFpaP6YDAXMtCJi+o/QQpCQFIYyxr01AdADi2y413eM8hSqJcoQym9WMePAJWoaODEJufC4Ug==}
 
+  json-rpc-middleware-stream@3.0.0:
+    resolution: {integrity: sha512-JmZmlehE0xF3swwORpLHny/GvW3MZxCsb2uFNBrn8TOqMqivzCfz232NSDLLOtIQlrPlgyEjiYpyzyOPFOzClw==}
+
   json-rpc-protocol@0.13.2:
     resolution: {integrity: sha512-2InSi+c7wGESmvYcEVS0clctpJCodV7gLqLN1BIIPNK07wokXIwhOL8RQWU4O7oX5adChn6HJGtIU6JaUQ1P/A==}
     engines: {node: '>=4'}
@@ -16004,6 +16139,10 @@ packages:
 
   jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keccak@3.0.3:
     resolution: {integrity: sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==}
@@ -17993,6 +18132,9 @@ packages:
     resolution: {integrity: sha512-3IKLNXclQgkU++2fSi93sQ6BznFuxSLB11HdvZQ6JW/spahf/P1pAHBQEahr20rs0htZW0UDkM1HmA+nZkXKsw==}
     engines: {node: '>=12.0.0'}
 
+  poseidon-lite@0.2.1:
+    resolution: {integrity: sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==}
+
   posix-character-classes@0.1.1:
     resolution: {integrity: sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==}
     engines: {node: '>=0.10.0'}
@@ -18478,6 +18620,9 @@ packages:
 
   postinstall-postinstall@2.1.0:
     resolution: {integrity: sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==}
+
+  postmate@1.5.2:
+    resolution: {integrity: sha512-EHLlEmrUA/hALls49oBrtE7BzDXXjB9EiO4MZpsoO3R/jRuBmD+2WKQuYAbeuVEpTzrPpUTT79z2cz4qaFgPRg==}
 
   preact@10.17.0:
     resolution: {integrity: sha512-SNsI8cbaCcUS5tbv9nlXuCfIXnJ9ysBMWk0WnB6UWwcVA3qZ2O6FxqDFECMAMttvLQcW/HaNZUe2BLidyvrVYw==}
@@ -22241,6 +22386,7 @@ packages:
 
   web3-provider-engine@14.2.1:
     resolution: {integrity: sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==}
+    deprecated: 'This package has been deprecated, see the README for details: https://github.com/MetaMask/web3-provider-engine'
 
   web3-providers-http@1.10.3:
     resolution: {integrity: sha512-6dAgsHR3MxJ0Qyu3QLFlQEelTapVfWNTu5F45FYh8t7Y03T1/o+YAkVxsbY5AdmD+y5bXG/XPJ4q8tjL6MgZHw==}
@@ -22300,8 +22446,15 @@ packages:
   webcrypto-core@1.7.7:
     resolution: {integrity: sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==}
 
+  webextension-polyfill-ts@0.25.0:
+    resolution: {integrity: sha512-ikQhwwHYkpBu00pFaUzIKY26I6L87DeRI+Q6jBT1daZUNuu8dSrg5U9l/ZbqdaQ1M/TTSPKeAa3kolP5liuedw==}
+    deprecated: This project has moved to @types/webextension-polyfill
+
   webextension-polyfill@0.10.0:
     resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}
+
+  webextension-polyfill@0.7.0:
+    resolution: {integrity: sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -22979,7 +23132,36 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
+  '@aptos-connect/wallet-adapter-plugin@1.0.1(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@aptos-labs/wallet-adapter-core': 3.10.0(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3)
+      '@identity-connect/crypto': 0.2.4(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@identity-connect/dapp-sdk': 0.9.2(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      aptos: 1.21.0
+    transitivePeerDependencies:
+      - debug
+
+  '@aptos-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.6.3
+      aptos: 1.21.0
+
+  '@aptos-connect/web-transport@0.0.7(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3)
+      aptos: 1.21.0
+      uuid: 9.0.1
+
   '@aptos-labs/aptos-cli@0.1.2': {}
+
+  '@aptos-labs/aptos-cli@0.2.0': {}
 
   '@aptos-labs/aptos-client@0.0.2':
     dependencies:
@@ -23019,9 +23201,25 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@aptos-labs/wallet-adapter-ant-design@2.2.0(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0)(date-fns@2.30.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@aptos-labs/ts-sdk@1.27.0':
     dependencies:
-      '@aptos-labs/wallet-adapter-react': 2.3.1(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0)(react@18.2.0)
+      '@aptos-labs/aptos-cli': 0.2.0
+      '@aptos-labs/aptos-client': 0.1.0(patch_hash=t5ob2d47ycxvxflm53kwwzv4kq)
+      '@noble/curves': 1.4.0
+      '@noble/hashes': 1.4.0
+      '@scure/bip32': 1.4.0
+      '@scure/bip39': 1.3.0
+      eventemitter3: 5.0.1
+      form-data: 4.0.0
+      js-base64: 3.7.7
+      jwt-decode: 4.0.0
+      poseidon-lite: 0.2.1
+    transitivePeerDependencies:
+      - debug
+
+  '@aptos-labs/wallet-adapter-ant-design@2.2.0(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)(date-fns@2.30.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@aptos-labs/wallet-adapter-react': 2.3.1(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)(react@18.2.0)
       antd: 5.17.0(date-fns@2.30.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -23037,15 +23235,6 @@ snapshots:
     dependencies:
       aptos: 1.21.0
       eventemitter3: 4.0.7
-    transitivePeerDependencies:
-      - debug
-
-  '@aptos-labs/wallet-adapter-core@0.2.3':
-    dependencies:
-      aptos: 1.21.0
-      buffer: 6.0.3
-      eventemitter3: 4.0.7
-      tweetnacl: 1.0.3
     transitivePeerDependencies:
       - debug
 
@@ -23077,9 +23266,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@aptos-labs/wallet-adapter-core@3.10.0(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0)':
+  '@aptos-labs/wallet-adapter-core@3.10.0(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.14.0
+      '@aptos-labs/ts-sdk': 1.27.0
       '@aptos-labs/wallet-standard': 0.0.11
       aptos: 1.21.0
       buffer: 6.0.3
@@ -23088,9 +23277,28 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@aptos-labs/wallet-adapter-react@2.3.1(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0)(react@18.2.0)':
+  '@aptos-labs/wallet-adapter-core@4.14.0(@aptos-labs/ts-sdk@1.27.0)(@mizuwallet-sdk/core@1.3.0(@aptos-labs/ts-sdk@1.27.0)(graphql-request@7.0.1(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
-      '@aptos-labs/wallet-adapter-core': 3.10.0(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0)
+      '@aptos-connect/wallet-adapter-plugin': 1.0.1(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3)
+      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@1.27.0)
+      '@mizuwallet-sdk/aptos-wallet-adapter': 0.1.5(@mizuwallet-sdk/core@1.3.0(@aptos-labs/ts-sdk@1.27.0)(graphql-request@7.0.1(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      aptos: 1.21.0
+      buffer: 6.0.3
+      eventemitter3: 4.0.7
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@mizuwallet-sdk/core'
+      - '@mizuwallet-sdk/protocol'
+      - '@wallet-standard/core'
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@aptos-labs/wallet-adapter-react@2.3.1(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)(react@18.2.0)':
+    dependencies:
+      '@aptos-labs/wallet-adapter-core': 3.10.0(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)
       react: 18.2.0
     transitivePeerDependencies:
       - '@aptos-labs/ts-sdk'
@@ -23103,6 +23311,16 @@ snapshots:
       '@wallet-standard/core': 1.0.3
     transitivePeerDependencies:
       - debug
+
+  '@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@wallet-standard/core': 1.0.3
+
+  '@aptos-labs/wallet-standard@0.1.0-ms.1(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@wallet-standard/core': 1.0.3
 
   '@aptstats/aptos-wallet-framework@0.0.2(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.4))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.4))(@types/babel__core@7.20.5)(aptos@1.21.0)(bufferutil@4.0.8)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@types/node@22.1.0)(typescript@5.4.5))(type-fest@4.18.3)(typescript@5.4.5)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.16)':
     dependencies:
@@ -23294,6 +23512,33 @@ snapshots:
       '@types/ms': 0.7.31
       hardhat: 2.20.1(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.14.14)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)
       ms: 2.1.2
+
+  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.27.0)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@aptos-labs/wallet-standard': 0.0.11
+      '@atomrigslab/dekey-web-wallet-provider': 1.2.1
+    transitivePeerDependencies:
+      - debug
+
+  '@atomrigslab/dekey-web-wallet-provider@1.2.1':
+    dependencies:
+      '@atomrigslab/providers': 1.1.0
+
+  '@atomrigslab/providers@1.1.0':
+    dependencies:
+      '@metamask/object-multiplex': 1.3.0
+      '@metamask/safe-event-emitter': 2.0.0
+      '@types/chrome': 0.0.136
+      detect-browser: 5.3.0
+      eth-rpc-errors: 4.0.3
+      extension-port-stream: 2.1.1
+      fast-deep-equal: 2.0.1
+      is-stream: 2.0.1
+      json-rpc-engine: 6.1.0
+      json-rpc-middleware-stream: 3.0.0
+      pump: 3.0.0
+      webextension-polyfill-ts: 0.25.0
 
   '@aw-web-design/x-default-browser@1.4.126':
     dependencies:
@@ -25653,6 +25898,18 @@ snapshots:
       - debug
       - utf-8-validate
 
+  '@blocto/sdk@0.10.3(aptos@1.21.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      buffer: 6.0.3
+      eip1193-provider: 1.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      js-sha3: 0.8.0
+    optionalDependencies:
+      aptos: 1.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
   '@changesets/apply-release-plan@6.1.4':
     dependencies:
       '@babel/runtime': 7.24.5
@@ -26989,6 +27246,39 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@identity-connect/api@0.6.3': {}
+
+  '@identity-connect/crypto@0.2.4(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@noble/hashes': 1.4.0
+      ed2curve: 0.3.0
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@aptos-labs/wallet-standard'
+      - aptos
+
+  '@identity-connect/dapp-sdk@0.9.2(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-connect/web-transport': 0.0.7(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.6.3
+      '@identity-connect/crypto': 0.2.4(@aptos-labs/ts-sdk@1.27.0)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@identity-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)
+      axios: 1.6.8
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - aptos
+      - debug
+
+  '@identity-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.0
+      aptos: 1.21.0
+
   '@ioredis/commands@1.2.0': {}
 
   '@isaacs/cliui@8.0.2':
@@ -27604,6 +27894,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@metamask/object-multiplex@1.3.0':
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
+      readable-stream: 2.3.8
+
   '@metamask/object-multiplex@2.0.0':
     dependencies:
       once: 1.4.0
@@ -27843,6 +28139,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@microsoft/fetch-event-source@2.0.1': {}
+
   '@microsoft/tsdoc-config@0.16.2':
     dependencies:
       '@microsoft/tsdoc': 0.14.2
@@ -27851,6 +28149,36 @@ snapshots:
       resolve: 1.19.0
 
   '@microsoft/tsdoc@0.14.2': {}
+
+  '@mizuwallet-sdk/aptos-wallet-adapter@0.1.5(@mizuwallet-sdk/core@1.3.0(@aptos-labs/ts-sdk@1.27.0)(graphql-request@7.0.1(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@aptos-labs/wallet-standard': 0.1.0-ms.1(@aptos-labs/ts-sdk@1.27.0)(@wallet-standard/core@1.0.3)
+      '@blocto/sdk': 0.10.3(aptos@1.21.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@mizuwallet-sdk/core': 1.3.0(@aptos-labs/ts-sdk@1.27.0)(graphql-request@7.0.1(graphql@16.6.0))
+      '@mizuwallet-sdk/protocol': 0.0.1
+      '@msafe/aptos-wallet': 6.1.1
+      buffer: 6.0.3
+      postmate: 1.5.2
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
+      - aptos
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@mizuwallet-sdk/core@1.3.0(@aptos-labs/ts-sdk@1.27.0)(graphql-request@7.0.1(graphql@16.6.0))':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.0
+      buffer: 6.0.3
+      graphql-request: 7.0.1(graphql@16.6.0)
+      jwt-decode: 4.0.0
+
+  '@mizuwallet-sdk/protocol@0.0.1':
+    dependencies:
+      '@microsoft/fetch-event-source': 2.0.1
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.15.1
 
   '@molt/command@0.9.0':
     dependencies:
@@ -27915,15 +28243,21 @@ snapshots:
       '@motionone/dom': 10.16.2
       tslib: 2.6.3
 
-  '@msafe/aptos-wallet-adapter@1.0.14(patch_hash=ftc7erqshkl7atv4bibkhe3fk4)':
+  '@msafe/aptos-wallet-adapter@1.1.3(patch_hash=ztcfam72g3tcfvfy23kjubyhqa)(@aptos-labs/ts-sdk@1.27.0)(@mizuwallet-sdk/core@1.3.0(@aptos-labs/ts-sdk@1.27.0)(graphql-request@7.0.1(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
-      '@aptos-labs/wallet-adapter-core': 0.2.3
-      '@msafe/aptos-wallet': 3.0.6
+      '@aptos-labs/wallet-adapter-core': 4.14.0(@aptos-labs/ts-sdk@1.27.0)(@mizuwallet-sdk/core@1.3.0(@aptos-labs/ts-sdk@1.27.0)(graphql-request@7.0.1(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@msafe/aptos-wallet': 6.1.1
       aptos: 1.21.0
     transitivePeerDependencies:
+      - '@aptos-labs/ts-sdk'
+      - '@mizuwallet-sdk/core'
+      - '@mizuwallet-sdk/protocol'
+      - '@wallet-standard/core'
+      - bufferutil
       - debug
+      - utf-8-validate
 
-  '@msafe/aptos-wallet@3.0.6':
+  '@msafe/aptos-wallet@6.1.1':
     dependencies:
       buffer: 6.0.3
       json-rpc-protocol: 0.13.2
@@ -32925,6 +33259,11 @@ snapshots:
 
   '@types/chai@4.3.5': {}
 
+  '@types/chrome@0.0.136':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.15
+
   '@types/cli-progress@3.11.0':
     dependencies:
       '@types/node': 20.14.14
@@ -33151,6 +33490,12 @@ snapshots:
       '@types/qs': 6.9.8
       '@types/serve-static': 1.15.2
 
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
   '@types/find-cache-dir@3.2.1': {}
 
   '@types/form-data@0.0.33':
@@ -33169,6 +33514,8 @@ snapshots:
       '@types/node': 22.1.0
 
   '@types/gtag.js@0.0.19': {}
+
+  '@types/har-format@1.2.15': {}
 
   '@types/hast@2.3.5':
     dependencies:
@@ -38918,6 +39265,10 @@ snapshots:
       futoin-hkdf: 1.5.3
       secp256k1: 5.0.0
 
+  ed2curve@0.3.0:
+    dependencies:
+      tweetnacl: 1.0.3
+
   edge-runtime@2.5.7:
     dependencies:
       '@edge-runtime/format': 2.2.0
@@ -40724,6 +41075,10 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
+  extension-port-stream@2.1.1:
+    dependencies:
+      webextension-polyfill: 0.10.0
+
   extension-port-stream@3.0.0:
     dependencies:
       readable-stream: 3.6.2
@@ -40766,6 +41121,8 @@ snapshots:
       checkpoint-store: 1.1.0
 
   fast-decode-uri-component@1.0.1: {}
+
+  fast-deep-equal@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -43831,6 +44188,8 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-base64@3.7.7: {}
+
   js-cookie@3.0.5: {}
 
   js-sdsl@4.4.2: {}
@@ -44025,6 +44384,11 @@ snapshots:
     dependencies:
       inherits: 2.0.4
 
+  json-rpc-middleware-stream@3.0.0:
+    dependencies:
+      '@metamask/safe-event-emitter': 2.0.0
+      readable-stream: 2.3.8
+
   json-rpc-protocol@0.13.2:
     dependencies:
       make-error: 1.3.6
@@ -44130,6 +44494,8 @@ snapshots:
     dependencies:
       jwa: 1.4.1
       safe-buffer: 5.2.1
+
+  jwt-decode@4.0.0: {}
 
   keccak@3.0.3:
     dependencies:
@@ -46533,10 +46899,10 @@ snapshots:
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
-  petra-plugin-wallet-adapter@0.4.5(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0):
+  petra-plugin-wallet-adapter@0.4.5(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0):
     dependencies:
-      '@aptos-labs/ts-sdk': 1.14.0
-      '@aptos-labs/wallet-adapter-core': 3.10.0(@aptos-labs/ts-sdk@1.14.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.0
+      '@aptos-labs/wallet-adapter-core': 3.10.0(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0)
       aptos: 1.21.0
     transitivePeerDependencies:
       - debug
@@ -46651,6 +47017,8 @@ snapshots:
       '@babel/runtime': 7.22.10
 
   pony-cause@2.1.10: {}
+
+  poseidon-lite@0.2.1: {}
 
   posix-character-classes@0.1.1: {}
 
@@ -47166,6 +47534,8 @@ snapshots:
       - debug
 
   postinstall-postinstall@2.1.0: {}
+
+  postmate@1.5.2: {}
 
   preact@10.17.0: {}
 
@@ -52588,7 +52958,13 @@ snapshots:
       pvtsutils: 1.3.4
       tslib: 2.6.3
 
+  webextension-polyfill-ts@0.25.0:
+    dependencies:
+      webextension-polyfill: 0.7.0
+
   webextension-polyfill@0.10.0: {}
+
+  webextension-polyfill@0.7.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `@msafe/aptos-wallet-adapter` package to version 1.1.3, removes unnecessary logging, and refactors wallet provider initialization.

### Detailed summary
- Updated `@msafe/aptos-wallet-adapter` to v1.1.3
- Removed unnecessary logging in `MSafeWalletAdapter`
- Refactored wallet provider initialization in `Providers` function

> The following files were skipped due to too many changes: `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->