### PR TITLE
push/pull cache and pruning

### DIFF
--- a/Dockerfile.extractor-init
+++ b/Dockerfile.extractor-init
@@ -1,0 +1,9 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY scripts/prune.ts prune.ts
+
+RUN npm i -g tsx@latest
+
+CMD npx tsx prune.ts

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,17 @@
 steps:
+
+# Build and tag using commit sha
+- name: 'gcr.io/cloud-builders/docker'
+  id: extractor-init-build
+  args: ['build', '-t', 'us-east4-docker.pkg.dev/${PROJECT_ID}/docker/extractor-init:${COMMIT_SHA}', '-f', 'Dockerfile.extractor-init', '.']
+  waitFor: ['-']
+
+# Push the container image
+- name: 'gcr.io/cloud-builders/docker'
+  id: extractor-init-push
+  args: ['push', 'us-east4-docker.pkg.dev/${PROJECT_ID}/docker/extractor-init:${COMMIT_SHA}']
+  waitFor: ['extractor-init-build']
+
 # Build and tag using commit sha
 - name: 'gcr.io/cloud-builders/docker'
   id: extractor-build

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -160,3 +160,9 @@ kubectl rollout restart statefulset/extractor-1
 ### Restart EVERYTHING
 
 kubectl rollout restart deployment -n default
+
+### Setting up service account for extractor
+
+kubectl create serviceaccount extractor --namespace default
+
+gcloud storage buckets add-iam-policy-binding gs://extractor-cache --member "principal://iam.googleapis.com/projects/104609065325/locations/global/workloadIdentityPools/sushi-api-414412.svc.id.goog/subject/ns/default/sa/extractor" --role "roles/storage.admin"

--- a/k8s/charts/extractor/templates/extractor-deployment.yaml
+++ b/k8s/charts/extractor/templates/extractor-deployment.yaml
@@ -21,6 +21,19 @@ spec:
             claimName: extractor-pvc
       serviceAccountName: extractor
       containers:
+        {{ if eq .Values.pruning "true" }}
+        - name: "extractor-init"
+          image: "extractor-init"
+          volumeMounts:
+            - mountPath: "/app/cache"
+              subPath: "{{ .id }}"
+              name: extractor-pv
+          env:
+            - name: CHAIN_ID
+              value: "{{ .id }}"
+            - name: CACHE_DIR
+              value: "/app/cache"
+        {{ end }}
         - name: extractor
           image: extractor
           ports:

--- a/k8s/charts/staging-values.yaml
+++ b/k8s/charts/staging-values.yaml
@@ -1,0 +1,1 @@
+pruning: true

--- a/k8s/extractor-service-account.yaml
+++ b/k8s/extractor-service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: extractor

--- a/k8s/pull-cache.yaml
+++ b/k8s/pull-cache.yaml
@@ -1,9 +1,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: push-cache
+  name: pull-cache
 spec:
-  schedule: "0 0 * * *" # run every day at midnight
+  schedule: "0 1 * * *" # run every day at 1am
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 100
   suspend: false
@@ -15,15 +15,15 @@ spec:
         spec:
           serviceAccountName: extractor
           containers:
-          - name: push-cache
+          - name: pull-cache
             image: google/cloud-sdk
             args:
             - gsutil
             - -m
             - cp
             - -r
