### PR TITLE
chore: add timeframe to v3 pool stats

### DIFF
--- a/apps/web/src/ui/pool/PoolPageV3.tsx
+++ b/apps/web/src/ui/pool/PoolPageV3.tsx
@@ -104,7 +104,7 @@ const Pool: FC<{ pool: V3Pool }> = ({ pool }) => {
               <CardContent>
                 <div className="grid grid-cols-1 gap-3">
                   <div>
-                    <CardLabel>Volume</CardLabel>
+                    <CardLabel>Volume (24h)</CardLabel>
                     {poolStats ? (
                       <div className="text-xl font-semibold">
                         {formatUSD(poolStats.volumeUSD1d ?? 0)}{' '}
@@ -125,7 +125,7 @@ const Pool: FC<{ pool: V3Pool }> = ({ pool }) => {
                     )}
                   </div>
                   <div>
-                    <CardLabel>Fees</CardLabel>
+                    <CardLabel>Fees (24h)</CardLabel>
                     {poolStats ? (
                       <div className="text-xl font-semibold">
                         {formatUSD(poolStats.feesUSD1d ?? 0)}{' '}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the labels in `PoolPageV3.tsx` to include the time period (24h) for Volume and Fees.

### Detailed summary
- Updated label "Volume" to "Volume (24h)"
- Updated label "Fees" to "Fees (24h)"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->