### PR TITLE
fix: manage v2 position links

### DIFF
--- a/apps/web/src/ui/pool/ManageV2LiquidityCard.tsx
+++ b/apps/web/src/ui/pool/ManageV2LiquidityCard.tsx
@@ -17,6 +17,7 @@ import Link from 'next/link'
 import { FC } from 'react'
 
 import { V2Pool } from '@sushiswap/graph-client/data-api'
+import { ChainKey } from 'sushi/chain'
 import { AddSectionLegacy } from './AddSectionLegacy'
 import { AddSectionStake } from './AddSectionStake'
 import { PoolPositionProvider } from './PoolPositionProvider'
@@ -50,7 +51,10 @@ export const ManageV2LiquidityCard: FC<ManageV2LiquidityCardProps> = ({
       >
         <CardContent>
           <TabsList className="!flex">
-            <Link href={`/pool/${pool.id}/add`} className="flex flex-1">
+            <Link
+              href={`/${ChainKey[pool.chainId]}/pool/v2/${pool.address}/add`}
+              className="flex flex-1"
+            >
               <TabsTrigger
                 testdata-id="add-tab"
                 value="add"
@@ -59,7 +63,10 @@ export const ManageV2LiquidityCard: FC<ManageV2LiquidityCardProps> = ({
                 Add
               </TabsTrigger>
             </Link>
-            <Link href={`/pool/${pool.id}/remove`} className="flex flex-1">
+            <Link
+              href={`/${ChainKey[pool.chainId]}/pool/v2/${pool.address}/remove`}
+              className="flex flex-1"
+            >
               <TabsTrigger
                 testdata-id="remove-tab"
                 value="remove"
@@ -69,7 +76,12 @@ export const ManageV2LiquidityCard: FC<ManageV2LiquidityCardProps> = ({
               </TabsTrigger>
             </Link>
             {isFarm ? (
-              <Link href={`/pool/${pool.id}/stake`} className="flex flex-1">
+              <Link
+                href={`/${ChainKey[pool.chainId]}/pool/v2/${
+                  pool.address
+                }/stake`}
+                className="flex flex-1"
+              >
                 <TabsTrigger
                   testdata-id="stake-tab"
                   value="stake"
@@ -89,7 +101,12 @@ export const ManageV2LiquidityCard: FC<ManageV2LiquidityCardProps> = ({
               </TabsTrigger>
             )}
             {isFarm ? (
-              <Link href={`/pool/${pool.id}/unstake`} className="flex flex-1">
+              <Link
+                href={`/${ChainKey[pool.chainId]}/pool/v2/${
+                  pool.address
+                }/unstake`}
+                className="flex flex-1"
+              >
                 <TabsTrigger
                   testdata-id="unstake-tab"
                   value="unstake"

--- a/apps/web/src/ui/pool/PoolButtons.tsx
+++ b/apps/web/src/ui/pool/PoolButtons.tsx
@@ -6,6 +6,7 @@ import { ZERO } from 'sushi/math'
 import { getAddress } from 'viem'
 
 import { V2Pool } from '@sushiswap/graph-client/data-api'
+import { ChainKey } from 'sushi/chain'
 import { usePoolPosition } from './PoolPositionProvider'
 import { usePoolPositionStaked } from './PoolPositionStakedProvider'
 
@@ -29,10 +30,18 @@ export const PoolButtons: FC<PoolButtonsProps> = ({ pool }) => {
           variant="secondary"
           fullWidth
         >
-          <LinkInternal href={`/pool/${pool.id}/remove`}>Withdraw</LinkInternal>
+          <LinkInternal
+            href={`/${ChainKey[pool.chainId]}/pool/v2/${pool.address}/remove`}
+          >
+            Withdraw
+          </LinkInternal>
         </Button>
         <Button asChild size="lg" fullWidth>
-          <LinkInternal href={`/pool/${pool.id}/add`}>Deposit</LinkInternal>
+          <LinkInternal
+            href={`/${ChainKey[pool.chainId]}/pool/v2/${pool.address}/add`}
+          >
+            Deposit
+          </LinkInternal>
         </Button>
       </div>
       <Button asChild className="col-span-2" size="lg" variant="secondary">

--- a/apps/web/src/ui/pool/PositionCard.tsx
+++ b/apps/web/src/ui/pool/PositionCard.tsx
@@ -11,7 +11,7 @@ import {
 } from '@sushiswap/ui'
 import React, { FC } from 'react'
 import { useTokensFromPool } from 'src/lib/hooks'
-import { Chain } from 'sushi/chain'
+import { Chain, ChainKey } from 'sushi/chain'
 import { formatPercent, formatUSD } from 'sushi/format'
 
 interface PositionCard {
@@ -88,7 +88,11 @@ export const PositionCard: FC<PositionCard> = ({ position }) => {
       </div>
       <div className="absolute bottom-7 right-7">
         <Button size="sm" asChild>
-          <LinkInternal href={`/pools/${position.pool.id}/migrate`}>
+          <LinkInternal
+            href={`/${ChainKey[position.pool.chainId]}/pool/v2/${
+              position.pool.address
+            }/migrate`}
+          >
             Migrate
           </LinkInternal>
         </Button>

--- a/apps/web/src/ui/pool/PositionQuickHoverTooltip.tsx
+++ b/apps/web/src/ui/pool/PositionQuickHoverTooltip.tsx
@@ -5,7 +5,7 @@ import { Currency } from '@sushiswap/ui'
 import { LinkInternal } from '@sushiswap/ui'
 import { List } from '@sushiswap/ui'
 import React, { FC, useCallback } from 'react'
-import { ChainId } from 'sushi/chain'
+import { ChainId, ChainKey } from 'sushi/chain'
 import { formatPercent, formatUSD } from 'sushi/format'
 import { ZERO } from 'sushi/math'
 import { useAccount, useSwitchChain } from 'wagmi'
@@ -80,10 +80,16 @@ const _PositionQuickHoverTooltip: FC<PositionQuickHoverTooltipProps> = ({
       </div>
       <div className="flex flex-wrap gap-2">
         <Button icon={PlusIcon} asChild size="sm" variant="secondary">
-          <LinkInternal href={`/pools/${pool.id}/add`}>Deposit</LinkInternal>
+          <LinkInternal
+            href={`/${ChainKey[pool.chainId]}/pool/v2/${pool.address}/add`}
+          >
+            Deposit
+          </LinkInternal>
         </Button>
         <Button icon={MinusIcon} asChild size="sm" variant="secondary">
-          <LinkInternal href={`/pools/${pool.id}/remove`}>
+          <LinkInternal
+            href={`/${ChainKey[pool.chainId]}/pool/v2/${pool.address}/remove`}
+          >
             Withdraw
           </LinkInternal>
         </Button>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update various components to use `ChainKey` from `sushi/chain` for dynamic URL generation.

### Detailed summary
- Updated links in `PositionCard`, `PoolButtons`, `PositionQuickHoverTooltip`, and `ManageV2LiquidityCard` components to include `ChainKey` for dynamic URL generation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->