### PR TITLE
chore: update swap api toggle copy

### DIFF
--- a/apps/web/src/ui/swap/simple/swap-api-setting.tsx
+++ b/apps/web/src/ui/swap/simple/swap-api-setting.tsx
@@ -22,8 +22,9 @@ export const SwapApi: FC = () => {
               className: 'text-sm',
             })}
           >
-            Switch to the client for trade discovery by deactivating the Swap
-            API.
+            {forceClient
+              ? 'Route your swap using the SushiSwap Client which calculates the route directly through your local client service.'
+              : 'Route your swap using the SushiSwap API to access all our supported third-party liquidity sources for the best swap rate.'}
           </span>
         </div>
         <Switch


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the swap route options message in the UI based on whether the swap is forced to use the client or the API.

### Detailed summary
- Updated message for swap route options based on `forceClient` variable
- Message now distinguishes between using SushiSwap Client or API for swap routing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->