### PR TITLE
feat(apps/web): actually cache useTokenWithCache

### DIFF
--- a/apps/web/src/app/(non-evm)/aptos/(common)/lib/common/use-token-with-cache.ts
+++ b/apps/web/src/app/(non-evm)/aptos/(common)/lib/common/use-token-with-cache.ts
@@ -79,6 +79,8 @@ export function useTokenWithCache({
     enabled: Boolean(enabled && address),
     refetchOnWindowFocus: false,
     placeholderData: (prevData) => (keepPreviousData ? prevData : undefined),
+    staleTime: 1000 * 60 * 60 * 24,
+    gcTime: 1000 * 60 * 60 * 24,
     retry: false,
   })
 }

--- a/apps/web/src/lib/wagmi/hooks/tokens/useTokenWithCache.ts
+++ b/apps/web/src/lib/wagmi/hooks/tokens/useTokenWithCache.ts
@@ -5,6 +5,7 @@ import {
 import { useCustomTokens } from '@sushiswap/hooks'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { getToken as getTokenWeb3 } from '@wagmi/core/actions'
+import ms from 'ms'
 import { useCallback } from 'react'
 import type { ID } from 'sushi'
 import { ChainId } from 'sushi/chain'
@@ -152,7 +153,7 @@ export const useTokenWithCache = ({
     placeholderData: isKeepPreviousData ? keepPreviousData : undefined,
     refetchOnWindowFocus: false,
     retry: false,
-    staleTime: 900000, // 15 mins
-    gcTime: 86400000, // 24hs
+    staleTime: ms('6 hours'),
+    gcTime: ms('24 hours'),
   })
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the caching times in the `useTokenWithCache` hook for better performance.

### Detailed summary
- Increased `staleTime` and `gcTime` to 24 hours each in `useTokenWithCache` hook
- Utilized `ms` library for time conversion

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->