-            - cache/*
-            - gs://extractor-cache
+            - gs://extractor-cache/*
+            - cache
             volumeMounts:
             - mountPath: /cache
               name: extractor-pv

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jest": "29.7.0",
     "sort-package-json": "2.6.0",
     "ts-jest": "29.1.1",
+    "tsx": "^4.19.0",
     "turbo": "2.0.5"
   },
   "packageManager": "pnpm@9.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       ts-jest:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.14)(typescript@5.5.4)))(typescript@5.5.4)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.19.0
       turbo:
         specifier: 2.0.5
         version: 2.0.5
@@ -4077,6 +4080,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.23.1':
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.17.19':
     resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
     engines: {node: '>=12'}
@@ -4098,6 +4107,12 @@ packages:
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.23.1':
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -4125,6 +4140,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.23.1':
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.17.19':
     resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
     engines: {node: '>=12'}
@@ -4146,6 +4167,12 @@ packages:
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.23.1':
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -4173,6 +4200,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.23.1':
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.17.19':
     resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
     engines: {node: '>=12'}
@@ -4194,6 +4227,12 @@ packages:
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.23.1':
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -4221,6 +4260,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.23.1':
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.17.19':
     resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
     engines: {node: '>=12'}
@@ -4242,6 +4287,12 @@ packages:
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.23.1':
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -4269,6 +4320,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.23.1':
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.17.19':
     resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
     engines: {node: '>=12'}
@@ -4290,6 +4347,12 @@ packages:
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.23.1':
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -4317,6 +4380,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.23.1':
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.17.19':
     resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
     engines: {node: '>=12'}
@@ -4338,6 +4407,12 @@ packages:
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.23.1':
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -4365,6 +4440,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.23.1':
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.17.19':
     resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
     engines: {node: '>=12'}
@@ -4386,6 +4467,12 @@ packages:
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.23.1':
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -4413,6 +4500,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.23.1':
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.17.19':
     resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
     engines: {node: '>=12'}
@@ -4434,6 +4527,12 @@ packages:
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.23.1':
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -4461,6 +4560,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.23.1':
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-x64@0.17.19':
     resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
     engines: {node: '>=12'}
@@ -4485,6 +4590,18 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.17.19':
     resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
     engines: {node: '>=12'}
@@ -4506,6 +4623,12 @@ packages:
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -4533,6 +4656,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.23.1':
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.17.19':
     resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
     engines: {node: '>=12'}
@@ -4554,6 +4683,12 @@ packages:
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.23.1':
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -4581,6 +4716,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.23.1':
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.17.19':
     resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
     engines: {node: '>=12'}
@@ -4602,6 +4743,12 @@ packages:
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.23.1':
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -13069,6 +13216,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -21411,6 +21563,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tsx@4.19.0:
+    resolution: {integrity: sha512-bV30kM7bsLZKZIOCHeMNVMJ32/LuJzLVajkQI/qf92J2Qr08ueLQvW00PUZGiuLPP760UINwupgUj8qrSCPUKg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tsx@4.7.1:
     resolution: {integrity: sha512-8d6VuibXHtlN5E3zFkgY8u4DX7Y3Z27zvvPKVmLon/D4AjuKzarkUBTLDBgj9iTQ0hg5xM7c/mYiRVM+HETf0g==}
     engines: {node: '>=18.0.0'}
@@ -22289,7 +22446,6 @@ packages:
 
   web3-provider-engine@14.2.1:
     resolution: {integrity: sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==}
-    deprecated: 'This package has been deprecated, see the README for details: https://github.com/MetaMask/web3-provider-engine'
 
   web3-providers-http@1.10.3:
     resolution: {integrity: sha512-6dAgsHR3MxJ0Qyu3QLFlQEelTapVfWNTu5F45FYh8t7Y03T1/o+YAkVxsbY5AdmD+y5bXG/XPJ4q8tjL6MgZHw==}
@@ -26331,6 +26487,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.23.1':
+    optional: true
+
   '@esbuild/android-arm64@0.17.19':
     optional: true
 
@@ -26341,6 +26500,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.23.1':
     optional: true
 
   '@esbuild/android-arm@0.17.19':
@@ -26355,6 +26517,9 @@ snapshots:
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.23.1':
+    optional: true
+
   '@esbuild/android-x64@0.17.19':
     optional: true
 
@@ -26365,6 +26530,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.23.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.17.19':
@@ -26379,6 +26547,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.23.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.17.19':
     optional: true
 
@@ -26389,6 +26560,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.23.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.17.19':
@@ -26403,6 +26577,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.23.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.17.19':
     optional: true
 
@@ -26413,6 +26590,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.23.1':
     optional: true
 
   '@esbuild/linux-arm64@0.17.19':
@@ -26427,6 +26607,9 @@ snapshots:
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.23.1':
+    optional: true
+
   '@esbuild/linux-arm@0.17.19':
     optional: true
 
@@ -26437,6 +26620,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.23.1':
     optional: true
 
   '@esbuild/linux-ia32@0.17.19':
@@ -26451,6 +26637,9 @@ snapshots:
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.23.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.17.19':
     optional: true
 
@@ -26461,6 +26650,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.23.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.17.19':
@@ -26475,6 +26667,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.23.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.17.19':
     optional: true
 
@@ -26485,6 +26680,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.23.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.17.19':
@@ -26499,6 +26697,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.23.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.17.19':
     optional: true
 
@@ -26509,6 +26710,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.23.1':
     optional: true
 
   '@esbuild/linux-x64@0.17.19':
@@ -26523,6 +26727,9 @@ snapshots:
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.23.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.17.19':
     optional: true
 
@@ -26533,6 +26740,12 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.17.19':
@@ -26547,6 +26760,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.23.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.17.19':
     optional: true
 
@@ -26557,6 +26773,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.23.1':
     optional: true
 
   '@esbuild/win32-arm64@0.17.19':
@@ -26571,6 +26790,9 @@ snapshots:
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.23.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.17.19':
     optional: true
 
@@ -26583,6 +26805,9 @@ snapshots:
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.23.1':
+    optional: true
+
   '@esbuild/win32-x64@0.17.19':
     optional: true
 
@@ -26593,6 +26818,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.23.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.43.0)':
@@ -39733,6 +39961,33 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.23.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
+
   escalade@3.1.1: {}
 
   escalade@3.1.2: {}
@@ -51321,6 +51576,13 @@ snapshots:
   tsx@4.16.5:
     dependencies:
       esbuild: 0.21.5
+      get-tsconfig: 4.7.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tsx@4.19.0:
+    dependencies:
+      esbuild: 0.23.1
       get-tsconfig: 4.7.6
     optionalDependencies:
       fsevents: 2.3.3

--- a/scripts/prune.ts
+++ b/scripts/prune.ts
@@ -1,0 +1,189 @@
+import { FileHandle, open } from 'fs/promises'
+
+const chainId = process.env.CHAIN_ID || '10'
+
+const cacheDir = process.env.CACHE_DIR || `./cache/${chainId}`
+
+let prices: string[]
+
+function percentage(x: number, y: number, fixed = 2) {
+  const percent = (x / y) * 100
+  return percent.toFixed(fixed)
+}
+
+async function prune(
+  path: string,
+  accessors: 'address' | ('token0' | 'token1')[],
+  minLines = 0,
+): Promise<[number, number, number, number]> {
+  let valid = 0
+  let invalid = 0
+  let duplicate = 0
+  let removed = 0
+
+  let file: FileHandle | null = null
+
+  try {
+    file = await open(path, 'r+')
+    const data = await file.readFile('utf8')
+    const set = new Set<string>()
+    const records: {
+      address: string
+    }[] &
+      {
+        address: string
+        token0: string
+        token1: string
+      }[] = []
+    const lines = data.split('\n')
+    if (lines.length < minLines) {
+      throw Error('Too few lines to prune')
+    }
+
+    for (const line of lines) {
+      if (line === '') {
+        //   console.log('Empty line')
+        continue
+      }
+      try {
+        const record: {
+          address: string
+        } & {
+          address: string
+          token0: string
+          token1: string
+        } = JSON.parse(line)
+        if (set.has(record.address)) {
+          duplicate++
+          // console.log(`Duplicate record: ${record.address}`)
+          continue
+        }
+        set.add(record.address)
+        if (typeof accessors === 'string') {
+          if (!prices.includes(record[accessors])) {
+            removed++
+          }
+        } else if (
+          accessors.some((accessor) => !prices.includes(record[accessor]))
+        ) {
+          removed++
+        } else {
+          records.push(record)
+          valid++
+        }
+      } catch {
+        invalid++
+      }
+    }
+
+    await file.truncate(0)
+    await file.write(
+      records.reduce(
+        (previousValue, currentValue) =>
+          `${previousValue}${JSON.stringify(currentValue)}\n`,
+        '',
+      ),
+      0,
+    )
+  } finally {
+    await file?.close()
+  }
+
+  return [valid, invalid, duplicate, removed]
+}
+;(async () => {
+  try {
+    prices = await fetch(`https://api.sushi.com/price/v1/${chainId}`)
+      .then((res) => res.json())
+      .then(Object.keys)
+  } catch {
+    console.warn('Failed to fetch prices, skipping pruning')
+    return
+  }
+
+  try {
+    console.log(`Analyzing cache for chain ${chainId}...`)
+
+    const [validTokens, invalidTokens, duplicateTokens, removedTokens] =
+      await prune(`${cacheDir}/tokens-${chainId}`, 'address', 200)
+    console.log(
+      `Tokens, Valid: ${validTokens} Invalid: ${invalidTokens} Duplicate: ${duplicateTokens} Removed: ${removedTokens} (${percentage(
+        removedTokens,
+        validTokens,
+      )}%) Remaining: ${validTokens - removedTokens} (${percentage(
+        validTokens - removedTokens,
+        validTokens,
+      )}%)`,
+    )
+  } catch (_e) {
+    // console.error(e)
+  }
+
+  try {
+    const [
+      validUniswapV2Pools,
+      invalidUniswapV2Pools,
+      duplicateUniswapV2Pools,
+      removedUniswapV2Pools,
+    ] = await prune(`${cacheDir}/uniV2Pools-${chainId}`, ['token0', 'token1'])
+    console.log(
+      `UniswapV2, Valid: ${validUniswapV2Pools} Invalid: ${invalidUniswapV2Pools} Duplicate: ${duplicateUniswapV2Pools} Removed: ${removedUniswapV2Pools} (${percentage(
+        removedUniswapV2Pools,
+        validUniswapV2Pools,
+      )}%) Remaining: ${
+        validUniswapV2Pools - removedUniswapV2Pools
+      } (${percentage(
+        validUniswapV2Pools - removedUniswapV2Pools,
+        validUniswapV2Pools,
+      )}%)`,
+    )
+  } catch (_e) {
+    // console.error(e)
+  }
+
+  try {
+    const [
+      validUniswapV3Pools,
+      invalidUniswapV3Pools,
+      duplicateUniswapV3Pools,
+      removedUniswapV3Pools,
+    ] = await prune(`${cacheDir}/uniV3Pools-${chainId}`, ['token0', 'token1'])
+
+    console.log(
+      `UniswapV3, Valid: ${validUniswapV3Pools} Invalid: ${invalidUniswapV3Pools} Duplicate: ${duplicateUniswapV3Pools} Removed: ${removedUniswapV3Pools} (${percentage(
+        removedUniswapV3Pools,
+        validUniswapV3Pools,
+      )}%) Remaining: ${
+        validUniswapV3Pools - removedUniswapV3Pools
+      } (${percentage(
+        validUniswapV3Pools - removedUniswapV3Pools,
+        validUniswapV3Pools,
+      )}%)`,
+    )
+  } catch (_e) {
+    // console.error(e)
+  }
+
+  try {
+    const [
+      validAlgebraIntegralPools,
+      invalidAlgebraIntegralPools,
+      duplicateAlgebraIntegralPools,
+      removedAlgebraIntegralPools,
+    ] = await prune(`${cacheDir}/AlgebraPools-${chainId}`, ['token0', 'token1'])
+
+    console.log(
+      `Algebra Integral, Valid: ${validAlgebraIntegralPools} Invalid: ${invalidAlgebraIntegralPools} Duplicate: ${duplicateAlgebraIntegralPools} Removed: ${removedAlgebraIntegralPools} (${percentage(
+        removedAlgebraIntegralPools,
+        validAlgebraIntegralPools,
+      )}%) Remaining: ${
+        validAlgebraIntegralPools - removedAlgebraIntegralPools
+      } (${percentage(
+        validAlgebraIntegralPools - removedAlgebraIntegralPools,
+        validAlgebraIntegralPools,
+      )}%)`,
+    )
+  } catch (_e) {
+    // console.error(e)
+  }
+})()

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -42,7 +42,6 @@ profiles:
       projectId: "sushi-api-414412"
   manifests:
     rawYaml:
-      - k8s/push-cache.yaml
       - k8s/ingress-staging.yaml
       - k8s/staging-managed-certificate.yaml
 - name: production

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -8,6 +8,10 @@ build:
   tagPolicy:
     sha256: {}
   artifacts:
+    - image: extractor-init
+      context: .
+      docker:
+        dockerfile: Dockerfile.extractor-init
     - image: extractor
       context: .
       docker:
@@ -19,27 +23,39 @@ build:
         # buildArgs:
         #   TURBO_TEAM: "teamsushi"
         #   TURBO_TOKEN:{{ .TURBO_TOKEN }}
-deploy:
-  helm:
-    releases:
-      - name: sushi-extractor
-        chartPath: k8s/charts/extractor
-        valuesFiles: [k8s/charts/values.yaml]
-      - name: sushi-router
-        chartPath: k8s/charts/router
-        valuesFiles: [k8s/charts/values.yaml]
-      - name: sushi-nginx
-        chartPath: k8s/charts/nginx
-        valuesFiles: [k8s/charts/values.yaml]
-manifests:
-  rawYaml:
-    - k8s/ingress-local.yaml
 profiles:
 - name: local
+  deploy:
+    helm:
+      releases:
+        - name: sushi-extractor
+          chartPath: k8s/charts/extractor
+          valuesFiles: [k8s/charts/values.yaml]
+        - name: sushi-router
+          chartPath: k8s/charts/router
+          valuesFiles: [k8s/charts/values.yaml]
+        - name: sushi-nginx
+          chartPath: k8s/charts/nginx
+          valuesFiles: [k8s/charts/values.yaml]
+  manifests:
+    rawYaml:
+      - k8s/ingress-local.yaml
 - name: staging
   build:
     googleCloudBuild:
       projectId: "sushi-api-414412"
+  deploy:
+    helm:
+      releases:
+        - name: sushi-extractor
+          chartPath: k8s/charts/extractor
+          valuesFiles: [k8s/charts/values.yaml, k8s/charts/staging-values.yaml]
+        - name: sushi-router
+          chartPath: k8s/charts/router
+          valuesFiles: [k8s/charts/values.yaml]
+        - name: sushi-nginx
+          chartPath: k8s/charts/nginx
+          valuesFiles: [k8s/charts/values.yaml]
   manifests:
     rawYaml:
       - k8s/ingress-staging.yaml
@@ -48,6 +64,18 @@ profiles:
   build:
     googleCloudBuild:
       projectId: "sushi-api-414412"
+  deploy:
+    helm:
+      releases:
+        - name: sushi-extractor
+          chartPath: k8s/charts/extractor
+          valuesFiles: [k8s/charts/values.yaml]
+        - name: sushi-router
+          chartPath: k8s/charts/router
+          valuesFiles: [k8s/charts/values.yaml]
+        - name: sushi-nginx
+          chartPath: k8s/charts/nginx
+          valuesFiles: [k8s/charts/values.yaml]
   manifests:
     rawYaml:
       - k8s/ingress-production.yaml


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `prune.ts` script for pruning cache data, adds `tsx` to `package.json`, updates Dockerfile for an `extractor-init` image, and modifies Helm releases configurations.

### Detailed summary
- Added `prune.ts` script for cache data pruning
- Updated `tsx` in `package.json`
- Modified Dockerfile for `extractor-init` image
- Adjusted Helm releases configurations for `sushi-extractor`, `sushi-router`, and `sushi-nginx`

> The following files were skipped due to too many changes: `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->