### PR TITLE
fix(jobs/pool): steer job, fix empty payload

### DIFF
--- a/jobs/pool/src/steer.ts
+++ b/jobs/pool/src/steer.ts
@@ -235,12 +235,12 @@ function transform(
         ? StrategyTypes[vault.payload.strategyConfigData.name]
         : null
 
-      if (!strategyType) {
+      if (!strategyType || !vault.payload) {
         return []
       }
 
       let lastAdjustmentTimestamp = Math.floor(
-        vault.payload!.strategyConfigData.epochStart,
+        vault.payload.strategyConfigData.epochStart,
       )
       if (lastAdjustmentTimestamp > 1000000000000) {
         lastAdjustmentTimestamp = Math.floor(lastAdjustmentTimestamp / 1000)
@@ -291,7 +291,7 @@ function transform(
           : TickMath.MAX_TICK,
 
         adjustmentFrequency: Number(
-          vault.payload?.strategyConfigData.epochLength ?? 0
+          vault.payload.strategyConfigData.epochLength
         ),
         lastAdjustmentTimestamp,
 

--- a/jobs/pool/src/steer.ts
+++ b/jobs/pool/src/steer.ts
@@ -291,7 +291,7 @@ function transform(
           : TickMath.MAX_TICK,
 
         adjustmentFrequency: Number(
-          vault.payload.strategyConfigData.epochLength
+          vault.payload.strategyConfigData.epochLength,
         ),
         lastAdjustmentTimestamp,
 

--- a/jobs/pool/src/steer.ts
+++ b/jobs/pool/src/steer.ts
@@ -278,7 +278,7 @@ function transform(
 
         strategy: strategyType,
         payloadHash: vault.payloadIpfs,
-        description: vault.payload!.strategyConfigData.description,
+        description: '', // not used
         state: 'PendingThreshold', // unused
 
         performanceFee: 0.15, // currently constant
@@ -291,7 +291,7 @@ function transform(
           : TickMath.MAX_TICK,
 
         adjustmentFrequency: Number(
-          vault.payload!.strategyConfigData.epochLength,
+          vault.payload?.strategyConfigData.epochLength ?? 0
         ),
         lastAdjustmentTimestamp,
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `steer.ts` file in the `jobs/pool/src` directory to handle cases where `vault.payload` is not defined.

### Detailed summary
- Added a check for `!vault.payload` in the condition
- Removed the usage of `vault.payload!.strategyConfigData.description`
- Set `description` to an empty string
- Updated `adjustmentFrequency` to use `vault.payload.strategyConfigData.epochLength`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->