### PR TITLE
feat: display chain name on explore table & charts

### DIFF
--- a/apps/web/src/app/(evm)/[chainId]/explore/pools/page.tsx
+++ b/apps/web/src/app/(evm)/[chainId]/explore/pools/page.tsx
@@ -20,7 +20,7 @@ const _PoolsTable: FC<{ chainId: ChainId }> = async ({ chainId }) => {
     },
   )()
 
-  return <PoolsTable pools={pools} />
+  return <PoolsTable chainId={chainId} pools={pools} />
 }
 
 export default async function PoolsPage({
@@ -39,7 +39,7 @@ export default async function PoolsPage({
         <TableFiltersSmartPoolsOnly />
         <TableFiltersResetButton />
       </div>
-      <Suspense fallback={<PoolsTable isLoading={true} />}>
+      <Suspense fallback={<PoolsTable chainId={chainId} isLoading={true} />}>
         <_PoolsTable chainId={chainId} />
       </Suspense>
     </Container>

--- a/apps/web/src/ui/explore/global-stats-charts.tsx
+++ b/apps/web/src/ui/explore/global-stats-charts.tsx
@@ -8,7 +8,7 @@ import { VolumeChart } from './volume-chart'
 
 export const GlobalStatsCharts: FC<{ chainId: ChainId }> = ({ chainId }) => {
   return (
-    <Suspense fallback={<GlobalStatsLoading />}>
+    <Suspense fallback={<GlobalStatsLoading chainId={chainId} />}>
       <_GlobalStatsCharts chainId={chainId} />
     </Suspense>
   )
@@ -27,11 +27,11 @@ const _GlobalStatsCharts: FC<{ chainId: ChainId }> = async ({ chainId }) => {
   )()
 
   return !dayBuckets.v2.length && !dayBuckets.v3.length ? (
-    <GlobalStatsLoading />
+    <GlobalStatsLoading chainId={chainId} />
   ) : (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-20 gap-y-10">
-      <TVLChart data={dayBuckets} />
-      <VolumeChart data={dayBuckets} />
+      <TVLChart chainId={chainId} data={dayBuckets} />
+      <VolumeChart chainId={chainId} data={dayBuckets} />
     </div>
   )
 }

--- a/apps/web/src/ui/explore/global-stats-loading.tsx
+++ b/apps/web/src/ui/explore/global-stats-loading.tsx
@@ -1,11 +1,15 @@
 import { SkeletonChart, SkeletonText } from '@sushiswap/ui'
+import { FC } from 'react'
+import { Chain, ChainId } from 'sushi/chain'
 
-export const GlobalStatsLoading = () => {
+export const GlobalStatsLoading: FC<{ chainId: ChainId }> = ({ chainId }) => {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-20 gap-y-10">
       <div>
         <div className="flex flex-col gap-3">
-          <span className="text-sm text-muted-foreground">TVL</span>
+          <span className="text-sm text-muted-foreground">
+            {Chain.from(chainId)?.name} TVL
+          </span>
           <SkeletonText fontSize="3xl" className="!w-36" />
           <SkeletonText fontSize="sm" className="!w-40" />
         </div>
@@ -13,7 +17,9 @@ export const GlobalStatsLoading = () => {
       </div>
       <div>
         <div className="flex flex-col gap-3">
-          <span className="text-sm text-muted-foreground">Volume</span>
+          <span className="text-sm text-muted-foreground">
+            {Chain.from(chainId)?.name} Volume
+          </span>
           <SkeletonText fontSize="3xl" className="!w-36" />
           <SkeletonText fontSize="sm" className="!w-40" />
         </div>

--- a/apps/web/src/ui/explore/tvl-chart.tsx
+++ b/apps/web/src/ui/explore/tvl-chart.tsx
@@ -7,9 +7,15 @@ import { EChartsOption } from 'echarts-for-react/lib/types'
 import echarts from 'echarts/lib/echarts'
 import { useTheme } from 'next-themes'
 import { FC, useCallback, useMemo } from 'react'
+import { Chain, ChainId } from 'sushi/chain'
 import { formatUSD } from 'sushi/format'
 
-export const TVLChart: FC<{ data: AnalyticsDayBuckets }> = ({ data }) => {
+interface TVLChart {
+  data: AnalyticsDayBuckets
+  chainId: ChainId
+}
+
+export const TVLChart: FC<TVLChart> = ({ data, chainId }) => {
   const { resolvedTheme } = useTheme()
 
   const [v2, v3, combinedTVL, currentDate] = useMemo(() => {
@@ -176,7 +182,9 @@ export const TVLChart: FC<{ data: AnalyticsDayBuckets }> = ({ data }) => {
   return (
     <div>
       <div className="flex flex-col gap-3">
-        <span className="text-muted-foreground text-sm">TVL</span>
+        <span className="text-muted-foreground text-sm">
+          {Chain.from(chainId)?.name} TVL
+        </span>
         <div className="flex justify-between">
           <div className="flex flex-col gap-3">
             <div className="text-3xl font-medium">

--- a/apps/web/src/ui/explore/volume-chart.tsx
+++ b/apps/web/src/ui/explore/volume-chart.tsx
@@ -7,9 +7,15 @@ import { EChartsOption } from 'echarts-for-react/lib/types'
 import echarts from 'echarts/lib/echarts'
 import { useTheme } from 'next-themes'
 import { FC, useCallback, useMemo } from 'react'
+import { Chain, ChainId } from 'sushi/chain'
 import { formatUSD } from 'sushi/format'
 
-export const VolumeChart: FC<{ data: AnalyticsDayBuckets }> = ({ data }) => {
+interface VolumeChart {
+  data: AnalyticsDayBuckets
+  chainId: ChainId
+}
+
+export const VolumeChart: FC<VolumeChart> = ({ data, chainId }) => {
   const { resolvedTheme } = useTheme()
 
   const [v2, v3, totalVolume] = useMemo(() => {
@@ -142,7 +148,9 @@ export const VolumeChart: FC<{ data: AnalyticsDayBuckets }> = ({ data }) => {
   return (
     <div>
       <div className="flex flex-col gap-3">
-        <span className="text-muted-foreground text-sm">Volume</span>
+        <span className="text-muted-foreground text-sm">
+          {Chain.from(chainId)?.name} Volume
+        </span>
         <div className="flex justify-between">
           <div className="flex flex-col gap-3">
             <div className="text-3xl font-medium">

--- a/apps/web/src/ui/pool/PoolsTable.tsx
+++ b/apps/web/src/ui/pool/PoolsTable.tsx
@@ -40,7 +40,7 @@ import { NetworkIcon } from '@sushiswap/ui/icons/NetworkIcon'
 import { ColumnDef, Row, SortingState, TableState } from '@tanstack/react-table'
 import Link from 'next/link'
 import React, { FC, ReactNode, useCallback, useMemo, useState } from 'react'
-import { ChainId, ChainKey } from 'sushi/chain'
+import { Chain, ChainId, ChainKey } from 'sushi/chain'
 import { isAngleEnabledChainId } from 'sushi/config'
 import { Native, Token } from 'sushi/currency'
 import { formatNumber, formatUSD } from 'sushi/format'
@@ -414,12 +414,14 @@ const COLUMNS = [
 ] as ColumnDef<TopPools[number], unknown>[]
 
 interface PoolsTableProps {
+  chainId: ChainId
   pools?: TopPools
   isLoading?: boolean
   onRowClick?(row: TopPools[number]): void
 }
 
 export const PoolsTable: FC<PoolsTableProps> = ({
+  chainId,
   pools,
   isLoading = false,
   onRowClick,
@@ -487,12 +489,15 @@ export const PoolsTable: FC<PoolsTableProps> = ({
     <Card>
       <CardHeader>
         <CardTitle>
-          Pools{' '}
-          {data.length ? (
-            <span className="text-gray-400 dark:text-slate-500">
-              ({data.length})
-            </span>
-          ) : null}
+          {isLoading ? (
+            <div className="!w-72 !h-[18px]">
+              <SkeletonText />
+            </div>
+          ) : (
+            <span>{`Top ${data.length} Pools on ${
+              Chain.from(chainId)?.name
+            }`}</span>
+          )}
         </CardTitle>
       </CardHeader>
       <DataTable


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the `chainId` prop to various components in the `explore` section to display data specific to a blockchain.

### Detailed summary
- Added `chainId` prop to `PoolsTable`, `GlobalStatsCharts`, `TVLChart`, `VolumeChart`, and `GlobalStatsLoading`
- Updated text content to include blockchain name
- Modified data rendering based on blockchain ID

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->