### PR TITLE
chore: add /pool, /pools, /explore redirects

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -79,11 +79,6 @@ const nextConfig = bundleAnalyzer({
         destination: '/pool/:path*',
       },
       {
-        source: '/pools/:path*',
-        permanent: true,
-        destination: '/pool/:path*',
-      },
-      {
         source: '/pool/:path*/positions',
         permanent: true,
         destination: '/pool/:path*',


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update middleware logic in `middleware.ts` to handle routing based on certain pathnames and chain IDs.

### Detailed summary
- Added imports for `NextRequest`, `NextResponse`, `ChainKey`, and `isSushiSwapChainId`
- Updated middleware logic to handle specific pathnames and chain IDs for redirection

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->