### PR TITLE
fix: honeypot typo

### DIFF
--- a/apps/web/src/lib/wagmi/components/token-selector/token-lists/common/token-selector-import-row.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-lists/common/token-selector-import-row.tsx
@@ -169,7 +169,7 @@ export const TokenSelectorImportRow: FC<TokenSelectorImportRow> = ({
                     </Button>
                   </DialogTrigger>
                   <Message variant="destructive" size="sm">
-                    Sushi does not support honetpot tokens. This token contract
+                    Sushi does not support honeypot tokens. This token contract
                     cannot be imported!
                   </Message>
                 </div>

--- a/apps/web/src/ui/swap/cross-chain/cross-chain-swap-token-not-found-dialog.tsx
+++ b/apps/web/src/ui/swap/cross-chain/cross-chain-swap-token-not-found-dialog.tsx
@@ -290,7 +290,7 @@ export const CrossChainSwapTokenNotFoundDialog = () => {
                 Close
               </Button>
               <Message variant="destructive" size="sm">
-                Sushi does not support honetpot tokens. This token contract
+                Sushi does not support honeypot tokens. This token contract
                 cannot be imported!
               </Message>
             </div>

--- a/apps/web/src/ui/swap/simple/simple-swap-token-not-found-dialog.tsx
+++ b/apps/web/src/ui/swap/simple/simple-swap-token-not-found-dialog.tsx
@@ -257,7 +257,7 @@ export const SimpleSwapTokenNotFoundDialog = () => {
                 Close
               </Button>
               <Message variant="destructive" size="sm">
-                Sushi does not support honetpot tokens. This token contract
+                Sushi does not support honeypot tokens. This token contract
                 cannot be imported!
               </Message>
             </div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates error messages in token not found dialogs across different swap components to correct the typo "honetpot" to "honeypot".

### Detailed summary
- Fixed typo "honetpot" to "honeypot" in error messages for token not found dialogs in swap components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->