### PR TITLE
fix: compute v3 pool address

### DIFF
--- a/.changeset/proud-chairs-explain.md
+++ b/.changeset/proud-chairs-explain.md
@@ -1,0 +1,5 @@
+---
+"sushi": patch
+---
+
+fix compute v3 pool address

--- a/packages/react-query/src/hooks/trade/types.ts
+++ b/packages/react-query/src/hooks/trade/types.ts
@@ -1,17 +1,15 @@
-import { ChainId } from 'sushi/chain'
-import { Amount, Price, type Type } from 'sushi/currency'
-import { Percent } from 'sushi/math'
-import type { Address, WriteContractParameters } from 'viem'
-import z from 'zod'
-import { RouterLiquiditySource } from 'sushi/router'
 import {
   routeProcessor2Abi_processRoute,
   routeProcessor2Abi_transferValueAndprocessRoute,
 } from 'sushi/abi'
+import { ChainId } from 'sushi/chain'
+import { Amount, Price, type Type } from 'sushi/currency'
+import { Percent } from 'sushi/math'
+import { RouterLiquiditySource } from 'sushi/router'
+import type { Address, WriteContractParameters } from 'viem'
+import z from 'zod'
 import { legValidator, tradeValidator01 } from './validator01'
 import { tradeValidator02 } from './validator02'
-
-
 
 export interface UseTradeParams {
   chainId: ChainId


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes the computation of v3 pool address and refactors imports in `types.ts`.

### Detailed summary
- Fixed computation of v3 pool address in `computeSushiSwapV3PoolAddress`
- Refactored imports in `types.ts` for `routeProcessor2Abi_processRoute` and `routeProcessor2Abi_transferValueAndprocessRoute`
- Removed redundant imports and comments

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->