### PR TITLE
chore: build cjs with esmoduleiterop true

### DIFF
--- a/.changeset/thick-dots-rule.md
+++ b/.changeset/thick-dots-rule.md
@@ -1,0 +1,5 @@
+---
+"sushi": patch
+---
+
+esmoduleinterop cjs build

--- a/packages/sushi/package.json
+++ b/packages/sushi/package.json
@@ -215,7 +215,7 @@
   ],
   "scripts": {
     "build": "pnpm build:cjs && pnpm build:esm && pnpm build:types",
-    "build:cjs": "tsc --project ./tsconfig.build.json --module commonjs --outDir ./dist/_cjs --removeComments --verbatimModuleSyntax false && printf '{\"type\":\"commonjs\"}' > ./dist/_cjs/package.json",
+    "build:cjs": "tsc --project ./tsconfig.build.json --module commonjs --outDir ./dist/_cjs --removeComments --verbatimModuleSyntax false --esModuleInterop true && printf '{\"type\":\"commonjs\"}' > ./dist/_cjs/package.json",
     "build:esm": "tsc --project ./tsconfig.build.json --module es2020 --outDir ./dist/_esm && printf '{\"type\": \"module\",\"sideEffects\": \"true\"}' > ./dist/_esm/package.json",
     "build:types": "tsc --project ./tsconfig.build.json --module esnext --declarationDir ./dist/_types --emitDeclarationOnly --declaration --declarationMap",
     "check": "tsc --pretty --noEmit",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1290,6 +1290,10 @@ importers:
         specifier: 3.23.8
         version: 3.23.8
 
+  packages/sushi/dist/_cjs: {}
+
+  packages/sushi/dist/_esm: {}
+
   packages/telemetry:
     devDependencies:
       '@tsconfig/esm':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1290,10 +1290,6 @@ importers:
         specifier: 3.23.8
         version: 3.23.8
 
-  packages/sushi/dist/_cjs: {}
-
-  packages/sushi/dist/_esm: {}
-
   packages/telemetry:
     devDependencies:
       '@tsconfig/esm':


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `sushi` package to enable ES module interop in the CommonJS build.

### Detailed summary
- Updated `build:cjs` script in `sushi` package to include `--esModuleInterop true`
- Ensured ES module interop in the CommonJS build for better compatibility

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->