### PR TITLE
chore: hide navbar items on unsupported chains

### DIFF
--- a/apps/web/src/app/(evm)/_common/header-elements.tsx
+++ b/apps/web/src/app/(evm)/_common/header-elements.tsx
@@ -1,3 +1,4 @@
+import { isPoolChainId } from '@sushiswap/graph-client/data-api'
 import {
   type NavigationElement,
   NavigationElementType,
@@ -11,7 +12,8 @@ import {
   EXPLORE_NAVIGATION_LINKS,
   // MORE_NAVIGATION_LINKS,
 } from 'src/app/_common/header-elements'
-import { ChainId, ChainKey, isChainId } from 'sushi'
+import { ChainId, ChainKey } from 'sushi/chain'
+import { isAggregatorOnlyChainId } from 'sushi/config'
 
 export const headerElements = (chainId?: ChainId): NavigationElement[] => [
   {
@@ -42,22 +44,26 @@ export const headerElements = (chainId?: ChainId): NavigationElement[] => [
       </NavigationMenuItem>
     ),
   },
-  {
-    title: 'Explore',
-    href: `/${
-      isChainId(Number(chainId)) ? ChainKey[chainId as ChainId] : 'ethereum'
-    }/explore/pools`,
-    show: 'desktop',
-    type: NavigationElementType.Single,
-  },
-  {
-    title: 'Pool',
-    href: `/${
-      isChainId(Number(chainId)) ? ChainKey[chainId as ChainId] : 'ethereum'
-    }/pool`,
-    show: 'desktop',
-    type: NavigationElementType.Single,
-  },
+  ...(!chainId || isPoolChainId(chainId)
+    ? ([
+        {
+          title: 'Explore',
+          href: `/${chainId ? ChainKey[chainId] : 'ethereum'}/explore/pools`,
+          show: 'desktop',
+          type: NavigationElementType.Single,
+        },
+      ] as const)
+    : []),
+  ...(!chainId || !isAggregatorOnlyChainId(chainId)
+    ? ([
+        {
+          title: 'Pool',
+          href: `/${chainId ? ChainKey[chainId] : 'ethereum'}/pool`,
+          show: 'desktop',
+          type: NavigationElementType.Single,
+        },
+      ] as const)
+    : []),
   {
     title: 'Stake',
     href: '/stake',

--- a/apps/web/src/app/_common/header-elements.ts
+++ b/apps/web/src/app/_common/header-elements.ts
@@ -1,9 +1,11 @@
+import { isPoolChainId } from '@sushiswap/graph-client/data-api'
 import {
   type NavigationElement,
   type NavigationElementDropdown,
   NavigationElementType,
 } from '@sushiswap/ui'
 import { ChainId, ChainKey, isChainId } from 'sushi'
+import { isAggregatorOnlyChainId } from 'sushi/config'
 
 export const EXPLORE_NAVIGATION_LINKS = (
   chainId?: ChainId,
@@ -13,20 +15,24 @@ export const EXPLORE_NAVIGATION_LINKS = (
     href: '/swap',
     description: 'The easiest way to trade.',
   },
-  {
-    title: 'Explore',
-    href: `/${
-      isChainId(Number(chainId)) ? ChainKey[chainId as ChainId] : 'ethereum'
-    }/explore/pools`,
-    description: 'Explore top pools.',
-  },
-  {
-    title: 'Pool',
-    href: `/${
-      isChainId(Number(chainId)) ? ChainKey[chainId as ChainId] : 'ethereum'
-    }/pool`,
-    description: 'Earn fees by providing liquidity.',
-  },
+  ...(!chainId || isPoolChainId(chainId)
+    ? ([
+        {
+          title: 'Explore',
+          href: `/${chainId ? ChainKey[chainId] : 'ethereum'}/explore/pools`,
+          description: 'Explore top pools.',
+        },
+      ] as const)
+    : []),
+  ...(!chainId || !isAggregatorOnlyChainId(chainId)
+    ? ([
+        {
+          title: 'Pool',
+          href: `/${chainId ? ChainKey[chainId] : 'ethereum'}/pool`,
+          description: 'Earn fees by providing liquidity.',
+        },
+      ] as const)
+    : []),
   //  {
   //    title: 'Bonds',
   //    href: '/bonds',

--- a/packages/sushi/src/config/features/aggregator.ts
+++ b/packages/sushi/src/config/features/aggregator.ts
@@ -5,3 +5,10 @@ export const AGGREGATOR_ONLY_CHAIN_IDS = [
   ChainId.MANTLE,
   ChainId.ZKSYNC_ERA,
 ] as const
+
+export type AggregatorOnlyChainId = (typeof AGGREGATOR_ONLY_CHAIN_IDS)[number]
+
+export const isAggregatorOnlyChainId = (
+  chainId: ChainId,
+): chainId is AggregatorOnlyChainId =>
+  AGGREGATOR_ONLY_CHAIN_IDS.includes(chainId as AggregatorOnlyChainId)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
**Focus:** Introduce `isAggregatorOnlyChainId` function to handle specific chain IDs in SushiSwap UI.

### Detailed summary
- Added `AggregatorOnlyChainId` type and `isAggregatorOnlyChainId` function in `sushi/config`
- Updated navigation links in `header-elements.ts` and `header-elements.tsx` to use `isAggregatorOnlyChainId` for specific chain IDs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->