### PR TITLE
chore(sushi): expose address module

### DIFF
--- a/.changeset/dull-cobras-tell.md
+++ b/.changeset/dull-cobras-tell.md
@@ -1,0 +1,5 @@
+---
+"sushi": patch
+---
+
+expose address module

--- a/packages/sushi/package.json
+++ b/packages/sushi/package.json
@@ -32,6 +32,11 @@
       "import": "./dist/_esm/abi/index.js",
       "default": "./dist/_cjs/abi/index.js"
     },
+    "./address": {
+      "types": "./dist/_types/address/index.d.ts",
+      "import": "./dist/_esm/address/index.js",
+      "default": "./dist/_cjs/address/index.js"
+    },
     "./bigint-serializer": {
       "types": "./dist/_types/bigint-serializer/index.d.ts",
       "import": "./dist/_esm/bigint-serializer/index.js",
@@ -156,6 +161,9 @@
     "*": {
       "abi": [
         "./dist/_types/abi/index.d.ts"
+      ],
+      "address": [
+        "./dist/_types/address/index.d.ts"
       ],
       "bigint-serializer": [
         "./_types/bigint-serializer/index.d.ts"

--- a/packages/sushi/src/address/index.ts
+++ b/packages/sushi/src/address/index.ts
@@ -1,0 +1,1 @@
+export { getCreate2Address } from './getCreate2Address.js'

--- a/packages/sushi/src/index.ts
+++ b/packages/sushi/src/index.ts
@@ -1,3 +1,4 @@
+export * from './address/index.js'
 // export * from './bigint-serializer/index.js'
 export * from './calculate/index.js'
 export * from './chain/index.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1498,10 +1498,6 @@ importers:
         specifier: 3.23.8
         version: 3.23.8
 
-  packages/sushi/dist/_cjs: {}
-
-  packages/sushi/dist/_esm: {}
-
   packages/telemetry:
     devDependencies:
       '@tsconfig/esm':


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to expose the address module in the Sushi package.

### Detailed summary
- Exposed `getCreate2Address` from `address/index.ts`
- Updated exports in `index.ts` to include `address`
- Added paths for `address` in `package.json`
- Updated paths for `address` in `package.json` to include types

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->