### PR TITLE
chore: clean up config

### DIFF
--- a/.changeset/red-pianos-march.md
+++ b/.changeset/red-pianos-march.md
@@ -1,0 +1,5 @@
+---
+"sushi": minor
+---
+
+update RouteProcessor5 config to include zkSync and Mantle.

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -1,11 +1,9 @@
 import { ChainId, TESTNET_CHAIN_IDS } from 'sushi/chain'
 import {
+  AGGREGATOR_ONLY_CHAIN_IDS,
   EXTRACTOR_SUPPORTED_CHAIN_IDS,
-  SushiSwapV2ChainIds,
-  SushiSwapV3ChainIds,
-  TridentChainIds,
+  SUSHISWAP_SUPPORTED_CHAIN_IDS,
 } from 'sushi/config'
-import { Currency } from 'sushi/currency'
 
 export const SWAP_API_SUPPORTED_CHAIN_IDS = EXTRACTOR_SUPPORTED_CHAIN_IDS
 
@@ -21,6 +19,8 @@ export const DISABLED_CHAIN_IDS = [
   ChainId.PALM,
   ChainId.HECO,
   ChainId.OKEX,
+  ChainId.MANTLE,
+  ChainId.ZKSYNC_ERA,
 ] as const
 
 const PREFERRED_CHAINID_ORDER = [
@@ -42,19 +42,16 @@ const PREFERRED_CHAINID_ORDER = [
   ChainId.HARMONY,
 ] as const
 
-const SUSHI_CHAIN_IDS = Array.from(
-  new Set([...TridentChainIds, ...SushiSwapV2ChainIds, ...SushiSwapV3ChainIds]),
-)
+export const CHAIN_IDS = [
+  ...SUSHISWAP_SUPPORTED_CHAIN_IDS,
+  ...AGGREGATOR_ONLY_CHAIN_IDS,
+] as const
 
-export const SWAP_ONLY_CHAIN_IDS = [ChainId.CRONOS, ChainId.MANTLE] as const
-
-export const CHAIN_IDS = [...SUSHI_CHAIN_IDS, ChainId.CRONOS] as const
-
-export const AMM_SUPPORTED_CHAIN_IDS = SUSHI_CHAIN_IDS.filter(
+export const AMM_SUPPORTED_CHAIN_IDS = SUSHISWAP_SUPPORTED_CHAIN_IDS.filter(
   (
     c,
   ): c is Exclude<
-    (typeof SUSHI_CHAIN_IDS)[number],
+    (typeof SUSHISWAP_SUPPORTED_CHAIN_IDS)[number],
     (typeof TESTNET_CHAIN_IDS)[number] | (typeof DISABLED_CHAIN_IDS)[number]
   > =>
     !TESTNET_CHAIN_IDS.includes(c as (typeof TESTNET_CHAIN_IDS)[number]) &&
@@ -79,34 +76,8 @@ export const SUPPORTED_CHAIN_IDS = Array.from(
     !DISABLED_CHAIN_IDS.includes(c as (typeof DISABLED_CHAIN_IDS)[number]),
 )
 
-export const DISABLED_ANALYTICS_CHAIN_IDS = [
-  ChainId.BOBA_AVAX,
-  ChainId.KAVA,
-  ChainId.MOONRIVER,
-]
-
-export const ANALYTICS_CHAIN_IDS = [
-  ...SUPPORTED_CHAIN_IDS.filter(
-    (el) =>
-      !DISABLED_ANALYTICS_CHAIN_IDS.includes(
-        el as (typeof DISABLED_ANALYTICS_CHAIN_IDS)[number],
-      ),
-  ),
-]
-
 export type SupportedChainId = (typeof SUPPORTED_CHAIN_IDS)[number]
 export const isSupportedChainId = (
   chainId: number,
 ): chainId is SupportedChainId =>
   SUPPORTED_CHAIN_IDS.includes(chainId as SupportedChainId)
-
-export type Config = {
-  [_chainId in SupportedChainId]: {
-    stables: Currency[]
-    lsds: Currency[]
-  }
-}
-
-export const config = {
-  [ChainId.ETHEREUM]: {},
-}

--- a/packages/sushi/src/config/features/aggregator.ts
+++ b/packages/sushi/src/config/features/aggregator.ts
@@ -1,0 +1,7 @@
+import { ChainId } from '../../chain/index.js'
+
+export const AGGREGATOR_ONLY_CHAIN_IDS = [
+  ChainId.CRONOS,
+  ChainId.MANTLE,
+  ChainId.ZKSYNC_ERA,
+] as const

--- a/packages/sushi/src/config/features/index.ts
+++ b/packages/sushi/src/config/features/index.ts
@@ -1,3 +1,4 @@
+export * from './aggregator.js'
 export * from './bentobox.js'
 export * from './extractor.js'
 export * from './furo.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1489,10 +1489,6 @@ importers:
         specifier: 3.23.8
         version: 3.23.8
 
-  packages/sushi/dist/_cjs: {}
-
-  packages/sushi/dist/_esm: {}
-
   packages/telemetry:
     devDependencies:
       '@tsconfig/esm':


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `RouteProcessor5` config in `sushi` to include `zkSync` and `Mantle`.

### Detailed summary
- Added `zkSync` and `Mantle` to the `RouteProcessor5` config in `sushi`
- Updated chain IDs in `aggregator.ts` and `web/src/config.ts`
- Removed unnecessary chain IDs and configurations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->